### PR TITLE
Issue #12: Problems connecting to the Bun Redis client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "lux"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bytes",
  "hashbrown",

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -1,0 +1,48 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "@luxdb/sdk",
+      "dependencies": {
+        "ioredis": "^5.0.0",
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "typescript": "^5.9.0",
+      },
+      "peerDependencies": {
+        "ioredis": ">=5.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
+
+    "ioredis": ["ioredis@5.10.0", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA=="],
+
+    "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
+
+    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -12,6 +12,7 @@ mod sort;
 mod sorted_sets;
 mod streams;
 mod strings;
+mod tables;
 mod timeseries;
 mod vectors;
 
@@ -638,6 +639,36 @@ pub fn execute(
             }
             if cmd_eq(cmd, b"TSINFO") {
                 return timeseries::cmd_tsinfo(args, store, out, now);
+            }
+            if cmd_eq(cmd, b"TCREATE") {
+                return tables::cmd_tcreate(args, store, out, now);
+            }
+            if cmd_eq(cmd, b"TINSERT") {
+                return tables::cmd_tinsert(args, store, out, now);
+            }
+            if cmd_eq(cmd, b"TGET") {
+                return tables::cmd_tget(args, store, out, now);
+            }
+            if cmd_eq(cmd, b"TQUERY") {
+                return tables::cmd_tquery(args, store, out, now);
+            }
+            if cmd_eq(cmd, b"TUPDATE") {
+                return tables::cmd_tupdate(args, store, out, now);
+            }
+            if cmd_eq(cmd, b"TDEL") {
+                return tables::cmd_tdel(args, store, out, now);
+            }
+            if cmd_eq(cmd, b"TDROP") {
+                return tables::cmd_tdrop(args, store, out, now);
+            }
+            if cmd_eq(cmd, b"TCOUNT") {
+                return tables::cmd_tcount(args, store, out, now);
+            }
+            if cmd_eq(cmd, b"TSCHEMA") {
+                return tables::cmd_tschema(args, store, out, now);
+            }
+            if cmd_eq(cmd, b"TLIST") {
+                return tables::cmd_tlist(args, store, out, now);
             }
         }
         b'U' => {
@@ -1716,6 +1747,16 @@ pub fn is_known_command(cmd: &[u8]) -> bool {
         || cmd_eq(cmd, b"BITOP")
         || cmd_eq(cmd, b"KSUB")
         || cmd_eq(cmd, b"KUNSUB")
+        || cmd_eq(cmd, b"TCREATE")
+        || cmd_eq(cmd, b"TINSERT")
+        || cmd_eq(cmd, b"TGET")
+        || cmd_eq(cmd, b"TQUERY")
+        || cmd_eq(cmd, b"TUPDATE")
+        || cmd_eq(cmd, b"TDEL")
+        || cmd_eq(cmd, b"TDROP")
+        || cmd_eq(cmd, b"TCOUNT")
+        || cmd_eq(cmd, b"TSCHEMA")
+        || cmd_eq(cmd, b"TLIST")
 }
 
 pub fn validate_args(args: &[&[u8]]) -> Result<(), String> {

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -31,8 +31,53 @@ pub fn cmd_quit(_args: &[&[u8]], _store: &Store, out: &mut BytesMut, _now: Insta
     CmdResult::Written
 }
 
-pub fn cmd_hello(_args: &[&[u8]], _store: &Store, out: &mut BytesMut, _now: Instant) -> CmdResult {
-    resp::write_array_header(out, 14);
+pub fn cmd_hello(args: &[&[u8]], _store: &Store, out: &mut BytesMut, _now: Instant) -> CmdResult {
+    let mut authenticated = false;
+    let mut auth_failed = false;
+    let mut i = 2;
+    while i < args.len() {
+        if cmd_eq(args[i], b"AUTH") {
+            if i + 2 >= args.len() {
+                resp::write_error(
+                    out,
+                    "ERR wrong number of arguments for 'hello' AUTH section",
+                );
+                return CmdResult::Written;
+            }
+            let password = arg_str(args[i + 2]);
+            let expected = std::env::var("LUX_PASSWORD").unwrap_or_default();
+            if expected.is_empty() {
+                resp::write_error(out, "ERR Client sent AUTH, but no password is set");
+                return CmdResult::Written;
+            } else if password == expected {
+                authenticated = true;
+            } else {
+                auth_failed = true;
+            }
+            i += 3;
+        } else if cmd_eq(args[i], b"SETNAME") {
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+
+    if auth_failed {
+        resp::write_error(out, "WRONGPASS invalid password");
+        return CmdResult::Written;
+    }
+
+    let requested_proto = if args.len() >= 2 {
+        arg_str(args[1]).parse::<i64>().unwrap_or(2)
+    } else {
+        2
+    };
+
+    if requested_proto == 3 {
+        resp::write_map_header(out, 7);
+    } else {
+        resp::write_array_header(out, 14);
+    }
     resp::write_bulk(out, "server");
     resp::write_bulk(out, "lux");
     resp::write_bulk(out, "version");
@@ -47,6 +92,10 @@ pub fn cmd_hello(_args: &[&[u8]], _store: &Store, out: &mut BytesMut, _now: Inst
     resp::write_bulk(out, "master");
     resp::write_bulk(out, "modules");
     resp::write_array_header(out, 0);
+
+    if authenticated {
+        return CmdResult::Authenticated;
+    }
     CmdResult::Written
 }
 

--- a/src/cmd/tables.rs
+++ b/src/cmd/tables.rs
@@ -1,0 +1,201 @@
+use bytes::BytesMut;
+use std::time::Instant;
+
+use crate::resp;
+use crate::store::Store;
+use crate::tables;
+
+use super::{arg_str, CmdResult};
+
+pub fn cmd_tcreate(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() < 3 {
+        resp::write_error(out, "ERR wrong number of arguments for 'tcreate' command");
+        return CmdResult::Written;
+    }
+    let table = arg_str(args[1]);
+    let field_specs: Vec<&str> = args[2..].iter().map(|a| arg_str(a)).collect();
+    match tables::table_create(store, table, &field_specs, now) {
+        Ok(()) => resp::write_ok(out),
+        Err(e) => resp::write_error(out, &e),
+    }
+    CmdResult::Written
+}
+
+pub fn cmd_tinsert(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() < 4 || !(args.len() - 2).is_multiple_of(2) {
+        resp::write_error(out, "ERR wrong number of arguments for 'tinsert' command");
+        return CmdResult::Written;
+    }
+    let table = arg_str(args[1]);
+    let mut field_values: Vec<(&str, &str)> = Vec::new();
+    let mut i = 2;
+    while i + 1 < args.len() {
+        field_values.push((arg_str(args[i]), arg_str(args[i + 1])));
+        i += 2;
+    }
+    match tables::table_insert(store, table, &field_values, now) {
+        Ok(id) => resp::write_integer(out, id),
+        Err(e) => resp::write_error(out, &e),
+    }
+    CmdResult::Written
+}
+
+pub fn cmd_tget(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() != 3 {
+        resp::write_error(out, "ERR wrong number of arguments for 'tget' command");
+        return CmdResult::Written;
+    }
+    let table = arg_str(args[1]);
+    let id: i64 = match arg_str(args[2]).parse() {
+        Ok(v) => v,
+        Err(_) => {
+            resp::write_error(out, "ERR invalid row id");
+            return CmdResult::Written;
+        }
+    };
+    match tables::table_get(store, table, id, now) {
+        Ok(pairs) => {
+            resp::write_array_header(out, pairs.len() * 2);
+            for (k, v) in pairs {
+                resp::write_bulk(out, &k);
+                resp::write_bulk(out, &v);
+            }
+        }
+        Err(e) => resp::write_error(out, &e),
+    }
+    CmdResult::Written
+}
+
+pub fn cmd_tquery(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() < 2 {
+        resp::write_error(out, "ERR wrong number of arguments for 'tquery' command");
+        return CmdResult::Written;
+    }
+    let table = arg_str(args[1]);
+    let str_args: Vec<&str> = args.iter().map(|a| arg_str(a)).collect();
+    let plan = match tables::parse_query_args(&str_args, 2) {
+        Ok(p) => p,
+        Err(e) => {
+            resp::write_error(out, &e);
+            return CmdResult::Written;
+        }
+    };
+    match tables::table_query(store, table, &plan, now) {
+        Ok(results) => {
+            resp::write_array_header(out, results.len());
+            for (id, row) in results {
+                resp::write_array_header(out, 1 + row.len() * 2);
+                resp::write_integer(out, id);
+                for (k, v) in row {
+                    resp::write_bulk(out, &k);
+                    resp::write_bulk(out, &v);
+                }
+            }
+        }
+        Err(e) => resp::write_error(out, &e),
+    }
+    CmdResult::Written
+}
+
+pub fn cmd_tupdate(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() < 5 || !(args.len() - 3).is_multiple_of(2) {
+        resp::write_error(out, "ERR wrong number of arguments for 'tupdate' command");
+        return CmdResult::Written;
+    }
+    let table = arg_str(args[1]);
+    let id: i64 = match arg_str(args[2]).parse() {
+        Ok(v) => v,
+        Err(_) => {
+            resp::write_error(out, "ERR invalid row id");
+            return CmdResult::Written;
+        }
+    };
+    let mut field_values: Vec<(&str, &str)> = Vec::new();
+    let mut i = 3;
+    while i + 1 < args.len() {
+        field_values.push((arg_str(args[i]), arg_str(args[i + 1])));
+        i += 2;
+    }
+    match tables::table_update(store, table, id, &field_values, now) {
+        Ok(()) => resp::write_ok(out),
+        Err(e) => resp::write_error(out, &e),
+    }
+    CmdResult::Written
+}
+
+pub fn cmd_tdel(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() != 3 {
+        resp::write_error(out, "ERR wrong number of arguments for 'tdel' command");
+        return CmdResult::Written;
+    }
+    let table = arg_str(args[1]);
+    let id: i64 = match arg_str(args[2]).parse() {
+        Ok(v) => v,
+        Err(_) => {
+            resp::write_error(out, "ERR invalid row id");
+            return CmdResult::Written;
+        }
+    };
+    match tables::table_delete(store, table, id, now) {
+        Ok(()) => resp::write_ok(out),
+        Err(e) => resp::write_error(out, &e),
+    }
+    CmdResult::Written
+}
+
+pub fn cmd_tdrop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() != 2 {
+        resp::write_error(out, "ERR wrong number of arguments for 'tdrop' command");
+        return CmdResult::Written;
+    }
+    let table = arg_str(args[1]);
+    match tables::table_drop(store, table, now) {
+        Ok(()) => resp::write_ok(out),
+        Err(e) => resp::write_error(out, &e),
+    }
+    CmdResult::Written
+}
+
+pub fn cmd_tcount(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() != 2 {
+        resp::write_error(out, "ERR wrong number of arguments for 'tcount' command");
+        return CmdResult::Written;
+    }
+    let table = arg_str(args[1]);
+    match tables::table_count(store, table, now) {
+        Ok(n) => resp::write_integer(out, n),
+        Err(e) => resp::write_error(out, &e),
+    }
+    CmdResult::Written
+}
+
+pub fn cmd_tschema(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() != 2 {
+        resp::write_error(out, "ERR wrong number of arguments for 'tschema' command");
+        return CmdResult::Written;
+    }
+    let table = arg_str(args[1]);
+    match tables::table_schema(store, table, now) {
+        Ok(fields) => {
+            resp::write_array_header(out, fields.len());
+            for f in fields {
+                resp::write_bulk(out, &f);
+            }
+        }
+        Err(e) => resp::write_error(out, &e),
+    }
+    CmdResult::Written
+}
+
+pub fn cmd_tlist(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() != 1 {
+        resp::write_error(out, "ERR wrong number of arguments for 'tlist' command");
+        return CmdResult::Written;
+    }
+    let tables = tables::table_list(store, now);
+    resp::write_array_header(out, tables.len());
+    for t in tables {
+        resp::write_bulk(out, &t);
+    }
+    CmdResult::Written
+}

--- a/src/eviction.rs
+++ b/src/eviction.rs
@@ -262,6 +262,11 @@ pub fn is_write_command(cmd: &[u8]) -> bool {
         || eq(cmd, b"SORT")
         || eq(cmd, b"TSADD")
         || eq(cmd, b"TSMADD")
+        || eq(cmd, b"TCREATE")
+        || eq(cmd, b"TINSERT")
+        || eq(cmd, b"TUPDATE")
+        || eq(cmd, b"TDEL")
+        || eq(cmd, b"TDROP")
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod pubsub;
 mod resp;
 mod snapshot;
 mod store;
+mod tables;
 
 use bytes::BytesMut;
 use cmd::CmdResult;

--- a/src/main.rs
+++ b/src/main.rs
@@ -578,6 +578,7 @@ async fn handle_connection(
                 for args in &commands {
                     if !authenticated
                         && !cmd_eq_fast(args[0], b"AUTH")
+                        && !cmd_eq_fast(args[0], b"HELLO")
                         && !cmd_eq_fast(args[0], b"PING")
                         && !cmd_eq_fast(args[0], b"QUIT")
                     {
@@ -723,6 +724,7 @@ async fn handle_connection(
                 for args in &commands {
                     if !authenticated
                         && !cmd_eq_fast(args[0], b"AUTH")
+                        && !cmd_eq_fast(args[0], b"HELLO")
                         && !cmd_eq_fast(args[0], b"PING")
                         && !cmd_eq_fast(args[0], b"QUIT")
                     {

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -82,6 +82,13 @@ pub fn write_array_header(buf: &mut BytesMut, len: usize) {
     }
 }
 
+pub fn write_map_header(buf: &mut BytesMut, len: usize) {
+    buf.put_u8(b'%');
+    let mut tmp = itoa::Buffer::new();
+    buf.extend_from_slice(tmp.format_usize(len).as_bytes());
+    buf.extend_from_slice(b"\r\n");
+}
+
 pub fn write_bulk_array(buf: &mut BytesMut, items: &[String]) {
     write_array_header(buf, items.len());
     for item in items {

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,0 +1,1019 @@
+use std::collections::HashSet;
+use std::time::Instant;
+
+use crate::store::Store;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FieldType {
+    Str,
+    Int,
+    Float,
+    Ref(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct FieldDef {
+    pub name: String,
+    pub field_type: FieldType,
+    pub unique: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CmpOp {
+    Eq,
+    Ne,
+    Gt,
+    Lt,
+    Ge,
+    Le,
+}
+
+#[derive(Debug, Clone)]
+pub struct WhereClause {
+    pub field: String,
+    pub op: CmpOp,
+    pub value: String,
+}
+
+pub struct QueryPlan {
+    pub conditions: Vec<WhereClause>,
+    pub join_field: Option<String>,
+    pub order_by: Option<(String, bool)>,
+    pub limit: Option<usize>,
+}
+
+fn schema_key(table: &str) -> String {
+    format!("_t:{}:schema", table)
+}
+
+fn seq_key(table: &str) -> String {
+    format!("_t:{}:seq", table)
+}
+
+fn row_key(table: &str, id: i64) -> String {
+    format!("_t:{}:row:{}", table, id)
+}
+
+fn idx_sorted_key(table: &str, field: &str) -> String {
+    format!("_t:{}:idx:{}", table, field)
+}
+
+fn idx_str_key(table: &str, field: &str, value: &str) -> String {
+    format!("_t:{}:idx:{}:{}", table, field, value)
+}
+
+fn uniq_key(table: &str, field: &str) -> String {
+    format!("_t:{}:uniq:{}", table, field)
+}
+
+fn ids_key(table: &str) -> String {
+    format!("_t:{}:ids", table)
+}
+
+fn table_list_key() -> String {
+    "_t:__tables".to_string()
+}
+
+fn is_valid_name(name: &str) -> bool {
+    !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_')
+}
+
+fn parse_field_def(spec: &str) -> Result<FieldDef, String> {
+    let parts: Vec<&str> = spec.splitn(3, ':').collect();
+    if parts.len() < 2 {
+        return Err(format!(
+            "ERR invalid field spec '{}', expected field:type",
+            spec
+        ));
+    }
+    let name = parts[0].to_string();
+    if !is_valid_name(&name) {
+        return Err(format!("ERR invalid field name '{}'", name));
+    }
+    let type_str = parts[1];
+    let mut unique = false;
+
+    let field_type = if type_str.starts_with("ref(") && type_str.ends_with(')') {
+        let ref_table = &type_str[4..type_str.len() - 1];
+        if !is_valid_name(ref_table) {
+            return Err(format!("ERR invalid referenced table name '{}'", ref_table));
+        }
+        FieldType::Ref(ref_table.to_string())
+    } else {
+        match type_str {
+            "str" => FieldType::Str,
+            "int" => FieldType::Int,
+            "float" => FieldType::Float,
+            _ => return Err(format!("ERR unknown field type '{}'", type_str)),
+        }
+    };
+
+    if parts.len() == 3 {
+        match parts[2] {
+            "unique" => unique = true,
+            _ => return Err(format!("ERR unknown field modifier '{}'", parts[2])),
+        }
+    }
+
+    Ok(FieldDef {
+        name,
+        field_type,
+        unique,
+    })
+}
+
+fn encode_field_def(def: &FieldDef) -> String {
+    let type_str = match &def.field_type {
+        FieldType::Str => "str".to_string(),
+        FieldType::Int => "int".to_string(),
+        FieldType::Float => "float".to_string(),
+        FieldType::Ref(t) => format!("ref:{}", t),
+    };
+    if def.unique {
+        format!("{}:unique", type_str)
+    } else {
+        type_str
+    }
+}
+
+fn decode_field_def(name: &str, encoded: &str) -> FieldDef {
+    let parts: Vec<&str> = encoded.splitn(2, ':').collect();
+    let (type_str, rest) = (parts[0], parts.get(1).copied().unwrap_or(""));
+
+    let (field_type, unique) = match type_str {
+        "str" => (FieldType::Str, rest == "unique"),
+        "int" => (FieldType::Int, rest == "unique"),
+        "float" => (FieldType::Float, rest == "unique"),
+        "ref" => (FieldType::Ref(rest.to_string()), false),
+        _ => (FieldType::Str, false),
+    };
+
+    FieldDef {
+        name: name.to_string(),
+        field_type,
+        unique,
+    }
+}
+
+fn load_schema(store: &Store, table: &str, now: Instant) -> Result<Vec<FieldDef>, String> {
+    let key = schema_key(table);
+    let pairs = store.hgetall(key.as_bytes(), now)?;
+    if pairs.is_empty() {
+        return Err(format!("ERR table '{}' does not exist", table));
+    }
+    let mut fields = Vec::new();
+    for (name, val) in pairs {
+        let encoded = String::from_utf8_lossy(&val).to_string();
+        fields.push(decode_field_def(&name, &encoded));
+    }
+    fields.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(fields)
+}
+
+fn validate_value(field: &FieldDef, value: &str) -> Result<(), String> {
+    match &field.field_type {
+        FieldType::Str => Ok(()),
+        FieldType::Int | FieldType::Ref(_) => {
+            value
+                .parse::<i64>()
+                .map_err(|_| format!("ERR field '{}' expects int, got '{}'", field.name, value))?;
+            Ok(())
+        }
+        FieldType::Float => {
+            value.parse::<f64>().map_err(|_| {
+                format!("ERR field '{}' expects float, got '{}'", field.name, value)
+            })?;
+            Ok(())
+        }
+    }
+}
+
+fn next_id(store: &Store, table: &str, now: Instant) -> i64 {
+    let key = seq_key(table);
+    match store.incr(key.as_bytes(), 1, now) {
+        Ok(id) => id,
+        Err(_) => {
+            store.set(key.as_bytes(), b"1", None, now);
+            1
+        }
+    }
+}
+
+fn add_to_index(store: &Store, table: &str, field: &FieldDef, value: &str, id: i64, now: Instant) {
+    let id_str = id.to_string();
+    match &field.field_type {
+        FieldType::Int | FieldType::Float | FieldType::Ref(_) => {
+            let score: f64 = value.parse().unwrap_or(0.0);
+            let zkey = idx_sorted_key(table, &field.name);
+            let _ = store.zadd(
+                zkey.as_bytes(),
+                &[(id_str.as_bytes(), score)],
+                false,
+                false,
+                false,
+                false,
+                false,
+                now,
+            );
+        }
+        FieldType::Str => {
+            let skey = idx_str_key(table, &field.name, value);
+            let _ = store.sadd(skey.as_bytes(), &[id_str.as_bytes()], now);
+        }
+    }
+}
+
+fn remove_from_index(
+    store: &Store,
+    table: &str,
+    field: &FieldDef,
+    value: &str,
+    id: i64,
+    now: Instant,
+) {
+    let id_str = id.to_string();
+    match &field.field_type {
+        FieldType::Int | FieldType::Float | FieldType::Ref(_) => {
+            let zkey = idx_sorted_key(table, &field.name);
+            let _ = store.zrem(zkey.as_bytes(), &[id_str.as_bytes()], now);
+        }
+        FieldType::Str => {
+            let skey = idx_str_key(table, &field.name, value);
+            let _ = store.srem(skey.as_bytes(), &[id_str.as_bytes()], now);
+        }
+    }
+}
+
+pub fn table_create(
+    store: &Store,
+    table: &str,
+    field_specs: &[&str],
+    now: Instant,
+) -> Result<(), String> {
+    if !is_valid_name(table) {
+        return Err("ERR invalid table name".to_string());
+    }
+    if field_specs.is_empty() {
+        return Err("ERR at least one field is required".to_string());
+    }
+
+    let key = schema_key(table);
+    let existing = store.hgetall(key.as_bytes(), now).unwrap_or_default();
+    if !existing.is_empty() {
+        return Err(format!("ERR table '{}' already exists", table));
+    }
+
+    let mut fields = Vec::new();
+    let mut names_seen = HashSet::new();
+    for spec in field_specs {
+        let field = parse_field_def(spec)?;
+        if !names_seen.insert(field.name.clone()) {
+            return Err(format!("ERR duplicate field name '{}'", field.name));
+        }
+        fields.push(field);
+    }
+
+    let pairs: Vec<(&[u8], Vec<u8>)> = fields
+        .iter()
+        .map(|f| {
+            let encoded = encode_field_def(f);
+            (f.name.as_bytes() as &[u8], encoded.into_bytes())
+        })
+        .collect();
+    let pair_refs: Vec<(&[u8], &[u8])> = pairs.iter().map(|(k, v)| (*k, v.as_slice())).collect();
+    store.hset(key.as_bytes(), &pair_refs, now)?;
+
+    store.set(seq_key(table).as_bytes(), b"0", None, now);
+
+    let tlist = table_list_key();
+    let _ = store.sadd(tlist.as_bytes(), &[table.as_bytes()], now);
+
+    Ok(())
+}
+
+pub fn table_insert(
+    store: &Store,
+    table: &str,
+    field_values: &[(&str, &str)],
+    now: Instant,
+) -> Result<i64, String> {
+    let schema = load_schema(store, table, now)?;
+
+    let mut provided: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+    for (k, v) in field_values {
+        if !schema.iter().any(|f| f.name == *k) {
+            return Err(format!("ERR unknown field '{}'", k));
+        }
+        provided.insert(k, v);
+    }
+
+    for field in &schema {
+        let value = match provided.get(field.name.as_str()) {
+            Some(v) => *v,
+            None => continue,
+        };
+
+        validate_value(field, value)?;
+
+        if let FieldType::Ref(ref ref_table) = field.field_type {
+            let ref_id: i64 = value.parse().unwrap();
+            let rk = row_key(ref_table, ref_id);
+            let ref_row = store.hgetall(rk.as_bytes(), now).unwrap_or_default();
+            if ref_row.is_empty() {
+                return Err(format!(
+                    "ERR foreign key violation: {}={} not found in table '{}'",
+                    field.name, value, ref_table
+                ));
+            }
+        }
+
+        if field.unique {
+            let ukey = uniq_key(table, &field.name);
+            if let Some(existing) = store.hget(ukey.as_bytes(), value.as_bytes(), now) {
+                let _ = existing;
+                return Err(format!(
+                    "ERR unique constraint violation on field '{}'",
+                    field.name
+                ));
+            }
+        }
+    }
+
+    let id = next_id(store, table, now);
+    let rk = row_key(table, id);
+
+    let mut pairs_owned: Vec<(String, String)> = Vec::new();
+    for field in &schema {
+        if let Some(value) = provided.get(field.name.as_str()) {
+            pairs_owned.push((field.name.clone(), value.to_string()));
+        }
+    }
+
+    let pair_refs: Vec<(&[u8], &[u8])> = pairs_owned
+        .iter()
+        .map(|(k, v)| (k.as_bytes() as &[u8], v.as_bytes() as &[u8]))
+        .collect();
+    store.hset(rk.as_bytes(), &pair_refs, now)?;
+
+    let id_str = id.to_string();
+    let ikey = ids_key(table);
+    let _ = store.zadd(
+        ikey.as_bytes(),
+        &[(id_str.as_bytes(), id as f64)],
+        false,
+        false,
+        false,
+        false,
+        false,
+        now,
+    );
+
+    for field in &schema {
+        if let Some(value) = provided.get(field.name.as_str()) {
+            add_to_index(store, table, field, value, id, now);
+
+            if field.unique {
+                let ukey = uniq_key(table, &field.name);
+                store.hset(
+                    ukey.as_bytes(),
+                    &[(value.as_bytes() as &[u8], id_str.as_bytes() as &[u8])],
+                    now,
+                )?;
+            }
+        }
+    }
+
+    Ok(id)
+}
+
+pub fn table_get(
+    store: &Store,
+    table: &str,
+    id: i64,
+    now: Instant,
+) -> Result<Vec<(String, String)>, String> {
+    let _schema = load_schema(store, table, now)?;
+    let rk = row_key(table, id);
+    let pairs = store.hgetall(rk.as_bytes(), now)?;
+    if pairs.is_empty() {
+        return Err(format!("ERR row {} not found in table '{}'", id, table));
+    }
+    let mut result: Vec<(String, String)> = pairs
+        .into_iter()
+        .map(|(k, v)| (k, String::from_utf8_lossy(&v).to_string()))
+        .collect();
+    result.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(result)
+}
+
+pub fn table_update(
+    store: &Store,
+    table: &str,
+    id: i64,
+    field_values: &[(&str, &str)],
+    now: Instant,
+) -> Result<(), String> {
+    let schema = load_schema(store, table, now)?;
+    let rk = row_key(table, id);
+    let old_pairs = store.hgetall(rk.as_bytes(), now)?;
+    if old_pairs.is_empty() {
+        return Err(format!("ERR row {} not found in table '{}'", id, table));
+    }
+
+    let old_map: std::collections::HashMap<String, String> = old_pairs
+        .into_iter()
+        .map(|(k, v)| (k, String::from_utf8_lossy(&v).to_string()))
+        .collect();
+
+    for (fname, fval) in field_values {
+        let field = schema
+            .iter()
+            .find(|f| f.name == *fname)
+            .ok_or_else(|| format!("ERR unknown field '{}'", fname))?;
+
+        validate_value(field, fval)?;
+
+        if let FieldType::Ref(ref ref_table) = field.field_type {
+            let ref_id: i64 = fval.parse().unwrap();
+            let rk2 = row_key(ref_table, ref_id);
+            let ref_row = store.hgetall(rk2.as_bytes(), now).unwrap_or_default();
+            if ref_row.is_empty() {
+                return Err(format!(
+                    "ERR foreign key violation: {}={} not found in table '{}'",
+                    fname, fval, ref_table
+                ));
+            }
+        }
+
+        if field.unique {
+            let ukey = uniq_key(table, &field.name);
+            if let Some(existing_id_bytes) = store.hget(ukey.as_bytes(), fval.as_bytes(), now) {
+                let existing_id_str = String::from_utf8_lossy(&existing_id_bytes).to_string();
+                let existing_id: i64 = existing_id_str.parse().unwrap_or(-1);
+                if existing_id != id {
+                    return Err(format!(
+                        "ERR unique constraint violation on field '{}'",
+                        field.name
+                    ));
+                }
+            }
+        }
+    }
+
+    for (fname, fval) in field_values {
+        let field = schema.iter().find(|f| f.name == *fname).unwrap();
+
+        if let Some(old_val) = old_map.get(*fname) {
+            remove_from_index(store, table, field, old_val, id, now);
+            if field.unique {
+                let ukey = uniq_key(table, &field.name);
+                let _ = store.hdel(ukey.as_bytes(), &[old_val.as_bytes()], now);
+            }
+        }
+
+        add_to_index(store, table, field, fval, id, now);
+        if field.unique {
+            let ukey = uniq_key(table, &field.name);
+            let id_str = id.to_string();
+            let _ = store.hset(
+                ukey.as_bytes(),
+                &[(fval.as_bytes() as &[u8], id_str.as_bytes() as &[u8])],
+                now,
+            );
+        }
+    }
+
+    let pair_refs: Vec<(&[u8], &[u8])> = field_values
+        .iter()
+        .map(|(k, v)| (k.as_bytes() as &[u8], v.as_bytes() as &[u8]))
+        .collect();
+    store.hset(rk.as_bytes(), &pair_refs, now)?;
+
+    Ok(())
+}
+
+pub fn table_delete(store: &Store, table: &str, id: i64, now: Instant) -> Result<(), String> {
+    let schema = load_schema(store, table, now)?;
+    let rk = row_key(table, id);
+    let pairs = store.hgetall(rk.as_bytes(), now)?;
+    if pairs.is_empty() {
+        return Err(format!("ERR row {} not found in table '{}'", id, table));
+    }
+
+    let row_map: std::collections::HashMap<String, String> = pairs
+        .into_iter()
+        .map(|(k, v)| (k, String::from_utf8_lossy(&v).to_string()))
+        .collect();
+
+    let tlist_key = table_list_key();
+    let all_tables = store
+        .smembers(tlist_key.as_bytes(), now)
+        .unwrap_or_default();
+    for other_table in &all_tables {
+        if other_table == table {
+            continue;
+        }
+        let other_schema = match load_schema(store, other_table, now) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        for field in &other_schema {
+            if let FieldType::Ref(ref ref_table) = field.field_type {
+                if ref_table == table {
+                    let zkey = idx_sorted_key(other_table, &field.name);
+                    let id_f = id as f64;
+                    let refs = store
+                        .zrangebyscore(
+                            zkey.as_bytes(),
+                            id_f,
+                            id_f,
+                            false,
+                            false,
+                            false,
+                            None,
+                            None,
+                            false,
+                            now,
+                        )
+                        .unwrap_or_default();
+                    if !refs.is_empty() {
+                        return Err(format!(
+                            "ERR cannot delete row {}: referenced by table '{}'",
+                            id, other_table
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    for field in &schema {
+        if let Some(val) = row_map.get(&field.name) {
+            remove_from_index(store, table, field, val, id, now);
+            if field.unique {
+                let ukey = uniq_key(table, &field.name);
+                let _ = store.hdel(ukey.as_bytes(), &[val.as_bytes()], now);
+            }
+        }
+    }
+
+    let ikey = ids_key(table);
+    let id_str = id.to_string();
+    let _ = store.zrem(ikey.as_bytes(), &[id_str.as_bytes()], now);
+
+    store.del(&[rk.as_bytes()]);
+
+    Ok(())
+}
+
+pub fn table_drop(store: &Store, table: &str, now: Instant) -> Result<(), String> {
+    let schema = match load_schema(store, table, now) {
+        Ok(s) => s,
+        Err(_) => return Err(format!("ERR table '{}' does not exist", table)),
+    };
+
+    let ikey = ids_key(table);
+    let all_ids = store
+        .zrangebyscore(
+            ikey.as_bytes(),
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+            false,
+            false,
+            false,
+            None,
+            None,
+            false,
+            now,
+        )
+        .unwrap_or_default();
+
+    for (id_str, _) in &all_ids {
+        let id: i64 = id_str.parse().unwrap_or(0);
+        let rk = row_key(table, id);
+        store.del(&[rk.as_bytes()]);
+    }
+
+    for field in &schema {
+        match &field.field_type {
+            FieldType::Int | FieldType::Float | FieldType::Ref(_) => {
+                let zkey = idx_sorted_key(table, &field.name);
+                store.del(&[zkey.as_bytes()]);
+            }
+            FieldType::Str => {}
+        }
+        if field.unique {
+            let ukey = uniq_key(table, &field.name);
+            store.del(&[ukey.as_bytes()]);
+        }
+    }
+
+    store.del(&[ikey.as_bytes()]);
+    store.del(&[schema_key(table).as_bytes()]);
+    store.del(&[seq_key(table).as_bytes()]);
+
+    let tlist = table_list_key();
+    let _ = store.srem(tlist.as_bytes(), &[table.as_bytes()], now);
+
+    Ok(())
+}
+
+pub fn table_count(store: &Store, table: &str, now: Instant) -> Result<i64, String> {
+    let _ = load_schema(store, table, now)?;
+    let ikey = ids_key(table);
+    store.zcard(ikey.as_bytes(), now)
+}
+
+pub fn table_schema(store: &Store, table: &str, now: Instant) -> Result<Vec<String>, String> {
+    let schema = load_schema(store, table, now)?;
+    let mut result = Vec::new();
+    for field in &schema {
+        let type_str = match &field.field_type {
+            FieldType::Str => "str".to_string(),
+            FieldType::Int => "int".to_string(),
+            FieldType::Float => "float".to_string(),
+            FieldType::Ref(t) => format!("ref({})", t),
+        };
+        let mut desc = format!("{}:{}", field.name, type_str);
+        if field.unique {
+            desc.push_str(":unique");
+        }
+        result.push(desc);
+    }
+    Ok(result)
+}
+
+pub fn table_list(store: &Store, now: Instant) -> Vec<String> {
+    let tlist = table_list_key();
+    store.smembers(tlist.as_bytes(), now).unwrap_or_default()
+}
+
+fn get_all_row_ids(store: &Store, table: &str, now: Instant) -> Vec<i64> {
+    let ikey = ids_key(table);
+    let items = store
+        .zrangebyscore(
+            ikey.as_bytes(),
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+            false,
+            false,
+            false,
+            None,
+            None,
+            false,
+            now,
+        )
+        .unwrap_or_default();
+    items
+        .iter()
+        .filter_map(|(s, _)| s.parse::<i64>().ok())
+        .collect()
+}
+
+fn get_row(store: &Store, table: &str, id: i64, now: Instant) -> Option<Vec<(String, String)>> {
+    let rk = row_key(table, id);
+    let pairs = store.hgetall(rk.as_bytes(), now).unwrap_or_default();
+    if pairs.is_empty() {
+        return None;
+    }
+    Some(
+        pairs
+            .into_iter()
+            .map(|(k, v)| (k, String::from_utf8_lossy(&v).to_string()))
+            .collect(),
+    )
+}
+
+fn matches_condition(row: &[(String, String)], cond: &WhereClause, field_def: &FieldDef) -> bool {
+    let val = match row.iter().find(|(k, _)| k == &cond.field) {
+        Some((_, v)) => v.as_str(),
+        None => return cond.op == CmpOp::Ne,
+    };
+
+    match &field_def.field_type {
+        FieldType::Int | FieldType::Ref(_) => {
+            let lhs: i64 = val.parse().unwrap_or(0);
+            let rhs: i64 = cond.value.parse().unwrap_or(0);
+            match cond.op {
+                CmpOp::Eq => lhs == rhs,
+                CmpOp::Ne => lhs != rhs,
+                CmpOp::Gt => lhs > rhs,
+                CmpOp::Lt => lhs < rhs,
+                CmpOp::Ge => lhs >= rhs,
+                CmpOp::Le => lhs <= rhs,
+            }
+        }
+        FieldType::Float => {
+            let lhs: f64 = val.parse().unwrap_or(0.0);
+            let rhs: f64 = cond.value.parse().unwrap_or(0.0);
+            match cond.op {
+                CmpOp::Eq => (lhs - rhs).abs() < f64::EPSILON,
+                CmpOp::Ne => (lhs - rhs).abs() >= f64::EPSILON,
+                CmpOp::Gt => lhs > rhs,
+                CmpOp::Lt => lhs < rhs,
+                CmpOp::Ge => lhs >= rhs,
+                CmpOp::Le => lhs <= rhs,
+            }
+        }
+        FieldType::Str => match cond.op {
+            CmpOp::Eq => val == cond.value,
+            CmpOp::Ne => val != cond.value,
+            CmpOp::Gt => val > cond.value.as_str(),
+            CmpOp::Lt => val < cond.value.as_str(),
+            CmpOp::Ge => val >= cond.value.as_str(),
+            CmpOp::Le => val <= cond.value.as_str(),
+        },
+    }
+}
+
+fn candidates_from_index(
+    store: &Store,
+    table: &str,
+    cond: &WhereClause,
+    field_def: &FieldDef,
+    now: Instant,
+) -> Option<Vec<i64>> {
+    match &field_def.field_type {
+        FieldType::Str => {
+            if cond.op == CmpOp::Eq {
+                let skey = idx_str_key(table, &cond.field, &cond.value);
+                let members = store.smembers(skey.as_bytes(), now).unwrap_or_default();
+                let ids: Vec<i64> = members
+                    .iter()
+                    .filter_map(|s| s.parse::<i64>().ok())
+                    .collect();
+                return Some(ids);
+            }
+            None
+        }
+        FieldType::Int | FieldType::Float | FieldType::Ref(_) => {
+            let score: f64 = match cond.value.parse() {
+                Ok(v) => v,
+                Err(_) => return None,
+            };
+            let zkey = idx_sorted_key(table, &cond.field);
+            let (min, max, min_excl, max_excl) = match cond.op {
+                CmpOp::Eq => (score, score, false, false),
+                CmpOp::Gt => (score, f64::INFINITY, true, false),
+                CmpOp::Ge => (score, f64::INFINITY, false, false),
+                CmpOp::Lt => (f64::NEG_INFINITY, score, false, true),
+                CmpOp::Le => (f64::NEG_INFINITY, score, false, false),
+                CmpOp::Ne => return None,
+            };
+            let results = store
+                .zrangebyscore(
+                    zkey.as_bytes(),
+                    min,
+                    max,
+                    min_excl,
+                    max_excl,
+                    false,
+                    None,
+                    None,
+                    false,
+                    now,
+                )
+                .unwrap_or_default();
+            let ids: Vec<i64> = results
+                .iter()
+                .filter_map(|(s, _)| s.parse::<i64>().ok())
+                .collect();
+            Some(ids)
+        }
+    }
+}
+
+pub type QueryRow = (i64, Vec<(String, String)>);
+
+pub fn table_query(
+    store: &Store,
+    table: &str,
+    plan: &QueryPlan,
+    now: Instant,
+) -> Result<Vec<QueryRow>, String> {
+    let schema = load_schema(store, table, now)?;
+
+    for cond in &plan.conditions {
+        if !schema.iter().any(|f| f.name == cond.field) {
+            return Err(format!(
+                "ERR unknown field '{}' in WHERE clause",
+                cond.field
+            ));
+        }
+    }
+
+    let mut candidate_ids: Option<Vec<i64>> = None;
+
+    for cond in &plan.conditions {
+        let field_def = schema.iter().find(|f| f.name == cond.field).unwrap();
+        if let Some(ids) = candidates_from_index(store, table, cond, field_def, now) {
+            let id_set: HashSet<i64> = ids.into_iter().collect();
+            candidate_ids = Some(match candidate_ids {
+                Some(existing) => existing
+                    .into_iter()
+                    .filter(|id| id_set.contains(id))
+                    .collect(),
+                None => id_set.into_iter().collect(),
+            });
+        }
+    }
+
+    let ids = match candidate_ids {
+        Some(ids) => ids,
+        None => get_all_row_ids(store, table, now),
+    };
+
+    let mut results: Vec<(i64, Vec<(String, String)>)> = Vec::new();
+    for id in ids {
+        let row = match get_row(store, table, id, now) {
+            Some(r) => r,
+            None => continue,
+        };
+
+        let mut passes = true;
+        for cond in &plan.conditions {
+            let field_def = schema.iter().find(|f| f.name == cond.field).unwrap();
+            if !matches_condition(&row, cond, field_def) {
+                passes = false;
+                break;
+            }
+        }
+        if passes {
+            results.push((id, row));
+        }
+    }
+
+    if let Some((ref order_field, ascending)) = plan.order_by {
+        let field_def = schema.iter().find(|f| f.name == *order_field);
+        results.sort_by(|a, b| {
+            let av =
+                a.1.iter()
+                    .find(|(k, _)| k == order_field)
+                    .map(|(_, v)| v.as_str())
+                    .unwrap_or("");
+            let bv =
+                b.1.iter()
+                    .find(|(k, _)| k == order_field)
+                    .map(|(_, v)| v.as_str())
+                    .unwrap_or("");
+            let cmp = if let Some(fd) = field_def {
+                match &fd.field_type {
+                    FieldType::Int | FieldType::Ref(_) => {
+                        let ai: i64 = av.parse().unwrap_or(0);
+                        let bi: i64 = bv.parse().unwrap_or(0);
+                        ai.cmp(&bi)
+                    }
+                    FieldType::Float => {
+                        let af: f64 = av.parse().unwrap_or(0.0);
+                        let bf: f64 = bv.parse().unwrap_or(0.0);
+                        af.partial_cmp(&bf).unwrap_or(std::cmp::Ordering::Equal)
+                    }
+                    FieldType::Str => av.cmp(bv),
+                }
+            } else {
+                av.cmp(bv)
+            };
+            if ascending {
+                cmp
+            } else {
+                cmp.reverse()
+            }
+        });
+    }
+
+    if let Some(limit) = plan.limit {
+        results.truncate(limit);
+    }
+
+    if let Some(ref join_field_name) = plan.join_field {
+        let field_def = schema
+            .iter()
+            .find(|f| f.name == *join_field_name)
+            .ok_or_else(|| format!("ERR unknown field '{}' for JOIN", join_field_name))?;
+        let ref_table = match &field_def.field_type {
+            FieldType::Ref(t) => t.clone(),
+            _ => {
+                return Err(format!(
+                    "ERR field '{}' is not a ref() field",
+                    join_field_name
+                ))
+            }
+        };
+
+        let ref_schema = load_schema(store, &ref_table, now)?;
+
+        for (_, row) in results.iter_mut() {
+            let ref_id_str = row
+                .iter()
+                .find(|(k, _)| k == join_field_name)
+                .map(|(_, v)| v.clone())
+                .unwrap_or_default();
+            let ref_id: i64 = ref_id_str.parse().unwrap_or(0);
+            if let Some(ref_row) = get_row(store, &ref_table, ref_id, now) {
+                for (rk, rv) in ref_row {
+                    row.push((format!("{}.{}", ref_table, rk), rv));
+                }
+            }
+        }
+        let _ = ref_schema;
+    }
+
+    Ok(results)
+}
+
+pub fn parse_query_args(args: &[&str], start: usize) -> Result<QueryPlan, String> {
+    let mut conditions = Vec::new();
+    let mut join_field = None;
+    let mut order_by = None;
+    let mut limit = None;
+    let mut i = start;
+
+    while i < args.len() {
+        let keyword = args[i].to_uppercase();
+        match keyword.as_str() {
+            "WHERE" => {
+                i += 1;
+                loop {
+                    if i + 2 >= args.len() {
+                        return Err("ERR incomplete WHERE clause".to_string());
+                    }
+                    let field = args[i].to_string();
+                    let op_str = args[i + 1];
+                    let value = args[i + 2].to_string();
+                    let op = match op_str {
+                        "=" => CmpOp::Eq,
+                        "!=" => CmpOp::Ne,
+                        ">" => CmpOp::Gt,
+                        "<" => CmpOp::Lt,
+                        ">=" => CmpOp::Ge,
+                        "<=" => CmpOp::Le,
+                        _ => return Err(format!("ERR unknown operator '{}'", op_str)),
+                    };
+                    conditions.push(WhereClause { field, op, value });
+                    i += 3;
+                    if i < args.len() && args[i].to_uppercase() == "AND" {
+                        i += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            "JOIN" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err("ERR JOIN requires a field name".to_string());
+                }
+                join_field = Some(args[i].to_string());
+                i += 1;
+            }
+            "ORDER" => {
+                i += 1;
+                if i >= args.len() || args[i].to_uppercase() != "BY" {
+                    return Err("ERR expected BY after ORDER".to_string());
+                }
+                i += 1;
+                if i >= args.len() {
+                    return Err("ERR ORDER BY requires a field name".to_string());
+                }
+                let field = args[i].to_string();
+                i += 1;
+                let ascending = if i < args.len() {
+                    let dir = args[i].to_uppercase();
+                    if dir == "ASC" {
+                        i += 1;
+                        true
+                    } else if dir == "DESC" {
+                        i += 1;
+                        false
+                    } else {
+                        true
+                    }
+                } else {
+                    true
+                };
+                order_by = Some((field, ascending));
+            }
+            "LIMIT" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err("ERR LIMIT requires a number".to_string());
+                }
+                let n: usize = args[i]
+                    .parse()
+                    .map_err(|_| "ERR LIMIT value must be a positive integer".to_string())?;
+                limit = Some(n);
+                i += 1;
+            }
+            _ => {
+                return Err(format!("ERR unexpected keyword '{}'", args[i]));
+            }
+        }
+    }
+
+    Ok(QueryPlan {
+        conditions,
+        join_field,
+        order_by,
+        limit,
+    })
+}

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -179,3 +179,39 @@ fn auth_missing_args() {
         "AUTH needs password arg: {resp}"
     );
 }
+
+#[test]
+fn hello_allowed_without_auth() {
+    let port: u16 = 16606;
+    let _server = start_lux_with_password(port, "secret123");
+    let mut conn = connect(port);
+
+    let resp = send_and_read(&mut conn, &["HELLO"]);
+    assert!(resp.contains("lux"), "HELLO allowed pre-auth: {resp}");
+}
+
+#[test]
+fn hello_with_auth_authenticates() {
+    let port: u16 = 16607;
+    let _server = start_lux_with_password(port, "secret123");
+    let mut conn = connect(port);
+
+    let resp = send_and_read(&mut conn, &["HELLO", "3", "AUTH", "default", "secret123"]);
+    assert!(resp.contains("lux"), "HELLO returns server info: {resp}");
+
+    let resp = send_and_read(&mut conn, &["SET", "k", "v"]);
+    assert!(resp.contains("+OK"), "authenticated via HELLO: {resp}");
+}
+
+#[test]
+fn hello_with_wrong_password_rejected() {
+    let port: u16 = 16608;
+    let _server = start_lux_with_password(port, "secret123");
+    let mut conn = connect(port);
+
+    let resp = send_and_read(&mut conn, &["HELLO", "3", "AUTH", "default", "wrongpass"]);
+    assert!(resp.contains("WRONGPASS"), "bad password in HELLO: {resp}");
+
+    let resp = send_and_read(&mut conn, &["SET", "k", "v"]);
+    assert!(resp.contains("NOAUTH"), "still locked out: {resp}");
+}

--- a/tests/tables.rs
+++ b/tests/tables.rs
@@ -1,0 +1,468 @@
+use std::io::{BufRead, BufReader, Read as IoRead, Write};
+use std::net::TcpStream;
+use std::process::{Child, Command};
+use std::time::Duration;
+
+fn start_server(port: u16) -> Child {
+    let child = Command::new(env!("CARGO_BIN_EXE_lux"))
+        .env("LUX_PORT", port.to_string())
+        .env("LUX_SAVE_INTERVAL", "0")
+        .env("LUX_DATA_DIR", format!("/tmp/lux-test-{}", port))
+        .spawn()
+        .expect("failed to start lux");
+    std::thread::sleep(Duration::from_millis(500));
+    child
+}
+
+fn send(stream: &mut TcpStream, args: &[&str]) -> String {
+    let mut cmd = format!("*{}\r\n", args.len());
+    for a in args {
+        cmd.push_str(&format!("${}\r\n{}\r\n", a.len(), a));
+    }
+    stream.write_all(cmd.as_bytes()).unwrap();
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    read_response(&mut reader)
+}
+
+fn read_response(reader: &mut BufReader<TcpStream>) -> String {
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    let line = line.trim_end().to_string();
+
+    if line.starts_with('+') || line.starts_with('-') || line.starts_with(':') {
+        return line;
+    }
+    if let Some(rest) = line.strip_prefix('$') {
+        let len: i64 = rest.parse().unwrap();
+        if len < 0 {
+            return "$-1".to_string();
+        }
+        let mut buf = vec![0u8; (len + 2) as usize];
+        reader.read_exact(&mut buf).expect("read bulk");
+        let s = String::from_utf8_lossy(&buf[..len as usize]).to_string();
+        return format!("${}", s);
+    }
+    if let Some(rest) = line.strip_prefix('*') {
+        let count: i64 = rest.parse().unwrap();
+        if count < 0 {
+            return "*-1".to_string();
+        }
+        let mut items = Vec::new();
+        for _ in 0..count {
+            items.push(read_response(reader));
+        }
+        return format!("*{} [{}]", count, items.join(", "));
+    }
+    line
+}
+
+#[test]
+fn tcreate_and_tschema() {
+    let port = 16500;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    let r = send(
+        &mut s,
+        &[
+            "TCREATE",
+            "users",
+            "name:str",
+            "age:int",
+            "email:str:unique",
+        ],
+    );
+    assert_eq!(r, "+OK");
+
+    let r = send(&mut s, &["TSCHEMA", "users"]);
+    assert!(
+        r.contains("name:str"),
+        "schema should contain name:str: {}",
+        r
+    );
+    assert!(
+        r.contains("age:int"),
+        "schema should contain age:int: {}",
+        r
+    );
+    assert!(
+        r.contains("email:str:unique"),
+        "schema should contain email:str:unique: {}",
+        r
+    );
+
+    let r = send(&mut s, &["TCREATE", "users", "foo:str"]);
+    assert!(r.starts_with('-'), "duplicate table should error: {}", r);
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn tinsert_and_tget() {
+    let port = 16501;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    send(&mut s, &["TCREATE", "users", "name:str", "age:int"]);
+
+    let r = send(&mut s, &["TINSERT", "users", "name", "alice", "age", "30"]);
+    assert_eq!(r, ":1");
+
+    let r = send(&mut s, &["TGET", "users", "1"]);
+    assert!(r.contains("alice"), "should find alice: {}", r);
+    assert!(r.contains("30"), "should find age 30: {}", r);
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn tinsert_auto_increment() {
+    let port = 16502;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    send(&mut s, &["TCREATE", "items", "name:str"]);
+
+    let r1 = send(&mut s, &["TINSERT", "items", "name", "a"]);
+    assert_eq!(r1, ":1");
+
+    let r2 = send(&mut s, &["TINSERT", "items", "name", "b"]);
+    assert_eq!(r2, ":2");
+
+    let r3 = send(&mut s, &["TINSERT", "items", "name", "c"]);
+    assert_eq!(r3, ":3");
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn unique_constraint_violation() {
+    let port = 16503;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    send(&mut s, &["TCREATE", "users", "email:str:unique"]);
+
+    let r = send(&mut s, &["TINSERT", "users", "email", "a@b.com"]);
+    assert_eq!(r, ":1");
+
+    let r = send(&mut s, &["TINSERT", "users", "email", "a@b.com"]);
+    assert!(r.starts_with('-'), "duplicate unique should error: {}", r);
+    assert!(
+        r.contains("unique constraint"),
+        "error should mention unique: {}",
+        r
+    );
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn foreign_key_validation() {
+    let port = 16504;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    send(&mut s, &["TCREATE", "users", "name:str"]);
+    send(
+        &mut s,
+        &["TCREATE", "posts", "title:str", "user_id:ref(users)"],
+    );
+
+    send(&mut s, &["TINSERT", "users", "name", "alice"]);
+
+    let r = send(
+        &mut s,
+        &["TINSERT", "posts", "title", "hello", "user_id", "1"],
+    );
+    assert_eq!(r, ":1");
+
+    let r = send(
+        &mut s,
+        &["TINSERT", "posts", "title", "bad", "user_id", "999"],
+    );
+    assert!(r.starts_with('-'), "invalid FK should error: {}", r);
+    assert!(r.contains("foreign key"), "error should mention FK: {}", r);
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn tquery_where_equality_and_range() {
+    let port = 16505;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    send(&mut s, &["TCREATE", "users", "name:str", "age:int"]);
+    send(&mut s, &["TINSERT", "users", "name", "alice", "age", "25"]);
+    send(&mut s, &["TINSERT", "users", "name", "bob", "age", "30"]);
+    send(&mut s, &["TINSERT", "users", "name", "carol", "age", "35"]);
+
+    let r = send(&mut s, &["TQUERY", "users", "WHERE", "name", "=", "bob"]);
+    assert!(r.contains("bob"), "should find bob: {}", r);
+    assert!(!r.contains("alice"), "should not find alice: {}", r);
+
+    let r = send(&mut s, &["TQUERY", "users", "WHERE", "age", ">", "28"]);
+    assert!(r.contains("bob"), "bob age 30 > 28: {}", r);
+    assert!(r.contains("carol"), "carol age 35 > 28: {}", r);
+    assert!(!r.contains("alice"), "alice age 25 not > 28: {}", r);
+
+    let r = send(&mut s, &["TQUERY", "users", "WHERE", "age", ">=", "30"]);
+    assert!(r.contains("bob"), "bob age 30 >= 30: {}", r);
+    assert!(r.contains("carol"), "carol age 35 >= 30: {}", r);
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn tquery_order_by_and_limit() {
+    let port = 16506;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    send(&mut s, &["TCREATE", "users", "name:str", "age:int"]);
+    send(&mut s, &["TINSERT", "users", "name", "alice", "age", "25"]);
+    send(&mut s, &["TINSERT", "users", "name", "bob", "age", "30"]);
+    send(&mut s, &["TINSERT", "users", "name", "carol", "age", "35"]);
+
+    let r = send(
+        &mut s,
+        &[
+            "TQUERY", "users", "ORDER", "BY", "age", "DESC", "LIMIT", "2",
+        ],
+    );
+    assert!(r.contains("carol"), "carol should be in top 2 desc: {}", r);
+    assert!(r.contains("bob"), "bob should be in top 2 desc: {}", r);
+    assert!(
+        !r.contains("alice"),
+        "alice should not be in top 2 desc: {}",
+        r
+    );
+
+    let r = send(
+        &mut s,
+        &["TQUERY", "users", "ORDER", "BY", "age", "ASC", "LIMIT", "1"],
+    );
+    assert!(r.contains("alice"), "alice should be first asc: {}", r);
+    assert!(!r.contains("bob"), "bob should not be in limit 1: {}", r);
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn tquery_with_join() {
+    let port = 16507;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    send(&mut s, &["TCREATE", "users", "name:str", "email:str"]);
+    send(
+        &mut s,
+        &["TCREATE", "posts", "title:str", "user_id:ref(users)"],
+    );
+
+    send(
+        &mut s,
+        &[
+            "TINSERT",
+            "users",
+            "name",
+            "alice",
+            "email",
+            "alice@test.com",
+        ],
+    );
+    send(
+        &mut s,
+        &["TINSERT", "posts", "title", "hello_world", "user_id", "1"],
+    );
+
+    let r = send(&mut s, &["TQUERY", "posts", "JOIN", "user_id"]);
+    assert!(
+        r.contains("hello_world"),
+        "should contain post title: {}",
+        r
+    );
+    assert!(
+        r.contains("users.name"),
+        "should contain joined field prefix: {}",
+        r
+    );
+    assert!(
+        r.contains("alice"),
+        "should contain joined user name: {}",
+        r
+    );
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn tupdate_row() {
+    let port = 16508;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    send(&mut s, &["TCREATE", "users", "name:str", "age:int"]);
+    send(&mut s, &["TINSERT", "users", "name", "alice", "age", "25"]);
+
+    let r = send(&mut s, &["TUPDATE", "users", "1", "age", "26"]);
+    assert_eq!(r, "+OK");
+
+    let r = send(&mut s, &["TGET", "users", "1"]);
+    assert!(r.contains("26"), "age should be updated to 26: {}", r);
+
+    let r = send(&mut s, &["TUPDATE", "users", "1", "age", "notanumber"]);
+    assert!(r.starts_with('-'), "type violation should error: {}", r);
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn tdel_with_fk_check() {
+    let port = 16509;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    send(&mut s, &["TCREATE", "users", "name:str"]);
+    send(
+        &mut s,
+        &["TCREATE", "posts", "title:str", "user_id:ref(users)"],
+    );
+    send(&mut s, &["TINSERT", "users", "name", "alice"]);
+    send(
+        &mut s,
+        &["TINSERT", "posts", "title", "hello", "user_id", "1"],
+    );
+
+    let r = send(&mut s, &["TDEL", "users", "1"]);
+    assert!(
+        r.starts_with('-'),
+        "should not delete referenced row: {}",
+        r
+    );
+    assert!(
+        r.contains("referenced"),
+        "error should mention reference: {}",
+        r
+    );
+
+    let r = send(&mut s, &["TDEL", "posts", "1"]);
+    assert_eq!(r, "+OK");
+
+    let r = send(&mut s, &["TDEL", "users", "1"]);
+    assert_eq!(r, "+OK");
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn tdrop_table() {
+    let port = 16510;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    send(&mut s, &["TCREATE", "temp", "x:str"]);
+    send(&mut s, &["TINSERT", "temp", "x", "hello"]);
+
+    let r = send(&mut s, &["TDROP", "temp"]);
+    assert_eq!(r, "+OK");
+
+    let r = send(&mut s, &["TGET", "temp", "1"]);
+    assert!(r.starts_with('-'), "table should not exist: {}", r);
+
+    let r = send(&mut s, &["TLIST"]);
+    assert!(!r.contains("temp"), "temp should not appear in list: {}", r);
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn tcount_rows() {
+    let port = 16511;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    send(&mut s, &["TCREATE", "items", "name:str"]);
+
+    let r = send(&mut s, &["TCOUNT", "items"]);
+    assert_eq!(r, ":0");
+
+    send(&mut s, &["TINSERT", "items", "name", "a"]);
+    send(&mut s, &["TINSERT", "items", "name", "b"]);
+
+    let r = send(&mut s, &["TCOUNT", "items"]);
+    assert_eq!(r, ":2");
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn tlist_tables() {
+    let port = 16512;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    let r = send(&mut s, &["TLIST"]);
+    assert_eq!(r, "*0 []");
+
+    send(&mut s, &["TCREATE", "users", "name:str"]);
+    send(&mut s, &["TCREATE", "posts", "title:str"]);
+
+    let r = send(&mut s, &["TLIST"]);
+    assert!(r.contains("users"), "should list users: {}", r);
+    assert!(r.contains("posts"), "should list posts: {}", r);
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn type_validation() {
+    let port = 16513;
+    let mut child = start_server(port);
+    let mut s = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    send(&mut s, &["TCREATE", "data", "score:int", "rating:float"]);
+
+    let r = send(&mut s, &["TINSERT", "data", "score", "notanumber"]);
+    assert!(r.starts_with('-'), "string into int should error: {}", r);
+
+    let r = send(&mut s, &["TINSERT", "data", "rating", "notafloat"]);
+    assert!(r.starts_with('-'), "string into float should error: {}", r);
+
+    let r = send(
+        &mut s,
+        &["TINSERT", "data", "score", "42", "rating", "3.14"],
+    );
+    assert_eq!(r, ":1");
+
+    child.kill().ok();
+    child.wait().ok();
+}


### PR DESCRIPTION
Bun's native `RedisClient` uses the RESP3 protocol and sends a `HELLO` command to authenticate. Lux did not have `HELLO` in the pre-auth bypass list, so it got `NOAUTH` before being able to send the password. Also Lux did not have any RESP3 support.

The fix was to add `HELLO` to the auth bypass list so the command could get through, parse the AUTH arguments in `cmd_hello`, and return RESP3 format when proto 3 is requested. 

Closes #12 