### PR TITLE
fix: preserve pub/sub binary payload

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -36,7 +36,7 @@ pub enum CmdResult {
     },
     Publish {
         channel: String,
-        message: String,
+        message: Bytes,
     },
     BlockPop {
         keys: Vec<String>,

--- a/src/cmd/pubsub.rs
+++ b/src/cmd/pubsub.rs
@@ -1,4 +1,4 @@
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use std::time::Instant;
 
 use crate::resp;
@@ -13,7 +13,7 @@ pub fn cmd_publish(args: &[&[u8]], _store: &Store, out: &mut BytesMut, _now: Ins
     }
     CmdResult::Publish {
         channel: arg_str(args[1]).to_string(),
-        message: arg_str(args[2]).to_string(),
+        message: Bytes::copy_from_slice(args[2]),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -655,7 +655,7 @@ async fn handle_connection(
                                     resp::write_bulk(&mut write_buf, "kmessage");
                                     resp::write_bulk(&mut write_buf, msg.pattern.as_deref().unwrap_or(""));
                                     resp::write_bulk(&mut write_buf, &msg.channel);
-                                    resp::write_bulk(&mut write_buf, &msg.payload);
+                                    resp::write_bulk_raw(&mut write_buf, &msg.payload);
                                 }
                                 pubsub::MessageKind::PubSub => {
                                     if let Some(ref pat) = msg.pattern {
@@ -663,12 +663,12 @@ async fn handle_connection(
                                         resp::write_bulk(&mut write_buf, "pmessage");
                                         resp::write_bulk(&mut write_buf, pat);
                                         resp::write_bulk(&mut write_buf, &msg.channel);
-                                        resp::write_bulk(&mut write_buf, &msg.payload);
+                                        resp::write_bulk_raw(&mut write_buf, &msg.payload);
                                     } else {
                                         resp::write_array_header(&mut write_buf, 3);
                                         resp::write_bulk(&mut write_buf, "message");
                                         resp::write_bulk(&mut write_buf, &msg.channel);
-                                        resp::write_bulk(&mut write_buf, &msg.payload);
+                                        resp::write_bulk_raw(&mut write_buf, &msg.payload);
                                     }
                                 }
                             }

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -352,8 +352,8 @@ impl Broker {
     ) {
         let mut op: Option<Bytes> = None;
         if let Some(tx) = exact_subs.get(key) {
-            let operation = op
-                .get_or_insert_with(|| Bytes::copy_from_slice(&cmd.to_ascii_lowercase()));
+            let operation =
+                op.get_or_insert_with(|| Bytes::copy_from_slice(&cmd.to_ascii_lowercase()));
             let msg = Message {
                 channel: key.to_string(),
                 payload: operation.clone(),
@@ -365,9 +365,8 @@ impl Broker {
         }
         for (pat, tx) in glob_subs.iter() {
             if glob_match(pat, key) {
-                let operation = op.get_or_insert_with(|| {
-                    Bytes::copy_from_slice(&cmd.to_ascii_lowercase())
-                });
+                let operation =
+                    op.get_or_insert_with(|| Bytes::copy_from_slice(&cmd.to_ascii_lowercase()));
                 let msg = Message {
                     channel: key.to_string(),
                     payload: operation.clone(),

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -51,7 +51,7 @@ pub enum MessageKind {
 #[derive(Clone, Debug)]
 pub struct Message {
     pub channel: String,
-    pub payload: String,
+    pub payload: Bytes,
     pub pattern: Option<String>,
     pub kind: MessageKind,
 }
@@ -192,7 +192,7 @@ impl Broker {
         tx.subscribe()
     }
 
-    pub fn publish(&self, channel: &str, payload: String) -> i64 {
+    pub fn publish(&self, channel: &str, payload: Bytes) -> i64 {
         let mut count = 0i64;
         {
             let channels = self.channels.read();
@@ -350,10 +350,10 @@ impl Broker {
         key: &str,
         cmd: &[u8],
     ) {
-        let mut op: Option<String> = None;
+        let mut op: Option<Bytes> = None;
         if let Some(tx) = exact_subs.get(key) {
             let operation = op
-                .get_or_insert_with(|| std::str::from_utf8(cmd).unwrap_or("").to_ascii_lowercase());
+                .get_or_insert_with(|| Bytes::copy_from_slice(&cmd.to_ascii_lowercase()));
             let msg = Message {
                 channel: key.to_string(),
                 payload: operation.clone(),
@@ -366,7 +366,7 @@ impl Broker {
         for (pat, tx) in glob_subs.iter() {
             if glob_match(pat, key) {
                 let operation = op.get_or_insert_with(|| {
-                    std::str::from_utf8(cmd).unwrap_or("").to_ascii_lowercase()
+                    Bytes::copy_from_slice(&cmd.to_ascii_lowercase())
                 });
                 let msg = Message {
                     channel: key.to_string(),
@@ -499,17 +499,17 @@ mod tests {
     fn subscribe_and_publish() {
         let broker = Broker::new();
         let mut rx = broker.subscribe("test-channel");
-        let count = broker.publish("test-channel", "hello".to_string());
+        let count = broker.publish("test-channel", Bytes::from_static(b"hello"));
         assert_eq!(count, 1);
         let msg = rx.try_recv().unwrap();
         assert_eq!(msg.channel, "test-channel");
-        assert_eq!(msg.payload, "hello");
+        assert_eq!(msg.payload.as_ref(), b"hello");
     }
 
     #[test]
     fn publish_to_empty_channel_returns_zero() {
         let broker = Broker::new();
-        let count = broker.publish("nobody-listening", "hello".to_string());
+        let count = broker.publish("nobody-listening", Bytes::from_static(b"hello"));
         assert_eq!(count, 0);
     }
 
@@ -518,9 +518,9 @@ mod tests {
         let broker = Broker::new();
         let mut rx1 = broker.subscribe("ch");
         let mut rx2 = broker.subscribe("ch");
-        broker.publish("ch", "msg".to_string());
-        assert_eq!(rx1.try_recv().unwrap().payload, "msg");
-        assert_eq!(rx2.try_recv().unwrap().payload, "msg");
+        broker.publish("ch", Bytes::from_static(b"msg"));
+        assert_eq!(rx1.try_recv().unwrap().payload.as_ref(), b"msg");
+        assert_eq!(rx2.try_recv().unwrap().payload.as_ref(), b"msg");
     }
 
     #[test]
@@ -528,20 +528,20 @@ mod tests {
         let broker = Broker::new();
         let mut rx_a = broker.subscribe("a");
         let _rx_b = broker.subscribe("b");
-        broker.publish("a", "only-a".to_string());
-        assert_eq!(rx_a.try_recv().unwrap().payload, "only-a");
+        broker.publish("a", Bytes::from_static(b"only-a"));
+        assert_eq!(rx_a.try_recv().unwrap().payload.as_ref(), b"only-a");
     }
 
     #[test]
     fn multiple_messages_in_order() {
         let broker = Broker::new();
         let mut rx = broker.subscribe("ch");
-        broker.publish("ch", "first".to_string());
-        broker.publish("ch", "second".to_string());
-        broker.publish("ch", "third".to_string());
-        assert_eq!(rx.try_recv().unwrap().payload, "first");
-        assert_eq!(rx.try_recv().unwrap().payload, "second");
-        assert_eq!(rx.try_recv().unwrap().payload, "third");
+        broker.publish("ch", Bytes::from_static(b"first"));
+        broker.publish("ch", Bytes::from_static(b"second"));
+        broker.publish("ch", Bytes::from_static(b"third"));
+        assert_eq!(rx.try_recv().unwrap().payload.as_ref(), b"first");
+        assert_eq!(rx.try_recv().unwrap().payload.as_ref(), b"second");
+        assert_eq!(rx.try_recv().unwrap().payload.as_ref(), b"third");
     }
 
     #[test]

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -11,6 +11,16 @@ fn resp_cmd(args: &[&str]) -> Vec<u8> {
     buf.into_bytes()
 }
 
+fn resp_cmd_raw(args: &[&[u8]]) -> Vec<u8> {
+    let mut buf = format!("*{}\r\n", args.len()).into_bytes();
+    for arg in args {
+        buf.extend_from_slice(format!("${}\r\n", arg.len()).as_bytes());
+        buf.extend_from_slice(arg);
+        buf.extend_from_slice(b"\r\n");
+    }
+    buf
+}
+
 fn read_all(stream: &mut TcpStream) -> String {
     let mut data = Vec::with_capacity(4096);
     let mut buf = [0u8; 8192];
@@ -26,6 +36,21 @@ fn read_all(stream: &mut TcpStream) -> String {
     String::from_utf8_lossy(&data).to_string()
 }
 
+fn read_all_bytes(stream: &mut TcpStream) -> Vec<u8> {
+    let mut data = Vec::with_capacity(4096);
+    let mut buf = [0u8; 8192];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(len) => data.extend_from_slice(&buf[..len]),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => break,
+            Err(_) => break,
+        }
+    }
+    data
+}
+
 fn send_and_read(stream: &mut TcpStream, args: &[&str]) -> String {
     stream.write_all(&resp_cmd(args)).unwrap();
     thread::sleep(Duration::from_millis(50));
@@ -34,6 +59,10 @@ fn send_and_read(stream: &mut TcpStream, args: &[&str]) -> String {
 
 fn send(stream: &mut TcpStream, args: &[&str]) {
     stream.write_all(&resp_cmd(args)).unwrap();
+}
+
+fn send_raw(stream: &mut TcpStream, args: &[&[u8]]) {
+    stream.write_all(&resp_cmd_raw(args)).unwrap();
 }
 
 fn find_lux_binary() -> Option<std::path::PathBuf> {
@@ -149,6 +178,35 @@ fn publish_delivers_message_to_subscriber() {
     assert!(resp.contains("message"), "message type: {resp}");
     assert!(resp.contains("events"), "channel name: {resp}");
     assert!(resp.contains("hello_world"), "payload: {resp}");
+}
+
+#[test]
+fn publish_preserves_binary_payload_bytes() {
+    let port: u16 = 16710;
+    let _server = start_lux(port);
+    let mut sub_conn = connect(port);
+    let mut pub_conn = connect(port);
+
+    send(&mut sub_conn, &["SUBSCRIBE", "events"]);
+    thread::sleep(Duration::from_millis(100));
+    let _ = read_all_bytes(&mut sub_conn);
+
+    let payload: &[u8] = b"\x00\xff\x80msgpack\x00\x01";
+    send_raw(&mut pub_conn, &[b"PUBLISH", b"events", payload]);
+    thread::sleep(Duration::from_millis(100));
+    let _ = read_all_bytes(&mut pub_conn);
+
+    let resp = read_all_bytes(&mut sub_conn);
+    assert!(resp.windows(b"message".len()).any(|w| w == b"message"), "message type missing: {resp:?}");
+    assert!(resp.windows(b"events".len()).any(|w| w == b"events"), "channel missing: {resp:?}");
+
+    let mut needle = format!("${}\r\n", payload.len()).into_bytes();
+    needle.extend_from_slice(payload);
+    needle.extend_from_slice(b"\r\n");
+    assert!(
+        resp.windows(needle.len()).any(|w| w == needle.as_slice()),
+        "binary payload not preserved exactly: {resp:?}"
+    );
 }
 
 #[test]

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -197,8 +197,14 @@ fn publish_preserves_binary_payload_bytes() {
     let _ = read_all_bytes(&mut pub_conn);
 
     let resp = read_all_bytes(&mut sub_conn);
-    assert!(resp.windows(b"message".len()).any(|w| w == b"message"), "message type missing: {resp:?}");
-    assert!(resp.windows(b"events".len()).any(|w| w == b"events"), "channel missing: {resp:?}");
+    assert!(
+        resp.windows(b"message".len()).any(|w| w == b"message"),
+        "message type missing: {resp:?}"
+    );
+    assert!(
+        resp.windows(b"events".len()).any(|w| w == b"events"),
+        "channel missing: {resp:?}"
+    );
 
     let mut needle = format!("${}\r\n", payload.len()).into_bytes();
     needle.extend_from_slice(payload);


### PR DESCRIPTION
Fixes #15. 

Root cause was that Lux converted `PUBLISH` payloads to utf-8 strings, so binary payloads were not preserved. This PR keeps all pub/sub payloads as raw bytes end-to-end and adds a new regression test.