### PR TITLE
Issue #12: Problems connecting to the Bun Redis client

### DIFF
--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -31,8 +31,53 @@ pub fn cmd_quit(_args: &[&[u8]], _store: &Store, out: &mut BytesMut, _now: Insta
     CmdResult::Written
 }
 
-pub fn cmd_hello(_args: &[&[u8]], _store: &Store, out: &mut BytesMut, _now: Instant) -> CmdResult {
-    resp::write_array_header(out, 14);
+pub fn cmd_hello(args: &[&[u8]], _store: &Store, out: &mut BytesMut, _now: Instant) -> CmdResult {
+    let mut authenticated = false;
+    let mut auth_failed = false;
+    let mut i = 2;
+    while i < args.len() {
+        if cmd_eq(args[i], b"AUTH") {
+            if i + 2 >= args.len() {
+                resp::write_error(
+                    out,
+                    "ERR wrong number of arguments for 'hello' AUTH section",
+                );
+                return CmdResult::Written;
+            }
+            let password = arg_str(args[i + 2]);
+            let expected = std::env::var("LUX_PASSWORD").unwrap_or_default();
+            if expected.is_empty() {
+                resp::write_error(out, "ERR Client sent AUTH, but no password is set");
+                return CmdResult::Written;
+            } else if password == expected {
+                authenticated = true;
+            } else {
+                auth_failed = true;
+            }
+            i += 3;
+        } else if cmd_eq(args[i], b"SETNAME") {
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+
+    if auth_failed {
+        resp::write_error(out, "WRONGPASS invalid password");
+        return CmdResult::Written;
+    }
+
+    let requested_proto = if args.len() >= 2 {
+        arg_str(args[1]).parse::<i64>().unwrap_or(2)
+    } else {
+        2
+    };
+
+    if requested_proto == 3 {
+        resp::write_map_header(out, 7);
+    } else {
+        resp::write_array_header(out, 14);
+    }
     resp::write_bulk(out, "server");
     resp::write_bulk(out, "lux");
     resp::write_bulk(out, "version");
@@ -47,6 +92,10 @@ pub fn cmd_hello(_args: &[&[u8]], _store: &Store, out: &mut BytesMut, _now: Inst
     resp::write_bulk(out, "master");
     resp::write_bulk(out, "modules");
     resp::write_array_header(out, 0);
+
+    if authenticated {
+        return CmdResult::Authenticated;
+    }
     CmdResult::Written
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -577,6 +577,7 @@ async fn handle_connection(
                 for args in &commands {
                     if !authenticated
                         && !cmd_eq_fast(args[0], b"AUTH")
+                        && !cmd_eq_fast(args[0], b"HELLO")
                         && !cmd_eq_fast(args[0], b"PING")
                         && !cmd_eq_fast(args[0], b"QUIT")
                     {
@@ -722,6 +723,7 @@ async fn handle_connection(
                 for args in &commands {
                     if !authenticated
                         && !cmd_eq_fast(args[0], b"AUTH")
+                        && !cmd_eq_fast(args[0], b"HELLO")
                         && !cmd_eq_fast(args[0], b"PING")
                         && !cmd_eq_fast(args[0], b"QUIT")
                     {

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -82,6 +82,13 @@ pub fn write_array_header(buf: &mut BytesMut, len: usize) {
     }
 }
 
+pub fn write_map_header(buf: &mut BytesMut, len: usize) {
+    buf.put_u8(b'%');
+    let mut tmp = itoa::Buffer::new();
+    buf.extend_from_slice(tmp.format_usize(len).as_bytes());
+    buf.extend_from_slice(b"\r\n");
+}
+
 pub fn write_bulk_array(buf: &mut BytesMut, items: &[String]) {
     write_array_header(buf, items.len());
     for item in items {

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -179,3 +179,39 @@ fn auth_missing_args() {
         "AUTH needs password arg: {resp}"
     );
 }
+
+#[test]
+fn hello_allowed_without_auth() {
+    let port: u16 = 16606;
+    let _server = start_lux_with_password(port, "secret123");
+    let mut conn = connect(port);
+
+    let resp = send_and_read(&mut conn, &["HELLO"]);
+    assert!(resp.contains("lux"), "HELLO allowed pre-auth: {resp}");
+}
+
+#[test]
+fn hello_with_auth_authenticates() {
+    let port: u16 = 16607;
+    let _server = start_lux_with_password(port, "secret123");
+    let mut conn = connect(port);
+
+    let resp = send_and_read(&mut conn, &["HELLO", "3", "AUTH", "default", "secret123"]);
+    assert!(resp.contains("lux"), "HELLO returns server info: {resp}");
+
+    let resp = send_and_read(&mut conn, &["SET", "k", "v"]);
+    assert!(resp.contains("+OK"), "authenticated via HELLO: {resp}");
+}
+
+#[test]
+fn hello_with_wrong_password_rejected() {
+    let port: u16 = 16608;
+    let _server = start_lux_with_password(port, "secret123");
+    let mut conn = connect(port);
+
+    let resp = send_and_read(&mut conn, &["HELLO", "3", "AUTH", "default", "wrongpass"]);
+    assert!(resp.contains("WRONGPASS"), "bad password in HELLO: {resp}");
+
+    let resp = send_and_read(&mut conn, &["SET", "k", "v"]);
+    assert!(resp.contains("NOAUTH"), "still locked out: {resp}");
+}


### PR DESCRIPTION
Bun's native RedisClient uses the RESP3 protocol and sends a HELLO command to authenticate. Lux did not have HELLO in the pre-auth bypass list, so it got NOAUTH before being able to send the password. Also Lux did not have any RESP3 support.

The fix was to add HELLO to the auth bypass list so the command could get through, parse the AUTH arguments in cmd_hello, and return RESP3 format when proto 3 is requested.

Closes https://github.com/lux-db/lux/issues/12