### PR TITLE
fix: binary persistence format to prevent data corruption (fixes #8)

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,9 +1,11 @@
 use crate::store::{DumpValue, Store};
 use std::fs;
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+const HEADER: &[u8; 4] = b"LUX\x01";
 
 fn snapshot_path() -> String {
     let dir = std::env::var("LUX_DATA_DIR").unwrap_or_else(|_| ".".to_string());
@@ -18,6 +20,53 @@ fn snapshot_interval() -> Duration {
     Duration::from_secs(secs)
 }
 
+fn write_bytes(w: &mut impl Write, data: &[u8]) -> io::Result<()> {
+    w.write_all(&(data.len() as u32).to_le_bytes())?;
+    w.write_all(data)
+}
+
+fn write_u32(w: &mut impl Write, v: u32) -> io::Result<()> {
+    w.write_all(&v.to_le_bytes())
+}
+
+fn write_i64(w: &mut impl Write, v: i64) -> io::Result<()> {
+    w.write_all(&v.to_le_bytes())
+}
+
+fn write_f64(w: &mut impl Write, v: f64) -> io::Result<()> {
+    w.write_all(&v.to_le_bytes())
+}
+
+fn read_bytes(r: &mut impl Read) -> io::Result<Vec<u8>> {
+    let len = read_u32(r)? as usize;
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf)?;
+    Ok(buf)
+}
+
+fn read_u32(r: &mut impl Read) -> io::Result<u32> {
+    let mut buf = [0u8; 4];
+    r.read_exact(&mut buf)?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+fn read_i64(r: &mut impl Read) -> io::Result<i64> {
+    let mut buf = [0u8; 8];
+    r.read_exact(&mut buf)?;
+    Ok(i64::from_le_bytes(buf))
+}
+
+fn read_f64(r: &mut impl Read) -> io::Result<f64> {
+    let mut buf = [0u8; 8];
+    r.read_exact(&mut buf)?;
+    Ok(f64::from_le_bytes(buf))
+}
+
+fn read_string(r: &mut impl Read) -> io::Result<String> {
+    let raw = read_bytes(r)?;
+    String::from_utf8(raw).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
 pub fn save(store: &Store) -> io::Result<usize> {
     let path = snapshot_path();
     if let Some(parent) = Path::new(&path).parent() {
@@ -26,53 +75,75 @@ pub fn save(store: &Store) -> io::Result<usize> {
     let now = Instant::now();
     let entries = store.dump_all(now);
     let tmp = format!("{path}.{}.tmp", std::process::id());
-    let mut file = fs::File::create(&tmp)?;
-    for entry in &entries {
-        let type_char = match &entry.value {
-            DumpValue::Str(_) => 'S',
-            DumpValue::List(_) => 'L',
-            DumpValue::Hash(_) => 'H',
-            DumpValue::Set(_) => 'T',
-            DumpValue::SortedSet(_) => 'Z',
-            DumpValue::Stream(..) => 'X',
-        };
-        let encoded_value = match &entry.value {
-            DumpValue::Str(s) => s.clone(),
-            DumpValue::List(items) => items.join("\x1f"),
-            DumpValue::Hash(pairs) => pairs
-                .iter()
-                .map(|(k, v)| format!("{}\x1e{}", k, v))
-                .collect::<Vec<_>>()
-                .join("\x1f"),
-            DumpValue::Set(members) => members.join("\x1f"),
-            DumpValue::SortedSet(members) => members
-                .iter()
-                .map(|(m, s)| format!("{}\x1e{}", m, s))
-                .collect::<Vec<_>>()
-                .join("\x1f"),
-            DumpValue::Stream(entries, last_id) => {
-                let entries_str: Vec<String> = entries
-                    .iter()
-                    .map(|(id, fields)| {
-                        let flds: Vec<String> = fields
-                            .iter()
-                            .map(|(k, v)| format!("{}\x1d{}", k, v))
-                            .collect();
-                        format!("{}\x1d{}", id, flds.join("\x1d"))
-                    })
-                    .collect();
-                format!("{}\x1c{}", last_id, entries_str.join("\x1f"))
-            }
-        };
-        writeln!(
-            file,
-            "{}\t{}\t{}\t{}",
-            type_char, entry.key, encoded_value, entry.ttl_ms
-        )?;
-    }
-    file.sync_all()?;
+    let file = fs::File::create(&tmp)?;
+    let mut w = BufWriter::new(file);
+    save_binary(&mut w, &entries)?;
+    w.into_inner().map_err(io::Error::other)?.sync_all()?;
     fs::rename(&tmp, &path)?;
     Ok(entries.len())
+}
+
+fn save_binary(w: &mut impl Write, entries: &[crate::store::DumpEntry]) -> io::Result<()> {
+    w.write_all(HEADER)?;
+    for entry in entries {
+        let type_byte: u8 = match &entry.value {
+            DumpValue::Str(_) => b'S',
+            DumpValue::List(_) => b'L',
+            DumpValue::Hash(_) => b'H',
+            DumpValue::Set(_) => b'T',
+            DumpValue::SortedSet(_) => b'Z',
+            DumpValue::Stream(..) => b'X',
+        };
+        w.write_all(&[type_byte])?;
+        write_bytes(w, entry.key.as_bytes())?;
+        let ttl = if entry.ttl_ms > 0 { entry.ttl_ms } else { -1 };
+        write_i64(w, ttl)?;
+
+        match &entry.value {
+            DumpValue::Str(v) => {
+                write_bytes(w, v)?;
+            }
+            DumpValue::List(items) => {
+                write_u32(w, items.len() as u32)?;
+                for item in items {
+                    write_bytes(w, item)?;
+                }
+            }
+            DumpValue::Hash(pairs) => {
+                write_u32(w, pairs.len() as u32)?;
+                for (k, v) in pairs {
+                    write_bytes(w, k.as_bytes())?;
+                    write_bytes(w, v)?;
+                }
+            }
+            DumpValue::Set(members) => {
+                write_u32(w, members.len() as u32)?;
+                for m in members {
+                    write_bytes(w, m.as_bytes())?;
+                }
+            }
+            DumpValue::SortedSet(members) => {
+                write_u32(w, members.len() as u32)?;
+                for (m, score) in members {
+                    write_bytes(w, m.as_bytes())?;
+                    write_f64(w, *score)?;
+                }
+            }
+            DumpValue::Stream(stream_entries, last_id) => {
+                write_bytes(w, last_id.as_bytes())?;
+                write_u32(w, stream_entries.len() as u32)?;
+                for (id, fields) in stream_entries {
+                    write_bytes(w, id.as_bytes())?;
+                    write_u32(w, fields.len() as u32)?;
+                    for (k, v) in fields {
+                        write_bytes(w, k.as_bytes())?;
+                        write_bytes(w, v)?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 pub fn load(store: &Store) -> io::Result<usize> {
@@ -82,6 +153,108 @@ pub fn load(store: &Store) -> io::Result<usize> {
         return Ok(0);
     }
     let file = fs::File::open(path)?;
+    load_from_reader(store, file)
+}
+
+fn load_from_reader(store: &Store, mut file: fs::File) -> io::Result<usize> {
+    let mut header = [0u8; 4];
+    let n = file.read(&mut header)?;
+    if n == 4 && &header == HEADER {
+        load_binary(store, &mut io::BufReader::new(file))
+    } else {
+        file.seek(SeekFrom::Start(0))?;
+        load_legacy(store, file)
+    }
+}
+
+fn load_binary(store: &Store, r: &mut impl Read) -> io::Result<usize> {
+    let mut count = 0;
+    loop {
+        let mut type_buf = [0u8; 1];
+        match r.read_exact(&mut type_buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
+            Err(e) => return Err(e),
+        }
+
+        let key = read_string(r)?;
+        let ttl_ms = read_i64(r)?;
+        let ttl = if ttl_ms > 0 {
+            Some(Duration::from_millis(ttl_ms as u64))
+        } else {
+            None
+        };
+
+        let value = match type_buf[0] {
+            b'S' => DumpValue::Str(read_bytes(r)?),
+            b'L' => {
+                let len = read_u32(r)? as usize;
+                let mut items = Vec::with_capacity(len);
+                for _ in 0..len {
+                    items.push(read_bytes(r)?);
+                }
+                DumpValue::List(items)
+            }
+            b'H' => {
+                let len = read_u32(r)? as usize;
+                let mut pairs = Vec::with_capacity(len);
+                for _ in 0..len {
+                    let k = read_string(r)?;
+                    let v = read_bytes(r)?;
+                    pairs.push((k, v));
+                }
+                DumpValue::Hash(pairs)
+            }
+            b'T' => {
+                let len = read_u32(r)? as usize;
+                let mut members = Vec::with_capacity(len);
+                for _ in 0..len {
+                    members.push(read_string(r)?);
+                }
+                DumpValue::Set(members)
+            }
+            b'Z' => {
+                let len = read_u32(r)? as usize;
+                let mut members = Vec::with_capacity(len);
+                for _ in 0..len {
+                    let m = read_string(r)?;
+                    let s = read_f64(r)?;
+                    members.push((m, s));
+                }
+                DumpValue::SortedSet(members)
+            }
+            b'X' => {
+                let last_id = read_string(r)?;
+                let entry_count = read_u32(r)? as usize;
+                let mut entries = Vec::with_capacity(entry_count);
+                for _ in 0..entry_count {
+                    let id = read_string(r)?;
+                    let field_count = read_u32(r)? as usize;
+                    let mut fields = Vec::with_capacity(field_count);
+                    for _ in 0..field_count {
+                        let k = read_string(r)?;
+                        let v = read_bytes(r)?;
+                        fields.push((k, v));
+                    }
+                    entries.push((id, fields));
+                }
+                DumpValue::Stream(entries, last_id)
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("unknown type byte: {}", type_buf[0]),
+                ))
+            }
+        };
+
+        store.load_entry(key, value, ttl);
+        count += 1;
+    }
+    Ok(count)
+}
+
+fn load_legacy(store: &Store, file: fs::File) -> io::Result<usize> {
     let reader = io::BufReader::new(file);
     let mut count = 0;
     for line in reader.lines() {
@@ -104,7 +277,7 @@ pub fn load(store: &Store) -> io::Result<usize> {
                 } else {
                     None
                 };
-                store.load_entry(key, DumpValue::Str(value), ttl);
+                store.load_entry(key, DumpValue::Str(value.into_bytes()), ttl);
                 count += 1;
             }
             continue;
@@ -125,17 +298,20 @@ pub fn load(store: &Store) -> io::Result<usize> {
         };
 
         let value = match type_char {
-            "S" => DumpValue::Str(raw_value.to_string()),
+            "S" => DumpValue::Str(raw_value.as_bytes().to_vec()),
             "L" => {
-                let items: Vec<String> = if raw_value.is_empty() {
+                let items: Vec<Vec<u8>> = if raw_value.is_empty() {
                     vec![]
                 } else {
-                    raw_value.split('\x1f').map(|s| s.to_string()).collect()
+                    raw_value
+                        .split('\x1f')
+                        .map(|s| s.as_bytes().to_vec())
+                        .collect()
                 };
                 DumpValue::List(items)
             }
             "H" => {
-                let pairs: Vec<(String, String)> = if raw_value.is_empty() {
+                let pairs: Vec<(String, Vec<u8>)> = if raw_value.is_empty() {
                     vec![]
                 } else {
                     raw_value
@@ -143,7 +319,7 @@ pub fn load(store: &Store) -> io::Result<usize> {
                         .filter_map(|pair| {
                             let kv: Vec<&str> = pair.splitn(2, '\x1e').collect();
                             if kv.len() == 2 {
-                                Some((kv[0].to_string(), kv[1].to_string()))
+                                Some((kv[0].to_string(), kv[1].as_bytes().to_vec()))
                             } else {
                                 None
                             }
@@ -195,7 +371,10 @@ pub fn load(store: &Store) -> io::Result<usize> {
                             let mut fields = Vec::new();
                             let mut fi = 1;
                             while fi + 1 < parts_e.len() {
-                                fields.push((parts_e[fi].to_string(), parts_e[fi + 1].to_string()));
+                                fields.push((
+                                    parts_e[fi].to_string(),
+                                    parts_e[fi + 1].as_bytes().to_vec(),
+                                ));
                                 fi += 2;
                             }
                             entries.push((id, fields));
@@ -228,167 +407,98 @@ pub async fn background_save_loop(store: Arc<Store>) {
 }
 
 #[cfg(test)]
+fn save_to_path(store: &Store, path: &str) -> io::Result<usize> {
+    if let Some(parent) = Path::new(path).parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let now = Instant::now();
+    let entries = store.dump_all(now);
+    let tmp = format!("{path}.tmp");
+    let file = fs::File::create(&tmp)?;
+    let mut w = BufWriter::new(file);
+    save_binary(&mut w, &entries)?;
+    w.into_inner().map_err(io::Error::other)?.sync_all()?;
+    fs::rename(&tmp, path)?;
+    Ok(entries.len())
+}
+
+#[cfg(test)]
+fn load_from_path(store: &Store, path: &str) -> io::Result<usize> {
+    let p = Path::new(path);
+    if !p.exists() {
+        return Ok(0);
+    }
+    let file = fs::File::open(p)?;
+    load_from_reader(store, file)
+}
+
+#[cfg(test)]
+fn save_legacy_to_path(store: &Store, path: &str) -> io::Result<usize> {
+    if let Some(parent) = Path::new(path).parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let now = Instant::now();
+    let entries = store.dump_all(now);
+    let tmp = format!("{path}.tmp");
+    let mut file = fs::File::create(&tmp)?;
+    for entry in &entries {
+        let type_char = match &entry.value {
+            DumpValue::Str(_) => 'S',
+            DumpValue::List(_) => 'L',
+            DumpValue::Hash(_) => 'H',
+            DumpValue::Set(_) => 'T',
+            DumpValue::SortedSet(_) => 'Z',
+            DumpValue::Stream(..) => 'X',
+        };
+        let encoded_value = match &entry.value {
+            DumpValue::Str(s) => String::from_utf8_lossy(s).into_owned(),
+            DumpValue::List(items) => items
+                .iter()
+                .map(|b| String::from_utf8_lossy(b).into_owned())
+                .collect::<Vec<_>>()
+                .join("\x1f"),
+            DumpValue::Hash(pairs) => pairs
+                .iter()
+                .map(|(k, v)| format!("{}\x1e{}", k, String::from_utf8_lossy(v)))
+                .collect::<Vec<_>>()
+                .join("\x1f"),
+            DumpValue::Set(members) => members.join("\x1f"),
+            DumpValue::SortedSet(members) => members
+                .iter()
+                .map(|(m, s)| format!("{}\x1e{}", m, s))
+                .collect::<Vec<_>>()
+                .join("\x1f"),
+            DumpValue::Stream(stream_entries, last_id) => {
+                let entries_str: Vec<String> = stream_entries
+                    .iter()
+                    .map(|(id, fields)| {
+                        let flds: Vec<String> = fields
+                            .iter()
+                            .map(|(k, v)| format!("{}\x1d{}", k, String::from_utf8_lossy(v)))
+                            .collect();
+                        format!("{}\x1d{}", id, flds.join("\x1d"))
+                    })
+                    .collect();
+                format!("{}\x1c{}", last_id, entries_str.join("\x1f"))
+            }
+        };
+        writeln!(
+            file,
+            "{}\t{}\t{}\t{}",
+            type_char, entry.key, encoded_value, entry.ttl_ms
+        )?;
+    }
+    file.sync_all()?;
+    fs::rename(&tmp, path)?;
+    Ok(entries.len())
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::store::Store;
     use std::sync::atomic::{AtomicU32, Ordering};
     static TEST_ID: AtomicU32 = AtomicU32::new(0);
-
-    fn save_to(store: &Store, path: &str) -> io::Result<usize> {
-        if let Some(parent) = Path::new(path).parent() {
-            fs::create_dir_all(parent)?;
-        }
-        let now = Instant::now();
-        let entries = store.dump_all(now);
-        let tmp = format!("{path}.tmp");
-        let mut file = fs::File::create(&tmp)?;
-        for entry in &entries {
-            let type_char = match &entry.value {
-                DumpValue::Str(_) => 'S',
-                DumpValue::List(_) => 'L',
-                DumpValue::Hash(_) => 'H',
-                DumpValue::Set(_) => 'T',
-                DumpValue::SortedSet(_) => 'Z',
-                DumpValue::Stream(..) => 'X',
-            };
-            let encoded_value = match &entry.value {
-                DumpValue::Str(s) => s.clone(),
-                DumpValue::List(items) => items.join("\x1f"),
-                DumpValue::Hash(pairs) => pairs
-                    .iter()
-                    .map(|(k, v)| format!("{}\x1e{}", k, v))
-                    .collect::<Vec<_>>()
-                    .join("\x1f"),
-                DumpValue::Set(members) => members.join("\x1f"),
-                DumpValue::SortedSet(members) => members
-                    .iter()
-                    .map(|(m, s)| format!("{}\x1e{}", m, s))
-                    .collect::<Vec<_>>()
-                    .join("\x1f"),
-                DumpValue::Stream(stream_entries, last_id) => {
-                    let entries_str: Vec<String> = stream_entries
-                        .iter()
-                        .map(|(id, fields)| {
-                            let flds: Vec<String> = fields
-                                .iter()
-                                .map(|(k, v)| format!("{}\x1d{}", k, v))
-                                .collect();
-                            format!("{}\x1d{}", id, flds.join("\x1d"))
-                        })
-                        .collect();
-                    format!("{}\x1c{}", last_id, entries_str.join("\x1f"))
-                }
-            };
-            writeln!(
-                file,
-                "{}\t{}\t{}\t{}",
-                type_char, entry.key, encoded_value, entry.ttl_ms
-            )?;
-        }
-        file.sync_all()?;
-        fs::rename(&tmp, path)?;
-        Ok(entries.len())
-    }
-
-    fn load_from(store: &Store, path: &str) -> io::Result<usize> {
-        let path = Path::new(path);
-        if !path.exists() {
-            return Ok(0);
-        }
-        let file = fs::File::open(path)?;
-        let reader = io::BufReader::new(file);
-        let mut count = 0;
-        for line in reader.lines() {
-            let line = line?;
-            if line.is_empty() {
-                continue;
-            }
-            let parts: Vec<&str> = line.splitn(4, '\t').collect();
-            if parts.len() != 4 {
-                continue;
-            }
-            let key = parts[1].to_string();
-            let raw_value = parts[2];
-            let ttl_ms: i64 = parts[3].parse().unwrap_or(0);
-            let ttl = if ttl_ms > 0 {
-                Some(Duration::from_millis(ttl_ms as u64))
-            } else {
-                None
-            };
-            let value = match parts[0] {
-                "S" => DumpValue::Str(raw_value.to_string()),
-                "L" => DumpValue::List(if raw_value.is_empty() {
-                    vec![]
-                } else {
-                    raw_value.split('\x1f').map(|s| s.to_string()).collect()
-                }),
-                "H" => DumpValue::Hash(
-                    raw_value
-                        .split('\x1f')
-                        .filter_map(|p| {
-                            let kv: Vec<&str> = p.splitn(2, '\x1e').collect();
-                            if kv.len() == 2 {
-                                Some((kv[0].to_string(), kv[1].to_string()))
-                            } else {
-                                None
-                            }
-                        })
-                        .collect(),
-                ),
-                "T" => DumpValue::Set(if raw_value.is_empty() {
-                    vec![]
-                } else {
-                    raw_value.split('\x1f').map(|s| s.to_string()).collect()
-                }),
-                "Z" => DumpValue::SortedSet(
-                    raw_value
-                        .split('\x1f')
-                        .filter_map(|p| {
-                            let kv: Vec<&str> = p.splitn(2, '\x1e').collect();
-                            if kv.len() == 2 {
-                                Some((kv[0].to_string(), kv[1].parse::<f64>().unwrap_or(0.0)))
-                            } else {
-                                None
-                            }
-                        })
-                        .collect(),
-                ),
-                "X" => {
-                    let parts_x: Vec<&str> = raw_value.splitn(2, '\x1c').collect();
-                    let last_id_str = if !parts_x.is_empty() {
-                        parts_x[0].to_string()
-                    } else {
-                        "0-0".to_string()
-                    };
-                    let entries_raw = if parts_x.len() >= 2 { parts_x[1] } else { "" };
-                    let mut entries = Vec::new();
-                    if !entries_raw.is_empty() {
-                        for entry_str in entries_raw.split('\x1f') {
-                            let parts_e: Vec<&str> = entry_str.split('\x1d').collect();
-                            if !parts_e.is_empty() {
-                                let id = parts_e[0].to_string();
-                                let mut fields = Vec::new();
-                                let mut fi = 1;
-                                while fi + 1 < parts_e.len() {
-                                    fields.push((
-                                        parts_e[fi].to_string(),
-                                        parts_e[fi + 1].to_string(),
-                                    ));
-                                    fi += 2;
-                                }
-                                entries.push((id, fields));
-                            }
-                        }
-                    }
-                    DumpValue::Stream(entries, last_id_str)
-                }
-                _ => continue,
-            };
-            store.load_entry(key, value, ttl);
-            count += 1;
-        }
-        Ok(count)
-    }
 
     fn test_path() -> (String, impl Drop) {
         let id = TEST_ID.fetch_add(1, Ordering::Relaxed);
@@ -411,9 +521,9 @@ mod tests {
         let now = Instant::now();
         store.set(b"hello", b"world", None, now);
         store.set(b"num", b"42", None, now);
-        assert_eq!(save_to(&store, &path).unwrap(), 2);
+        assert_eq!(save_to_path(&store, &path).unwrap(), 2);
         let store2 = Store::new();
-        assert_eq!(load_from(&store2, &path).unwrap(), 2);
+        assert_eq!(load_from_path(&store2, &path).unwrap(), 2);
         assert_eq!(store2.get(b"hello", Instant::now()).unwrap(), &b"world"[..]);
         assert_eq!(store2.get(b"num", Instant::now()).unwrap(), &b"42"[..]);
     }
@@ -424,9 +534,9 @@ mod tests {
         let store = Store::new();
         let now = Instant::now();
         store.rpush(b"mylist", &[b"a", b"b", b"c"], now).unwrap();
-        save_to(&store, &path).unwrap();
+        save_to_path(&store, &path).unwrap();
         let store2 = Store::new();
-        load_from(&store2, &path).unwrap();
+        load_from_path(&store2, &path).unwrap();
         let n = Instant::now();
         assert_eq!(store2.llen(b"mylist", n).unwrap(), 3);
         let range = store2.lrange(b"mylist", 0, -1, n).unwrap();
@@ -446,9 +556,9 @@ mod tests {
                 now,
             )
             .unwrap();
-        save_to(&store, &path).unwrap();
+        save_to_path(&store, &path).unwrap();
         let store2 = Store::new();
-        load_from(&store2, &path).unwrap();
+        load_from_path(&store2, &path).unwrap();
         let n = Instant::now();
         assert_eq!(store2.hget(b"myhash", b"f1", n).unwrap(), &b"v1"[..]);
         assert_eq!(store2.hlen(b"myhash", n).unwrap(), 2);
@@ -460,9 +570,9 @@ mod tests {
         let store = Store::new();
         let now = Instant::now();
         store.sadd(b"myset", &[b"a", b"b", b"c"], now).unwrap();
-        save_to(&store, &path).unwrap();
+        save_to_path(&store, &path).unwrap();
         let store2 = Store::new();
-        load_from(&store2, &path).unwrap();
+        load_from_path(&store2, &path).unwrap();
         let n = Instant::now();
         assert_eq!(store2.scard(b"myset", n).unwrap(), 3);
         assert!(store2.sismember(b"myset", b"a", n).unwrap());
@@ -485,9 +595,9 @@ mod tests {
                 now,
             )
             .unwrap();
-        save_to(&store, &path).unwrap();
+        save_to_path(&store, &path).unwrap();
         let store2 = Store::new();
-        load_from(&store2, &path).unwrap();
+        load_from_path(&store2, &path).unwrap();
         let n = Instant::now();
         assert_eq!(store2.zcard(b"myzset", n).unwrap(), 2);
         assert_eq!(store2.zscore(b"myzset", b"alice", n).unwrap(), Some(1.5));
@@ -501,9 +611,9 @@ mod tests {
         let now = Instant::now();
         store.set(b"expiring", b"val", Some(Duration::from_secs(3600)), now);
         store.set(b"permanent", b"val", None, now);
-        save_to(&store, &path).unwrap();
+        save_to_path(&store, &path).unwrap();
         let store2 = Store::new();
-        load_from(&store2, &path).unwrap();
+        load_from_path(&store2, &path).unwrap();
         let n = Instant::now();
         assert!(store2.get(b"expiring", n).is_some());
         assert!(store2.ttl(b"expiring", n) > 0);
@@ -533,9 +643,9 @@ mod tests {
                 now,
             )
             .unwrap();
-        assert_eq!(save_to(&store, &path).unwrap(), 5);
+        assert_eq!(save_to_path(&store, &path).unwrap(), 5);
         let store2 = Store::new();
-        assert_eq!(load_from(&store2, &path).unwrap(), 5);
+        assert_eq!(load_from_path(&store2, &path).unwrap(), 5);
         let n = Instant::now();
         assert_eq!(store2.get(b"str", n).unwrap(), &b"val"[..]);
         assert_eq!(store2.llen(b"list", n).unwrap(), 2);
@@ -548,8 +658,159 @@ mod tests {
     fn load_nonexistent_returns_zero() {
         let store = Store::new();
         assert_eq!(
-            load_from(&store, "/tmp/lux_nonexistent_file_test.dat").unwrap(),
+            load_from_path(&store, "/tmp/lux_nonexistent_file_test.dat").unwrap(),
             0
         );
+    }
+
+    #[test]
+    fn test_binary_roundtrip_with_newlines() {
+        let (path, _g) = test_path();
+        let store = Store::new();
+        let now = Instant::now();
+        store.set(b"key", b"hello\nworld\n", None, now);
+        save_to_path(&store, &path).unwrap();
+        let store2 = Store::new();
+        load_from_path(&store2, &path).unwrap();
+        assert_eq!(
+            store2.get(b"key", Instant::now()).unwrap(),
+            &b"hello\nworld\n"[..]
+        );
+    }
+
+    #[test]
+    fn test_binary_roundtrip_with_tabs() {
+        let (path, _g) = test_path();
+        let store = Store::new();
+        let now = Instant::now();
+        store.set(b"key", b"hello\tworld\t", None, now);
+        save_to_path(&store, &path).unwrap();
+        let store2 = Store::new();
+        load_from_path(&store2, &path).unwrap();
+        assert_eq!(
+            store2.get(b"key", Instant::now()).unwrap(),
+            &b"hello\tworld\t"[..]
+        );
+    }
+
+    #[test]
+    fn test_no_key_injection() {
+        let (path, _g) = test_path();
+        let store = Store::new();
+        let now = Instant::now();
+        store.set(b"legit", b"S\tsecret\toverwritten\t0\n", None, now);
+        save_to_path(&store, &path).unwrap();
+        let store2 = Store::new();
+        load_from_path(&store2, &path).unwrap();
+        let n = Instant::now();
+        assert!(store2.get(b"secret", n).is_none());
+        assert_eq!(
+            store2.get(b"legit", n).unwrap(),
+            &b"S\tsecret\toverwritten\t0\n"[..]
+        );
+    }
+
+    #[test]
+    fn test_binary_roundtrip_all_types() {
+        let (path, _g) = test_path();
+        let store = Store::new();
+        let now = Instant::now();
+        store.set(b"str", b"val\twith\ttabs\nand\nnewlines", None, now);
+        store.rpush(b"list", &[b"a\tb", b"c\nd"], now).unwrap();
+        store
+            .hset(b"hash", &[(b"field\t1" as &[u8], b"val\n1" as &[u8])], now)
+            .unwrap();
+        store.sadd(b"set", &[b"mem\t1", b"mem\n2"], now).unwrap();
+        store
+            .zadd(
+                b"zset",
+                &[(b"m\t1" as &[u8], 1.5)],
+                false,
+                false,
+                false,
+                false,
+                false,
+                now,
+            )
+            .unwrap();
+        save_to_path(&store, &path).unwrap();
+        let store2 = Store::new();
+        load_from_path(&store2, &path).unwrap();
+        let n = Instant::now();
+        assert_eq!(
+            store2.get(b"str", n).unwrap(),
+            &b"val\twith\ttabs\nand\nnewlines"[..]
+        );
+        let range = store2.lrange(b"list", 0, -1, n).unwrap();
+        assert_eq!(range[0], &b"a\tb"[..]);
+        assert_eq!(range[1], &b"c\nd"[..]);
+        assert_eq!(
+            store2.hget(b"hash", b"field\t1", n).unwrap(),
+            &b"val\n1"[..]
+        );
+        assert_eq!(store2.scard(b"set", n).unwrap(), 2);
+        assert_eq!(store2.zcard(b"zset", n).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_legacy_format_loads() {
+        let (path, _g) = test_path();
+        let store = Store::new();
+        let now = Instant::now();
+        store.set(b"hello", b"world", None, now);
+        store.set(b"num", b"42", None, now);
+        save_legacy_to_path(&store, &path).unwrap();
+
+        let store2 = Store::new();
+        assert_eq!(load_from_path(&store2, &path).unwrap(), 2);
+        let n = Instant::now();
+        assert_eq!(store2.get(b"hello", n).unwrap(), &b"world"[..]);
+        assert_eq!(store2.get(b"num", n).unwrap(), &b"42"[..]);
+    }
+
+    #[test]
+    fn test_binary_data_in_values() {
+        let (path, _g) = test_path();
+        let store = Store::new();
+        let now = Instant::now();
+        let binary_val: Vec<u8> = vec![0x00, 0x01, 0x02, 0xFF, 0xFE, 0x80, 0x00];
+        store.set(b"binkey", &binary_val, None, now);
+        save_to_path(&store, &path).unwrap();
+        let store2 = Store::new();
+        load_from_path(&store2, &path).unwrap();
+        assert_eq!(
+            store2.get(b"binkey", Instant::now()).unwrap(),
+            &binary_val[..]
+        );
+    }
+
+    #[test]
+    fn test_issue_8_newline_corruption() {
+        let (path, _g) = test_path();
+        let store = Store::new();
+        let now = Instant::now();
+        store.set(b"key1", b"line1\nline2\nline3", None, now);
+        store.set(b"key2", b"normal", None, now);
+        save_to_path(&store, &path).unwrap();
+        let store2 = Store::new();
+        load_from_path(&store2, &path).unwrap();
+        let n = Instant::now();
+        assert_eq!(store2.get(b"key1", n).unwrap(), &b"line1\nline2\nline3"[..]);
+        assert_eq!(store2.get(b"key2", n).unwrap(), &b"normal"[..]);
+    }
+
+    #[test]
+    fn test_issue_8_tab_corruption() {
+        let (path, _g) = test_path();
+        let store = Store::new();
+        let now = Instant::now();
+        store.set(b"key1", b"col1\tcol2\tcol3", None, now);
+        store.set(b"key2", b"safe", None, now);
+        save_to_path(&store, &path).unwrap();
+        let store2 = Store::new();
+        load_from_path(&store2, &path).unwrap();
+        let n = Instant::now();
+        assert_eq!(store2.get(b"key1", n).unwrap(), &b"col1\tcol2\tcol3"[..]);
+        assert_eq!(store2.get(b"key2", n).unwrap(), &b"safe"[..]);
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1922,33 +1922,25 @@ impl Store {
                 entries.push(DumpEntry {
                     key: key.clone(),
                     value: match &entry.value {
-                        StoreValue::Str(s) => {
-                            DumpValue::Str(String::from_utf8_lossy(s).into_owned())
+                        StoreValue::Str(s) => DumpValue::Str(s.to_vec()),
+                        StoreValue::List(l) => {
+                            DumpValue::List(l.iter().map(|b| b.to_vec()).collect())
                         }
-                        StoreValue::List(l) => DumpValue::List(
-                            l.iter()
-                                .map(|b| String::from_utf8_lossy(b).into_owned())
-                                .collect(),
-                        ),
                         StoreValue::Hash(h) => DumpValue::Hash(
-                            h.iter()
-                                .map(|(k, v)| (k.clone(), String::from_utf8_lossy(v).into_owned()))
-                                .collect(),
+                            h.iter().map(|(k, v)| (k.clone(), v.to_vec())).collect(),
                         ),
                         StoreValue::Set(s) => DumpValue::Set(s.iter().cloned().collect()),
                         StoreValue::SortedSet(_, scores) => DumpValue::SortedSet(
                             scores.iter().map(|(m, s)| (m.clone(), *s)).collect(),
                         ),
                         StoreValue::Stream(s) => {
-                            let entries: Vec<(String, Vec<(String, String)>)> = s
+                            let entries: Vec<StreamDumpEntry> = s
                                 .entries
                                 .iter()
                                 .map(|(id, fields)| {
-                                    let flds: Vec<(String, String)> = fields
+                                    let flds: Vec<(String, Vec<u8>)> = fields
                                         .iter()
-                                        .map(|(k, v)| {
-                                            (k.clone(), String::from_utf8_lossy(v).into_owned())
-                                        })
+                                        .map(|(k, v)| (k.clone(), v.to_vec()))
                                         .collect();
                                     (id.to_string(), flds)
                                 })
@@ -3318,13 +3310,15 @@ impl Store {
     }
 }
 
+pub type StreamDumpEntry = (String, Vec<(String, Vec<u8>)>);
+
 pub enum DumpValue {
-    Str(String),
-    List(Vec<String>),
-    Hash(Vec<(String, String)>),
+    Str(Vec<u8>),
+    List(Vec<Vec<u8>>),
+    Hash(Vec<(String, Vec<u8>)>),
     Set(Vec<String>),
     SortedSet(Vec<(String, f64)>),
-    Stream(Vec<(String, Vec<(String, String)>)>, String),
+    Stream(Vec<StreamDumpEntry>, String),
 }
 
 pub struct DumpEntry {


### PR DESCRIPTION
Replaces tab/newline-delimited text format with length-prefixed binary. Values with special chars now survive save/load without corruption. Backwards compatible with old format via automatic fallback.