### PR TITLE
Release Lux 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +60,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +77,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -84,6 +105,41 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "either"
@@ -136,6 +192,58 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -192,6 +300,22 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "id-arena"
@@ -273,7 +397,9 @@ dependencies = [
 name = "lux"
 version = "0.12.1"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-util",
  "hashbrown 0.14.5",
  "mlua",
  "ordered-float",
@@ -284,6 +410,7 @@ dependencies = [
  "sha1_smol",
  "tempfile",
  "tokio",
+ "tokio-tungstenite",
 ]
 
 [[package]]
@@ -428,8 +555,8 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -466,12 +593,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -481,7 +629,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -499,7 +656,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -618,6 +775,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +806,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -680,6 +854,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +902,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +954,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "lux"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lux"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 description = "A fast, multi-threaded Redis-compatible key-value store."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ path = "src/main.rs"
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 bytes = "1"
+base64 = "0.22"
+futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 parking_lot = "0.12"
 hashbrown = "0.14"
 ordered-float = "4"
@@ -26,6 +28,7 @@ mlua = { version = "0.10", features = ["lua54", "vendored"] }
 sha1_smol = "1"
 rmp = "0.8"
 serde_json = "1"
+tokio-tungstenite = "0.24"
 [dev-dependencies]
 tempfile = "3"
 proptest = "1"

--- a/src/cmd/bitops.rs
+++ b/src/cmd/bitops.rs
@@ -6,6 +6,18 @@ use crate::store::Store;
 
 use super::{arg_str, cmd_eq, parse_i64, CmdResult};
 
+const INTEGER_ERR: &str = "ERR value is not an integer or out of range";
+
+fn parse_i64_arg(arg: &[u8], out: &mut BytesMut) -> Option<i64> {
+    match parse_i64(arg) {
+        Ok(n) => Some(n),
+        Err(_) => {
+            resp::write_error(out, INTEGER_ERR);
+            None
+        }
+    }
+}
+
 pub fn cmd_setbit(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     if args.len() != 4 {
         resp::write_error(out, "ERR wrong number of arguments for 'setbit' command");
@@ -112,17 +124,30 @@ pub fn cmd_bitpos(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         }
     };
     let start = if args.len() >= 4 {
-        parse_i64(args[3]).unwrap_or(0)
+        match parse_i64_arg(args[3], out) {
+            Some(start) => start,
+            None => return CmdResult::Written,
+        }
     } else {
         0
     };
     let end = if args.len() >= 5 {
-        Some(parse_i64(args[4]).unwrap_or(-1))
+        match parse_i64_arg(args[4], out) {
+            Some(end) => Some(end),
+            None => return CmdResult::Written,
+        }
     } else {
         None
     };
     let use_bit = if args.len() >= 6 {
-        cmd_eq(args[5], b"BIT")
+        if cmd_eq(args[5], b"BIT") {
+            true
+        } else if cmd_eq(args[5], b"BYTE") {
+            false
+        } else {
+            resp::write_error(out, "ERR syntax error");
+            return CmdResult::Written;
+        }
     } else {
         false
     };
@@ -139,26 +164,26 @@ pub fn cmd_bitop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         resp::write_error(out, "ERR wrong number of arguments for 'bitop' command");
         return CmdResult::Written;
     }
-    let op = if cmd_eq(args[1], b"AND") {
-        "AND"
-    } else if cmd_eq(args[1], b"OR") {
-        "OR"
-    } else if cmd_eq(args[1], b"XOR") {
-        "XOR"
-    } else if cmd_eq(args[1], b"NOT") {
-        "NOT"
-    } else {
-        arg_str(args[1])
-    };
+    let op = arg_str(args[1]).to_uppercase();
+    if !matches!(op.as_str(), "AND" | "OR" | "XOR" | "NOT") {
+        resp::write_error(
+            out,
+            &format!("ERR BITOP requires AND, OR, XOR, or NOT, got '{op}'"),
+        );
+        return CmdResult::Written;
+    }
     let dest = args[2];
-    let src_keys = &args[3..];
+    let src_keys: Vec<&[u8]> = args[3..].to_vec();
+    for key in &src_keys {
+        store.try_promote(key, now);
+    }
 
     if op == "NOT" && src_keys.len() != 1 {
         resp::write_error(out, "ERR BITOP NOT requires one and only one key");
         return CmdResult::Written;
     }
 
-    match store.bitop(op, dest, src_keys, now) {
+    match store.bitop(&op, dest, &src_keys, now) {
         Ok(len) => resp::write_integer(out, len as i64),
         Err(e) => resp::write_error(out, &e),
     }

--- a/src/cmd/hashes.rs
+++ b/src/cmd/hashes.rs
@@ -6,6 +6,18 @@ use crate::store::{Store, StoreValue};
 
 use super::{arg_str, cmd_eq, parse_i64, parse_u64, CmdResult};
 
+const INTEGER_ERR: &str = "ERR value is not an integer or out of range";
+
+fn parse_usize_arg(arg: &[u8], out: &mut BytesMut) -> Option<usize> {
+    match parse_u64(arg).ok().and_then(|n| usize::try_from(n).ok()) {
+        Some(n) => Some(n),
+        None => {
+            resp::write_error(out, INTEGER_ERR);
+            None
+        }
+    }
+}
+
 pub fn cmd_hset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     let is_hmset = cmd_eq(args[0], b"HMSET");
     if args.len() < 4 || !(args.len() - 2).is_multiple_of(2) {
@@ -310,14 +322,24 @@ pub fn cmd_hscan(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         resp::write_error(out, "ERR wrong number of arguments");
         return CmdResult::Written;
     }
-    let cursor = parse_u64(args[2]).unwrap_or(0) as usize;
+    let cursor = match parse_usize_arg(args[2], out) {
+        Some(cursor) => cursor,
+        None => return CmdResult::Written,
+    };
     let mut count = 10usize;
     let mut pattern: Option<&[u8]> = None;
     let mut novalues = false;
     let mut i = 3;
     while i < args.len() {
         if cmd_eq(args[i], b"COUNT") && i + 1 < args.len() {
-            count = parse_u64(args[i + 1]).unwrap_or(10) as usize;
+            count = match parse_usize_arg(args[i + 1], out) {
+                Some(count) if count > 0 => count,
+                Some(_) => {
+                    resp::write_error(out, INTEGER_ERR);
+                    return CmdResult::Written;
+                }
+                None => return CmdResult::Written,
+            };
             i += 2;
         } else if cmd_eq(args[i], b"MATCH") && i + 1 < args.len() {
             pattern = Some(args[i + 1]);
@@ -326,7 +348,8 @@ pub fn cmd_hscan(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
             novalues = true;
             i += 1;
         } else {
-            i += 1;
+            resp::write_error(out, "ERR syntax error");
+            return CmdResult::Written;
         }
     }
     let pat_str = pattern.map(|p| arg_str(p).to_string());

--- a/src/cmd/keys.rs
+++ b/src/cmd/keys.rs
@@ -6,12 +6,25 @@ use crate::store::{Store, StoreValue};
 
 use super::{arg_str, cmd_eq, parse_i64, parse_u64, CmdResult};
 
+const INTEGER_ERR: &str = "ERR value is not an integer or out of range";
+
+fn parse_usize_arg(arg: &[u8], out: &mut BytesMut) -> Option<usize> {
+    match parse_u64(arg).ok().and_then(|n| usize::try_from(n).ok()) {
+        Some(n) => Some(n),
+        None => {
+            resp::write_error(out, INTEGER_ERR);
+            None
+        }
+    }
+}
+
 pub fn cmd_del(args: &[&[u8]], store: &Store, out: &mut BytesMut, _now: Instant) -> CmdResult {
     if args.len() < 2 {
         resp::write_error(out, "ERR wrong number of arguments for 'del' command");
         return CmdResult::Written;
     }
-    resp::write_integer(out, store.del(&args[1..]));
+    let keys: Vec<&[u8]> = args[1..].to_vec();
+    resp::write_integer(out, store.del(&keys));
     CmdResult::Written
 }
 
@@ -29,7 +42,8 @@ pub fn cmd_exists(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, "ERR wrong number of arguments for 'exists' command");
         return CmdResult::Written;
     }
-    resp::write_integer(out, store.exists(&args[1..], now));
+    let keys: Vec<&[u8]> = args[1..].to_vec();
+    resp::write_integer(out, store.exists(&keys, now));
     CmdResult::Written
 }
 
@@ -48,7 +62,10 @@ pub fn cmd_scan(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
         resp::write_error(out, "ERR wrong number of arguments for 'scan' command");
         return CmdResult::Written;
     }
-    let cursor = parse_u64(args[1]).unwrap_or(0) as usize;
+    let cursor = match parse_usize_arg(args[1], out) {
+        Some(cursor) => cursor,
+        None => return CmdResult::Written,
+    };
     let mut pattern: &[u8] = b"*";
     let mut count = 10usize;
     let mut type_filter: Option<&str> = None;
@@ -58,13 +75,21 @@ pub fn cmd_scan(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
             pattern = args[i + 1];
             i += 2;
         } else if cmd_eq(args[i], b"COUNT") && i + 1 < args.len() {
-            count = parse_u64(args[i + 1]).unwrap_or(10) as usize;
+            count = match parse_usize_arg(args[i + 1], out) {
+                Some(count) if count > 0 => count,
+                Some(_) => {
+                    resp::write_error(out, INTEGER_ERR);
+                    return CmdResult::Written;
+                }
+                None => return CmdResult::Written,
+            };
             i += 2;
         } else if cmd_eq(args[i], b"TYPE") && i + 1 < args.len() {
             type_filter = Some(arg_str(args[i + 1]));
             i += 2;
         } else {
-            i += 1;
+            resp::write_error(out, "ERR syntax error");
+            return CmdResult::Written;
         }
     }
     let (next_cursor, all_keys) = store.scan(cursor, pattern, count, now);
@@ -99,6 +124,7 @@ pub fn cmd_rename(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, "ERR wrong number of arguments for 'rename' command");
         return CmdResult::Written;
     }
+    store.try_promote(args[2], now);
     match store.rename(args[1], args[2], now) {
         Ok(()) => resp::write_ok(out),
         Err(e) => resp::write_error(out, &e),
@@ -111,6 +137,7 @@ pub fn cmd_renamenx(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Inst
         resp::write_error(out, "ERR wrong number of arguments for 'renamenx' command");
         return CmdResult::Written;
     }
+    store.try_promote(args[2], now);
     if store.get(args[2], now).is_some() {
         resp::write_integer(out, 0);
     } else {
@@ -128,17 +155,7 @@ pub fn cmd_randomkey(
     out: &mut BytesMut,
     now: Instant,
 ) -> CmdResult {
-    let mut found = None;
-    for i in 0..store.shard_count() {
-        let shard = store.lock_read_shard(i);
-        if let Some((k, entry)) = shard.data.iter().next() {
-            if !entry.is_expired_at(now) {
-                found = Some(k.clone());
-                break;
-            }
-        }
-    }
-    match found {
+    match store.keys(b"*", now).into_iter().next() {
         Some(k) => resp::write_bulk(out, &k),
         None => resp::write_null(out),
     }
@@ -180,6 +197,7 @@ pub fn cmd_copy(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
             return CmdResult::Written;
         }
     }
+    store.try_promote(args[2], now);
     match store.copy_key(args[1], args[2], replace, now) {
         Ok(copied) => resp::write_integer(out, if copied { 1 } else { 0 }),
         Err(e) => resp::write_error(out, &e),

--- a/src/cmd/lists.rs
+++ b/src/cmd/lists.rs
@@ -7,6 +7,55 @@ use crate::store::{Store, StoreValue};
 
 use super::{arg_str, cmd_eq, parse_i64, parse_u64, CmdResult};
 
+const INTEGER_ERR: &str = "ERR value is not an integer or out of range";
+
+fn parse_i64_arg(arg: &[u8], out: &mut BytesMut) -> Option<i64> {
+    match parse_i64(arg) {
+        Ok(n) => Some(n),
+        Err(_) => {
+            resp::write_error(out, INTEGER_ERR);
+            None
+        }
+    }
+}
+
+fn parse_u64_arg(arg: &[u8], out: &mut BytesMut) -> Option<u64> {
+    match parse_u64(arg) {
+        Ok(n) => Some(n),
+        Err(_) => {
+            resp::write_error(out, INTEGER_ERR);
+            None
+        }
+    }
+}
+
+fn parse_list_side(arg: &[u8], out: &mut BytesMut) -> Option<bool> {
+    if cmd_eq(arg, b"LEFT") {
+        Some(true)
+    } else if cmd_eq(arg, b"RIGHT") {
+        Some(false)
+    } else {
+        resp::write_error(out, "ERR syntax error");
+        None
+    }
+}
+
+fn parse_block_timeout(arg: &[u8], out: &mut BytesMut) -> Option<Duration> {
+    match arg_str(arg).parse::<f64>() {
+        Ok(secs) if secs >= 0.0 && secs.is_finite() && secs <= u64::MAX as f64 => {
+            Some(if secs == 0.0 {
+                Duration::from_secs(300)
+            } else {
+                Duration::from_secs_f64(secs)
+            })
+        }
+        _ => {
+            resp::write_error(out, "ERR timeout is not a float or out of range");
+            None
+        }
+    }
+}
+
 pub fn cmd_lpush(
     args: &[&[u8]],
     store: &Store,
@@ -192,8 +241,14 @@ pub fn cmd_lrange(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, "ERR wrong number of arguments for 'lrange' command");
         return CmdResult::Written;
     }
-    let start = parse_i64(args[2]).unwrap_or(0);
-    let stop = parse_i64(args[3]).unwrap_or(-1);
+    let start = match parse_i64_arg(args[2], out) {
+        Some(n) => n,
+        None => return CmdResult::Written,
+    };
+    let stop = match parse_i64_arg(args[3], out) {
+        Some(n) => n,
+        None => return CmdResult::Written,
+    };
     match store.lrange(args[1], start, stop, now) {
         Ok(items) => resp::write_bulk_array_raw(out, &items),
         Err(e) => resp::write_error(out, &e),
@@ -206,7 +261,10 @@ pub fn cmd_lindex(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, "ERR wrong number of arguments for 'lindex' command");
         return CmdResult::Written;
     }
-    let index = parse_i64(args[2]).unwrap_or(0);
+    let index = match parse_i64_arg(args[2], out) {
+        Some(n) => n,
+        None => return CmdResult::Written,
+    };
     resp::write_optional_bulk_raw(out, &store.lindex(args[1], index, now));
     CmdResult::Written
 }
@@ -216,7 +274,11 @@ pub fn cmd_lset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
         resp::write_error(out, "ERR wrong number of arguments for 'lset' command");
         return CmdResult::Written;
     }
-    match store.lset(args[1], parse_i64(args[2]).unwrap_or(0), args[3], now) {
+    let index = match parse_i64_arg(args[2], out) {
+        Some(n) => n,
+        None => return CmdResult::Written,
+    };
+    match store.lset(args[1], index, args[3], now) {
         Ok(()) => resp::write_ok(out),
         Err(e) => resp::write_error(out, &e),
     }
@@ -228,7 +290,15 @@ pub fn cmd_linsert(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Insta
         resp::write_error(out, "ERR wrong number of arguments for 'linsert' command");
         return CmdResult::Written;
     }
-    match store.linsert(args[1], cmd_eq(args[2], b"BEFORE"), args[3], args[4], now) {
+    let before = if cmd_eq(args[2], b"BEFORE") {
+        true
+    } else if cmd_eq(args[2], b"AFTER") {
+        false
+    } else {
+        resp::write_error(out, "ERR syntax error");
+        return CmdResult::Written;
+    };
+    match store.linsert(args[1], before, args[3], args[4], now) {
         Ok(n) => resp::write_integer(out, n),
         Err(e) => resp::write_error(out, &e),
     }
@@ -240,7 +310,11 @@ pub fn cmd_lrem(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
         resp::write_error(out, "ERR wrong number of arguments for 'lrem' command");
         return CmdResult::Written;
     }
-    match store.lrem(args[1], parse_i64(args[2]).unwrap_or(0), args[3], now) {
+    let count = match parse_i64_arg(args[2], out) {
+        Some(n) => n,
+        None => return CmdResult::Written,
+    };
+    match store.lrem(args[1], count, args[3], now) {
         Ok(n) => resp::write_integer(out, n),
         Err(e) => resp::write_error(out, &e),
     }
@@ -254,8 +328,14 @@ pub fn cmd_ltrim(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
     }
     match store.ltrim(
         args[1],
-        parse_i64(args[2]).unwrap_or(0),
-        parse_i64(args[3]).unwrap_or(-1),
+        match parse_i64_arg(args[2], out) {
+            Some(n) => n,
+            None => return CmdResult::Written,
+        },
+        match parse_i64_arg(args[3], out) {
+            Some(n) => n,
+            None => return CmdResult::Written,
+        },
         now,
     ) {
         Ok(()) => resp::write_ok(out),
@@ -277,7 +357,10 @@ pub fn cmd_lpos(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
     let mut i = 3;
     while i < args.len() {
         if cmd_eq(args[i], b"RANK") && i + 1 < args.len() {
-            rank = parse_i64(args[i + 1]).unwrap_or(1);
+            rank = match parse_i64_arg(args[i + 1], out) {
+                Some(n) => n,
+                None => return CmdResult::Written,
+            };
             if rank == 0 {
                 resp::write_error(out, "ERR RANK can't be zero: use 1 to start from the first match, 2 from the second ... or use negative to start from the end of the list");
                 return CmdResult::Written;
@@ -288,14 +371,21 @@ pub fn cmd_lpos(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
             }
             i += 2;
         } else if cmd_eq(args[i], b"COUNT") && i + 1 < args.len() {
-            let c = parse_u64(args[i + 1]).unwrap_or(0) as usize;
+            let c = match parse_u64_arg(args[i + 1], out) {
+                Some(n) => n as usize,
+                None => return CmdResult::Written,
+            };
             count = Some(c);
             i += 2;
         } else if cmd_eq(args[i], b"MAXLEN") && i + 1 < args.len() {
-            maxlen = parse_u64(args[i + 1]).unwrap_or(0) as usize;
+            maxlen = match parse_u64_arg(args[i + 1], out) {
+                Some(n) => n as usize,
+                None => return CmdResult::Written,
+            };
             i += 2;
         } else {
-            i += 1;
+            resp::write_error(out, "ERR syntax error");
+            return CmdResult::Written;
         }
     }
     let idx = store.shard_for_key(key);
@@ -381,16 +471,15 @@ pub fn cmd_lmove(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         resp::write_error(out, "ERR wrong number of arguments for 'lmove' command");
         return CmdResult::Written;
     }
-    resp::write_optional_bulk_raw(
-        out,
-        &store.lmove(
-            args[1],
-            args[2],
-            cmd_eq(args[3], b"LEFT"),
-            cmd_eq(args[4], b"LEFT"),
-            now,
-        ),
-    );
+    let src_left = match parse_list_side(args[3], out) {
+        Some(side) => side,
+        None => return CmdResult::Written,
+    };
+    let dst_left = match parse_list_side(args[4], out) {
+        Some(side) => side,
+        None => return CmdResult::Written,
+    };
+    resp::write_optional_bulk_raw(out, &store.lmove(args[1], args[2], src_left, dst_left, now));
     CmdResult::Written
 }
 
@@ -415,7 +504,10 @@ pub fn cmd_blpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         return CmdResult::Written;
     }
     let pop_left = cmd_eq(args[0], b"BLPOP");
-    let timeout_secs: f64 = arg_str(args[args.len() - 1]).parse().unwrap_or(0.0);
+    let timeout = match parse_block_timeout(args[args.len() - 1], out) {
+        Some(timeout) => timeout,
+        None => return CmdResult::Written,
+    };
     let keys: Vec<String> = args[1..args.len() - 1]
         .iter()
         .map(|k| arg_str(k).to_string())
@@ -435,11 +527,6 @@ pub fn cmd_blpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         }
     }
 
-    let timeout = if timeout_secs <= 0.0 {
-        Duration::from_secs(300)
-    } else {
-        Duration::from_secs_f64(timeout_secs)
-    };
     CmdResult::BlockPop {
         keys,
         timeout,
@@ -454,20 +541,24 @@ pub fn cmd_blmove(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
     }
     let src = arg_str(args[1]).to_string();
     let dst = arg_str(args[2]).to_string();
-    let src_left = cmd_eq(args[3], b"LEFT");
-    let dst_left = cmd_eq(args[4], b"LEFT");
-    let timeout_secs: f64 = arg_str(args[5]).parse().unwrap_or(0.0);
+    let src_left = match parse_list_side(args[3], out) {
+        Some(side) => side,
+        None => return CmdResult::Written,
+    };
+    let dst_left = match parse_list_side(args[4], out) {
+        Some(side) => side,
+        None => return CmdResult::Written,
+    };
+    let timeout = match parse_block_timeout(args[5], out) {
+        Some(timeout) => timeout,
+        None => return CmdResult::Written,
+    };
 
     if let Some(v) = store.lmove(args[1], args[2], src_left, dst_left, now) {
         resp::write_bulk_raw(out, &v);
         return CmdResult::Written;
     }
 
-    let timeout = if timeout_secs <= 0.0 {
-        Duration::from_secs(300)
-    } else {
-        Duration::from_secs_f64(timeout_secs)
-    };
     CmdResult::BlockMove {
         src,
         dst,

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -126,7 +126,7 @@ pub fn cmd_time(_args: &[&[u8]], _store: &Store, out: &mut BytesMut, _now: Insta
 }
 
 pub fn cmd_save(_args: &[&[u8]], store: &Store, out: &mut BytesMut, _now: Instant) -> CmdResult {
-    match crate::snapshot::save(store) {
+    match crate::snapshot::save_and_truncate_wal_consistent(store) {
         Ok(n) => resp::write_simple(out, &format!("OK ({n} keys saved)")),
         Err(e) => resp::write_error(out, &format!("ERR snapshot failed: {e}")),
     }
@@ -134,7 +134,7 @@ pub fn cmd_save(_args: &[&[u8]], store: &Store, out: &mut BytesMut, _now: Instan
 }
 
 pub fn cmd_bgsave(_args: &[&[u8]], store: &Store, out: &mut BytesMut, _now: Instant) -> CmdResult {
-    match crate::snapshot::save(store) {
+    match crate::snapshot::save_and_truncate_wal_consistent(store) {
         Ok(_) => resp::write_simple(out, "Background saving started"),
         Err(e) => resp::write_error(out, &format!("ERR snapshot failed: {e}")),
     }

--- a/src/cmd/sets.rs
+++ b/src/cmd/sets.rs
@@ -6,6 +6,18 @@ use crate::store::Store;
 
 use super::{cmd_eq, parse_i64, parse_u64, CmdResult};
 
+const INTEGER_ERR: &str = "ERR value is not an integer or out of range";
+
+fn parse_usize_arg(arg: &[u8], out: &mut BytesMut) -> Option<usize> {
+    match parse_u64(arg).ok().and_then(|n| usize::try_from(n).ok()) {
+        Some(n) => Some(n),
+        None => {
+            resp::write_error(out, INTEGER_ERR);
+            None
+        }
+    }
+}
+
 pub fn cmd_sadd(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     if args.len() < 3 {
         resp::write_error(out, "ERR wrong number of arguments for 'sadd' command");
@@ -107,10 +119,9 @@ pub fn cmd_spop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
         }
         return CmdResult::Written;
     }
-    let count = if args.len() > 2 {
-        parse_u64(args[2]).unwrap_or(1) as usize
-    } else {
-        1
+    let count = match parse_usize_arg(args[2], out) {
+        Some(count) => count,
+        None => return CmdResult::Written,
     };
     match store.spop(args[1], count, now) {
         Ok(members) => {
@@ -138,7 +149,13 @@ pub fn cmd_srandmember(
         return CmdResult::Written;
     }
     let count = if args.len() > 2 {
-        parse_i64(args[2]).unwrap_or(1)
+        match parse_i64(args[2]) {
+            Ok(count) => count,
+            Err(_) => {
+                resp::write_error(out, INTEGER_ERR);
+                return CmdResult::Written;
+            }
+        }
     } else {
         0
     };
@@ -304,7 +321,10 @@ pub fn cmd_sintercard(
     let mut limit: usize = 0;
     let rest = &args[2 + numkeys..];
     if rest.len() == 2 && cmd_eq(rest[0], b"LIMIT") {
-        limit = parse_u64(rest[1]).unwrap_or(0) as usize;
+        limit = match parse_usize_arg(rest[1], out) {
+            Some(limit) => limit,
+            None => return CmdResult::Written,
+        };
     } else if !rest.is_empty() {
         resp::write_error(out, "ERR syntax error");
         return CmdResult::Written;

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -6,6 +6,18 @@ use crate::store::Store;
 
 use super::{arg_str, cmd_eq, parse_i64, CmdResult};
 
+const INTEGER_ERR: &str = "ERR value is not an integer or out of range";
+
+fn parse_i64_arg(arg: &[u8], out: &mut BytesMut) -> Option<i64> {
+    match parse_i64(arg) {
+        Ok(n) => Some(n),
+        Err(_) => {
+            resp::write_error(out, INTEGER_ERR);
+            None
+        }
+    }
+}
+
 pub fn cmd_sort(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     let readonly = cmd_eq(args[0], b"SORT_RO");
     if args.len() < 2 {
@@ -42,8 +54,22 @@ pub fn cmd_sort(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
                 resp::write_error(out, "ERR syntax error");
                 return CmdResult::Written;
             }
-            limit_offset = parse_i64(args[i + 1]).unwrap_or(0);
-            limit_count = parse_i64(args[i + 2]).unwrap_or(-1);
+            limit_offset = match parse_i64_arg(args[i + 1], out) {
+                Some(offset) if offset >= 0 => offset,
+                Some(_) => {
+                    resp::write_error(out, INTEGER_ERR);
+                    return CmdResult::Written;
+                }
+                None => return CmdResult::Written,
+            };
+            limit_count = match parse_i64_arg(args[i + 2], out) {
+                Some(count) if count >= 0 => count,
+                Some(_) => {
+                    resp::write_error(out, INTEGER_ERR);
+                    return CmdResult::Written;
+                }
+                None => return CmdResult::Written,
+            };
             i += 3;
         } else if cmd_eq(args[i], b"ASC") {
             desc = false;

--- a/src/cmd/sorted_sets.rs
+++ b/src/cmd/sorted_sets.rs
@@ -6,57 +6,148 @@ use crate::store::{Store, StoreValue};
 
 use super::{arg_str, cmd_eq, format_float, parse_i64, parse_u64, CmdResult};
 
-fn parse_score_bound(s: &str, is_max: bool) -> (f64, bool) {
-    if s == "-inf" || s == "-" {
-        (f64::NEG_INFINITY, false)
-    } else if s == "+inf" || s == "+" {
-        (f64::INFINITY, false)
-    } else if let Some(rest) = s.strip_prefix('(') {
-        (
-            rest.parse::<f64>().unwrap_or(if is_max {
-                f64::INFINITY
-            } else {
-                f64::NEG_INFINITY
-            }),
-            true,
-        )
-    } else {
-        (
-            s.parse::<f64>().unwrap_or(if is_max {
-                f64::INFINITY
-            } else {
-                f64::NEG_INFINITY
-            }),
-            false,
-        )
+const INTEGER_ERR: &str = "ERR value is not an integer or out of range";
+
+fn parse_i64_arg(arg: &[u8], out: &mut BytesMut) -> Option<i64> {
+    match parse_i64(arg) {
+        Ok(n) => Some(n),
+        Err(_) => {
+            resp::write_error(out, INTEGER_ERR);
+            None
+        }
     }
 }
 
-fn parse_zstore_options(args: &[&[u8]]) -> (Vec<f64>, &'static str) {
+fn parse_usize_arg(arg: &[u8], out: &mut BytesMut) -> Option<usize> {
+    match parse_u64(arg).ok().and_then(|n| usize::try_from(n).ok()) {
+        Some(n) => Some(n),
+        None => {
+            resp::write_error(out, INTEGER_ERR);
+            None
+        }
+    }
+}
+
+fn parse_score_bound(s: &str, _is_max: bool) -> Result<(f64, bool), String> {
+    if s == "-inf" || s == "-" {
+        Ok((f64::NEG_INFINITY, false))
+    } else if s == "+inf" || s == "+" {
+        Ok((f64::INFINITY, false))
+    } else if let Some(rest) = s.strip_prefix('(') {
+        match rest.parse::<f64>() {
+            Ok(v) if v.is_finite() => Ok((v, true)),
+            _ => Err("ERR min or max is not a float".to_string()),
+        }
+    } else {
+        match s.parse::<f64>() {
+            Ok(v) if v.is_finite() => Ok((v, false)),
+            _ => Err("ERR min or max is not a float".to_string()),
+        }
+    }
+}
+
+fn parse_limit(
+    args: &[&[u8]],
+    i: usize,
+    out: &mut BytesMut,
+) -> Option<(Option<usize>, Option<usize>)> {
+    if i + 2 >= args.len() {
+        resp::write_error(out, "ERR syntax error");
+        return None;
+    }
+    let offset = parse_usize_arg(args[i + 1], out)?;
+    let count = parse_usize_arg(args[i + 2], out)?;
+    Some((Some(offset), Some(count)))
+}
+
+fn glob_match(pattern: &str, s: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    let p: Vec<char> = pattern.chars().collect();
+    let s: Vec<char> = s.chars().collect();
+    do_glob(&p, &s, 0, 0)
+}
+
+fn do_glob(p: &[char], s: &[char], pi: usize, si: usize) -> bool {
+    if pi == p.len() && si == s.len() {
+        return true;
+    }
+    if pi == p.len() {
+        return false;
+    }
+    match p[pi] {
+        '*' => do_glob(p, s, pi + 1, si) || (si < s.len() && do_glob(p, s, pi, si + 1)),
+        '?' => si < s.len() && do_glob(p, s, pi + 1, si + 1),
+        c => si < s.len() && c == s[si] && do_glob(p, s, pi + 1, si + 1),
+    }
+}
+
+fn parse_zstore_numkeys(arg: &[u8], out: &mut BytesMut) -> Option<usize> {
+    let numkeys = match parse_u64(arg) {
+        Ok(n) => n,
+        Err(_) => {
+            resp::write_error(out, "ERR value is not an integer or out of range");
+            return None;
+        }
+    };
+    let numkeys = match usize::try_from(numkeys) {
+        Ok(n) if n > 0 => n,
+        _ => {
+            resp::write_error(
+                out,
+                "ERR at least 1 input key is needed for ZUNIONSTORE/ZINTERSTORE/ZDIFFSTORE",
+            );
+            return None;
+        }
+    };
+    Some(numkeys)
+}
+
+fn parse_zstore_options(
+    args: &[&[u8]],
+    numkeys: usize,
+    out: &mut BytesMut,
+) -> Option<(Vec<f64>, String)> {
     let mut weights = Vec::new();
-    let mut aggregate = "SUM";
+    let mut aggregate = "SUM".to_string();
     let mut i = 0;
     while i < args.len() {
         if cmd_eq(args[i], b"WEIGHTS") {
             i += 1;
-            while i < args.len() && !cmd_eq(args[i], b"AGGREGATE") {
-                weights.push(arg_str(args[i]).parse::<f64>().unwrap_or(1.0));
-                i += 1;
+            if i + numkeys > args.len() {
+                resp::write_error(out, "ERR syntax error");
+                return None;
             }
-        } else if cmd_eq(args[i], b"AGGREGATE") && i + 1 < args.len() {
-            aggregate = if cmd_eq(args[i + 1], b"MIN") {
-                "MIN"
-            } else if cmd_eq(args[i + 1], b"MAX") {
-                "MAX"
+            for weight_arg in &args[i..i + numkeys] {
+                match arg_str(weight_arg).parse::<f64>() {
+                    Ok(weight) if weight.is_finite() => weights.push(weight),
+                    _ => {
+                        resp::write_error(out, "ERR weight value is not a float");
+                        return None;
+                    }
+                }
+            }
+            i += numkeys;
+        } else if cmd_eq(args[i], b"AGGREGATE") {
+            if i + 1 >= args.len() {
+                resp::write_error(out, "ERR syntax error");
+                return None;
+            }
+            let mode = arg_str(args[i + 1]).to_uppercase();
+            if matches!(mode.as_str(), "SUM" | "MIN" | "MAX") {
+                aggregate = mode;
+                i += 2;
             } else {
-                "SUM"
-            };
-            i += 2;
+                resp::write_error(out, "ERR syntax error");
+                return None;
+            }
         } else {
-            i += 1;
+            resp::write_error(out, "ERR syntax error");
+            return None;
         }
     }
-    (weights, aggregate)
+    Some((weights, aggregate))
 }
 
 fn write_zset_result(out: &mut BytesMut, items: &[(String, f64)], with_scores: bool) {
@@ -77,24 +168,6 @@ fn write_zset_result(out: &mut BytesMut, items: &[(String, f64)], with_scores: b
 pub fn cmd_zadd(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     if args.len() < 4 {
         resp::write_error(out, "ERR wrong number of arguments for 'zadd' command");
-        return CmdResult::Written;
-    }
-    if args.len() == 4 {
-        let score: f64 = match arg_str(args[2]).parse::<f64>() {
-            Ok(s) if s.is_nan() => {
-                resp::write_error(out, "ERR value is not a valid float");
-                return CmdResult::Written;
-            }
-            Ok(s) => s,
-            Err(_) => {
-                resp::write_error(out, "ERR value is not a valid float");
-                return CmdResult::Written;
-            }
-        };
-        match store.zadd_single_default(args[1], args[3], score, now) {
-            Ok(count) => resp::write_integer(out, count),
-            Err(error) => resp::write_error(out, &error),
-        };
         return CmdResult::Written;
     }
     let mut nx = false;
@@ -130,7 +203,14 @@ pub fn cmd_zadd(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
         );
         return CmdResult::Written;
     }
-    if nx && (gt || lt) {
+    if nx && gt {
+        resp::write_error(
+            out,
+            "ERR GT, LT, and NX options at the same time are not compatible",
+        );
+        return CmdResult::Written;
+    }
+    if nx && lt {
         resp::write_error(
             out,
             "ERR GT, LT, and NX options at the same time are not compatible",
@@ -148,7 +228,7 @@ pub fn cmd_zadd(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
         resp::write_error(out, "ERR syntax error");
         return CmdResult::Written;
     }
-    let mut members = Vec::with_capacity((args.len() - i) / 2);
+    let mut members = Vec::new();
     while i + 1 < args.len() {
         let score: f64 = match arg_str(args[i]).parse::<f64>() {
             Ok(s) if s.is_nan() => {
@@ -192,7 +272,8 @@ pub fn cmd_zmscore(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Insta
         resp::write_error(out, "ERR wrong number of arguments for 'zmscore' command");
         return CmdResult::Written;
     }
-    match store.zmscore(args[1], &args[2..], now) {
+    let members: Vec<&[u8]> = args[2..].to_vec();
+    match store.zmscore(args[1], &members, now) {
         Ok(scores) => {
             resp::write_array_header(out, scores.len());
             for s in &scores {
@@ -238,7 +319,8 @@ pub fn cmd_zrem(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
         resp::write_error(out, "ERR wrong number of arguments for 'zrem' command");
         return CmdResult::Written;
     }
-    match store.zrem(args[1], &args[2..], now) {
+    let members: Vec<&[u8]> = args[2..].to_vec();
+    match store.zrem(args[1], &members, now) {
         Ok(n) => resp::write_integer(out, n),
         Err(e) => resp::write_error(out, &e),
     }
@@ -262,8 +344,20 @@ pub fn cmd_zcount(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, "ERR wrong number of arguments for 'zcount' command");
         return CmdResult::Written;
     }
-    let (min, min_ex) = parse_score_bound(arg_str(args[2]), false);
-    let (max, max_ex) = parse_score_bound(arg_str(args[3]), true);
+    let (min, min_ex) = match parse_score_bound(arg_str(args[2]), false) {
+        Ok(bound) => bound,
+        Err(e) => {
+            resp::write_error(out, &e);
+            return CmdResult::Written;
+        }
+    };
+    let (max, max_ex) = match parse_score_bound(arg_str(args[3]), true) {
+        Ok(bound) => bound,
+        Err(e) => {
+            resp::write_error(out, &e);
+            return CmdResult::Written;
+        }
+    };
     match store.zcount(args[1], min, max, min_ex, max_ex, now) {
         Ok(n) => resp::write_integer(out, n),
         Err(e) => resp::write_error(out, &e),
@@ -322,15 +416,6 @@ pub fn cmd_zrange(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, "ERR wrong number of arguments for 'zrange' command");
         return CmdResult::Written;
     }
-    if args.len() == 4 {
-        let start = parse_i64(args[2]).unwrap_or(0);
-        let stop = parse_i64(args[3]).unwrap_or(-1);
-        match store.zrange(args[1], start, stop, false, false, now) {
-            Ok(items) => write_zset_result(out, &items, false),
-            Err(e) => resp::write_error(out, &e),
-        }
-        return CmdResult::Written;
-    }
     let mut reverse = false;
     let mut with_scores = false;
     let mut byscore = false;
@@ -351,17 +436,34 @@ pub fn cmd_zrange(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         } else if cmd_eq(args[i], b"BYLEX") {
             bylex = true;
             i += 1;
-        } else if cmd_eq(args[i], b"LIMIT") && i + 2 < args.len() {
-            offset = Some(parse_u64(args[i + 1]).unwrap_or(0) as usize);
-            count = Some(parse_u64(args[i + 2]).unwrap_or(0) as usize);
+        } else if cmd_eq(args[i], b"LIMIT") {
+            let parsed = match parse_limit(args, i, out) {
+                Some(parsed) => parsed,
+                None => return CmdResult::Written,
+            };
+            offset = parsed.0;
+            count = parsed.1;
             i += 3;
         } else {
-            i += 1;
+            resp::write_error(out, "ERR syntax error");
+            return CmdResult::Written;
         }
     }
     if byscore {
-        let (min, min_ex) = parse_score_bound(arg_str(args[2]), false);
-        let (max, max_ex) = parse_score_bound(arg_str(args[3]), true);
+        let (min, min_ex) = match parse_score_bound(arg_str(args[2]), false) {
+            Ok(bound) => bound,
+            Err(e) => {
+                resp::write_error(out, &e);
+                return CmdResult::Written;
+            }
+        };
+        let (max, max_ex) = match parse_score_bound(arg_str(args[3]), true) {
+            Ok(bound) => bound,
+            Err(e) => {
+                resp::write_error(out, &e);
+                return CmdResult::Written;
+            }
+        };
         match store.zrangebyscore(
             args[1],
             min,
@@ -396,8 +498,14 @@ pub fn cmd_zrange(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
             Err(e) => resp::write_error(out, &e),
         }
     } else {
-        let start = parse_i64(args[2]).unwrap_or(0);
-        let stop = parse_i64(args[3]).unwrap_or(-1);
+        let start = match parse_i64_arg(args[2], out) {
+            Some(start) => start,
+            None => return CmdResult::Written,
+        };
+        let stop = match parse_i64_arg(args[3], out) {
+            Some(stop) => stop,
+            None => return CmdResult::Written,
+        };
         match store.zrange(args[1], start, stop, reverse, with_scores, now) {
             Ok(items) => write_zset_result(out, &items, with_scores),
             Err(e) => resp::write_error(out, &e),
@@ -411,9 +519,24 @@ pub fn cmd_zrevrange(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Ins
         resp::write_error(out, "ERR wrong number of arguments for 'zrevrange' command");
         return CmdResult::Written;
     }
-    let with_scores = args.len() > 4 && cmd_eq(args[4], b"WITHSCORES");
-    let start = parse_i64(args[2]).unwrap_or(0);
-    let stop = parse_i64(args[3]).unwrap_or(-1);
+    let with_scores = if args.len() > 4 {
+        if args.len() == 5 && cmd_eq(args[4], b"WITHSCORES") {
+            true
+        } else {
+            resp::write_error(out, "ERR syntax error");
+            return CmdResult::Written;
+        }
+    } else {
+        false
+    };
+    let start = match parse_i64_arg(args[2], out) {
+        Some(start) => start,
+        None => return CmdResult::Written,
+    };
+    let stop = match parse_i64_arg(args[3], out) {
+        Some(stop) => stop,
+        None => return CmdResult::Written,
+    };
     match store.zrange(args[1], start, stop, true, with_scores, now) {
         Ok(items) => write_zset_result(out, &items, with_scores),
         Err(e) => resp::write_error(out, &e),
@@ -434,8 +557,20 @@ pub fn cmd_zrangebyscore(
         );
         return CmdResult::Written;
     }
-    let (min, min_ex) = parse_score_bound(arg_str(args[2]), false);
-    let (max, max_ex) = parse_score_bound(arg_str(args[3]), true);
+    let (min, min_ex) = match parse_score_bound(arg_str(args[2]), false) {
+        Ok(bound) => bound,
+        Err(e) => {
+            resp::write_error(out, &e);
+            return CmdResult::Written;
+        }
+    };
+    let (max, max_ex) = match parse_score_bound(arg_str(args[3]), true) {
+        Ok(bound) => bound,
+        Err(e) => {
+            resp::write_error(out, &e);
+            return CmdResult::Written;
+        }
+    };
     let mut with_scores = false;
     let mut offset: Option<usize> = None;
     let mut count: Option<usize> = None;
@@ -444,12 +579,17 @@ pub fn cmd_zrangebyscore(
         if cmd_eq(args[i], b"WITHSCORES") {
             with_scores = true;
             i += 1;
-        } else if cmd_eq(args[i], b"LIMIT") && i + 2 < args.len() {
-            offset = Some(parse_u64(args[i + 1]).unwrap_or(0) as usize);
-            count = Some(parse_u64(args[i + 2]).unwrap_or(0) as usize);
+        } else if cmd_eq(args[i], b"LIMIT") {
+            let parsed = match parse_limit(args, i, out) {
+                Some(parsed) => parsed,
+                None => return CmdResult::Written,
+            };
+            offset = parsed.0;
+            count = parsed.1;
             i += 3;
         } else {
-            i += 1;
+            resp::write_error(out, "ERR syntax error");
+            return CmdResult::Written;
         }
     }
     match store.zrangebyscore(
@@ -483,8 +623,20 @@ pub fn cmd_zrevrangebyscore(
         );
         return CmdResult::Written;
     }
-    let (max, max_ex) = parse_score_bound(arg_str(args[2]), true);
-    let (min, min_ex) = parse_score_bound(arg_str(args[3]), false);
+    let (max, max_ex) = match parse_score_bound(arg_str(args[2]), true) {
+        Ok(bound) => bound,
+        Err(e) => {
+            resp::write_error(out, &e);
+            return CmdResult::Written;
+        }
+    };
+    let (min, min_ex) = match parse_score_bound(arg_str(args[3]), false) {
+        Ok(bound) => bound,
+        Err(e) => {
+            resp::write_error(out, &e);
+            return CmdResult::Written;
+        }
+    };
     let mut with_scores = false;
     let mut offset: Option<usize> = None;
     let mut count: Option<usize> = None;
@@ -493,12 +645,17 @@ pub fn cmd_zrevrangebyscore(
         if cmd_eq(args[i], b"WITHSCORES") {
             with_scores = true;
             i += 1;
-        } else if cmd_eq(args[i], b"LIMIT") && i + 2 < args.len() {
-            offset = Some(parse_u64(args[i + 1]).unwrap_or(0) as usize);
-            count = Some(parse_u64(args[i + 2]).unwrap_or(0) as usize);
+        } else if cmd_eq(args[i], b"LIMIT") {
+            let parsed = match parse_limit(args, i, out) {
+                Some(parsed) => parsed,
+                None => return CmdResult::Written,
+            };
+            offset = parsed.0;
+            count = parsed.1;
             i += 3;
         } else {
-            i += 1;
+            resp::write_error(out, "ERR syntax error");
+            return CmdResult::Written;
         }
     }
     match store.zrangebyscore(
@@ -536,12 +693,17 @@ pub fn cmd_zrangebylex(
     let mut count: Option<usize> = None;
     let mut i = 4;
     while i < args.len() {
-        if cmd_eq(args[i], b"LIMIT") && i + 2 < args.len() {
-            offset = Some(parse_u64(args[i + 1]).unwrap_or(0) as usize);
-            count = Some(parse_u64(args[i + 2]).unwrap_or(0) as usize);
+        if cmd_eq(args[i], b"LIMIT") {
+            let parsed = match parse_limit(args, i, out) {
+                Some(parsed) => parsed,
+                None => return CmdResult::Written,
+            };
+            offset = parsed.0;
+            count = parsed.1;
             i += 3;
         } else {
-            i += 1;
+            resp::write_error(out, "ERR syntax error");
+            return CmdResult::Written;
         }
     }
     match store.zrangebylex(
@@ -581,12 +743,17 @@ pub fn cmd_zrevrangebylex(
     let mut count: Option<usize> = None;
     let mut i = 4;
     while i < args.len() {
-        if cmd_eq(args[i], b"LIMIT") && i + 2 < args.len() {
-            offset = Some(parse_u64(args[i + 1]).unwrap_or(0) as usize);
-            count = Some(parse_u64(args[i + 2]).unwrap_or(0) as usize);
+        if cmd_eq(args[i], b"LIMIT") {
+            let parsed = match parse_limit(args, i, out) {
+                Some(parsed) => parsed,
+                None => return CmdResult::Written,
+            };
+            offset = parsed.0;
+            count = parsed.1;
             i += 3;
         } else {
-            i += 1;
+            resp::write_error(out, "ERR syntax error");
+            return CmdResult::Written;
         }
     }
     match store.zrangebylex(
@@ -615,7 +782,10 @@ pub fn cmd_zpopmin(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Insta
         return CmdResult::Written;
     }
     let count = if args.len() > 2 {
-        parse_u64(args[2]).unwrap_or(1) as usize
+        match parse_usize_arg(args[2], out) {
+            Some(count) => count,
+            None => return CmdResult::Written,
+        }
     } else {
         1
     };
@@ -648,7 +818,10 @@ pub fn cmd_zpopmax(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Insta
         return CmdResult::Written;
     }
     let count = if args.len() > 2 {
-        parse_u64(args[2]).unwrap_or(1) as usize
+        match parse_usize_arg(args[2], out) {
+            Some(count) => count,
+            None => return CmdResult::Written,
+        }
     } else {
         1
     };
@@ -688,13 +861,23 @@ pub fn cmd_zunionstore(
         );
         return CmdResult::Written;
     }
-    let numkeys = parse_u64(args[2]).unwrap_or(0) as usize;
+    let numkeys = match parse_zstore_numkeys(args[2], out) {
+        Some(numkeys) => numkeys,
+        None => return CmdResult::Written,
+    };
     if 3 + numkeys > args.len() {
         resp::write_error(out, "ERR syntax error");
         return CmdResult::Written;
     }
-    let (weights, aggregate) = parse_zstore_options(&args[3 + numkeys..]);
-    match store.zunionstore(args[1], &args[3..3 + numkeys], &weights, aggregate, now) {
+    let keys: Vec<&[u8]> = args[3..3 + numkeys].to_vec();
+    for key in &keys {
+        store.try_promote(key, now);
+    }
+    let (weights, aggregate) = match parse_zstore_options(&args[3 + numkeys..], numkeys, out) {
+        Some(parsed) => parsed,
+        None => return CmdResult::Written,
+    };
+    match store.zunionstore(args[1], &keys, &weights, &aggregate, now) {
         Ok(n) => resp::write_integer(out, n),
         Err(e) => resp::write_error(out, &e),
     }
@@ -714,13 +897,23 @@ pub fn cmd_zinterstore(
         );
         return CmdResult::Written;
     }
-    let numkeys = parse_u64(args[2]).unwrap_or(0) as usize;
+    let numkeys = match parse_zstore_numkeys(args[2], out) {
+        Some(numkeys) => numkeys,
+        None => return CmdResult::Written,
+    };
     if 3 + numkeys > args.len() {
         resp::write_error(out, "ERR syntax error");
         return CmdResult::Written;
     }
-    let (weights, aggregate) = parse_zstore_options(&args[3 + numkeys..]);
-    match store.zinterstore(args[1], &args[3..3 + numkeys], &weights, aggregate, now) {
+    let keys: Vec<&[u8]> = args[3..3 + numkeys].to_vec();
+    for key in &keys {
+        store.try_promote(key, now);
+    }
+    let (weights, aggregate) = match parse_zstore_options(&args[3 + numkeys..], numkeys, out) {
+        Some(parsed) => parsed,
+        None => return CmdResult::Written,
+    };
+    match store.zinterstore(args[1], &keys, &weights, &aggregate, now) {
         Ok(n) => resp::write_integer(out, n),
         Err(e) => resp::write_error(out, &e),
     }
@@ -740,12 +933,23 @@ pub fn cmd_zdiffstore(
         );
         return CmdResult::Written;
     }
-    let numkeys = parse_u64(args[2]).unwrap_or(0) as usize;
+    let numkeys = match parse_zstore_numkeys(args[2], out) {
+        Some(numkeys) => numkeys,
+        None => return CmdResult::Written,
+    };
     if 3 + numkeys > args.len() {
         resp::write_error(out, "ERR syntax error");
         return CmdResult::Written;
     }
-    match store.zdiffstore(args[1], &args[3..3 + numkeys], now) {
+    if 3 + numkeys != args.len() {
+        resp::write_error(out, "ERR syntax error");
+        return CmdResult::Written;
+    }
+    let keys: Vec<&[u8]> = args[3..3 + numkeys].to_vec();
+    for key in &keys {
+        store.try_promote(key, now);
+    }
+    match store.zdiffstore(args[1], &keys, now) {
         Ok(n) => resp::write_integer(out, n),
         Err(e) => resp::write_error(out, &e),
     }
@@ -765,8 +969,14 @@ pub fn cmd_zremrangebyrank(
         );
         return CmdResult::Written;
     }
-    let start = parse_i64(args[2]).unwrap_or(0);
-    let stop = parse_i64(args[3]).unwrap_or(-1);
+    let start = match parse_i64_arg(args[2], out) {
+        Some(start) => start,
+        None => return CmdResult::Written,
+    };
+    let stop = match parse_i64_arg(args[3], out) {
+        Some(stop) => stop,
+        None => return CmdResult::Written,
+    };
     match store.zrange(args[1], start, stop, false, true, now) {
         Ok(items) => {
             let members: Vec<&[u8]> = items.iter().map(|(m, _)| m.as_bytes()).collect();
@@ -793,8 +1003,20 @@ pub fn cmd_zremrangebyscore(
         );
         return CmdResult::Written;
     }
-    let (min, min_ex) = parse_score_bound(arg_str(args[2]), false);
-    let (max, max_ex) = parse_score_bound(arg_str(args[3]), true);
+    let (min, min_ex) = match parse_score_bound(arg_str(args[2]), false) {
+        Ok(bound) => bound,
+        Err(e) => {
+            resp::write_error(out, &e);
+            return CmdResult::Written;
+        }
+    };
+    let (max, max_ex) = match parse_score_bound(arg_str(args[3]), true) {
+        Ok(bound) => bound,
+        Err(e) => {
+            resp::write_error(out, &e);
+            return CmdResult::Written;
+        }
+    };
     match store.zrangebyscore(
         args[1], min, max, min_ex, max_ex, false, None, None, true, now,
     ) {
@@ -849,15 +1071,30 @@ pub fn cmd_zscan(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         resp::write_error(out, "ERR wrong number of arguments for 'zscan' command");
         return CmdResult::Written;
     }
-    let cursor = parse_u64(args[2]).unwrap_or(0) as usize;
+    let cursor = match parse_usize_arg(args[2], out) {
+        Some(cursor) => cursor,
+        None => return CmdResult::Written,
+    };
     let mut count = 10usize;
+    let mut pattern: Option<&str> = None;
     let mut i = 3;
     while i < args.len() {
         if cmd_eq(args[i], b"COUNT") && i + 1 < args.len() {
-            count = parse_u64(args[i + 1]).unwrap_or(10) as usize;
+            count = match parse_usize_arg(args[i + 1], out) {
+                Some(count) if count > 0 => count,
+                Some(_) => {
+                    resp::write_error(out, INTEGER_ERR);
+                    return CmdResult::Written;
+                }
+                None => return CmdResult::Written,
+            };
+            i += 2;
+        } else if cmd_eq(args[i], b"MATCH") && i + 1 < args.len() {
+            pattern = Some(arg_str(args[i + 1]));
             i += 2;
         } else {
-            i += 1;
+            resp::write_error(out, "ERR syntax error");
+            return CmdResult::Written;
         }
     }
     let idx = store.shard_for_key(args[1]);
@@ -866,7 +1103,10 @@ pub fn cmd_zscan(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
     match shard.data.get(ks) {
         Some(entry) if !entry.is_expired_at(now) => {
             if let StoreValue::SortedSet(tree, _) = &entry.value {
-                let all: Vec<_> = tree.keys().collect();
+                let all: Vec<_> = tree
+                    .keys()
+                    .filter(|(_, member)| pattern.is_none_or(|p| glob_match(p, member)))
+                    .collect();
                 let s = cursor.min(all.len());
                 let e = (s + count).min(all.len());
                 let next = if e >= all.len() { 0 } else { e };
@@ -906,8 +1146,9 @@ pub fn cmd_bzpopmin(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Inst
     }
     let is_min = cmd_eq(args[0], b"BZPOPMIN");
     let timeout_secs: f64 = arg_str(args[args.len() - 1]).parse().unwrap_or(0.0);
-    let keys = &args[1..args.len() - 1];
-    for key in keys {
+    let keys: Vec<&[u8]> = args[1..args.len() - 1].to_vec();
+
+    for key in &keys {
         let result = if is_min {
             store.zpopmin(key, 1, now)
         } else {

--- a/src/cmd/strings.rs
+++ b/src/cmd/strings.rs
@@ -6,6 +6,45 @@ use crate::store::{Entry, Store, StoreValue};
 
 use super::{arg_str, cmd_eq, parse_i64, parse_u64, CmdResult};
 
+const INTEGER_ERR: &str = "ERR value is not an integer or out of range";
+
+fn parse_i64_arg(arg: &[u8], out: &mut BytesMut) -> Option<i64> {
+    match parse_i64(arg) {
+        Ok(n) => Some(n),
+        Err(_) => {
+            resp::write_error(out, INTEGER_ERR);
+            None
+        }
+    }
+}
+
+fn parse_u64_arg(arg: &[u8], out: &mut BytesMut) -> Option<u64> {
+    match parse_u64(arg) {
+        Ok(n) => Some(n),
+        Err(_) => {
+            resp::write_error(out, INTEGER_ERR);
+            None
+        }
+    }
+}
+
+fn parse_positive_ttl(arg: &[u8], command: &str, out: &mut BytesMut) -> Option<u64> {
+    match parse_u64(arg) {
+        Ok(0) => {
+            resp::write_error(
+                out,
+                &format!("ERR invalid expire time in '{command}' command"),
+            );
+            None
+        }
+        Ok(n) => Some(n),
+        Err(_) => {
+            resp::write_error(out, INTEGER_ERR);
+            None
+        }
+    }
+}
+
 pub fn cmd_set(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     if args.len() < 3 {
         resp::write_error(out, "ERR wrong number of arguments for 'set' command");
@@ -21,21 +60,36 @@ pub fn cmd_set(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
                 resp::write_error(out, "ERR syntax error");
                 return CmdResult::Written;
             }
-            match parse_u64(args[i + 1]) {
-                Ok(s) => ttl = Some(Duration::from_secs(s)),
-                Err(_) => {
-                    resp::write_error(out, "ERR value is not an integer or out of range");
-                    return CmdResult::Written;
-                }
-            }
+            let secs = match parse_positive_ttl(args[i + 1], "set", out) {
+                Some(secs) => secs,
+                None => return CmdResult::Written,
+            };
+            ttl = Some(Duration::from_secs(secs));
             i += 2;
         } else if cmd_eq(args[i], b"PX") {
             if i + 1 >= args.len() {
                 resp::write_error(out, "ERR syntax error");
                 return CmdResult::Written;
             }
+            let ms = match parse_positive_ttl(args[i + 1], "set", out) {
+                Some(ms) => ms,
+                None => return CmdResult::Written,
+            };
+            ttl = Some(Duration::from_millis(ms));
+            i += 2;
+        } else if cmd_eq(args[i], b"PXAT") {
+            if i + 1 >= args.len() {
+                resp::write_error(out, "ERR syntax error");
+                return CmdResult::Written;
+            }
             match parse_u64(args[i + 1]) {
-                Ok(ms) => ttl = Some(Duration::from_millis(ms)),
+                Ok(expiry_ms) => {
+                    let now_ms = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_millis() as u64;
+                    ttl = Some(Duration::from_millis(expiry_ms.saturating_sub(now_ms)));
+                }
                 Err(_) => {
                     resp::write_error(out, "ERR value is not an integer or out of range");
                     return CmdResult::Written;
@@ -117,13 +171,12 @@ pub fn cmd_psetex(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, "ERR wrong number of arguments for 'psetex' command");
         return CmdResult::Written;
     }
-    match parse_u64(args[2]) {
-        Ok(ms) => {
-            store.set(args[1], args[3], Some(Duration::from_millis(ms)), now);
-            resp::write_ok(out);
-        }
-        Err(_) => resp::write_error(out, "ERR value is not an integer or out of range"),
-    }
+    let ms = match parse_positive_ttl(args[2], "psetex", out) {
+        Some(ms) => ms,
+        None => return CmdResult::Written,
+    };
+    store.set(args[1], args[3], Some(Duration::from_millis(ms)), now);
+    resp::write_ok(out);
     CmdResult::Written
 }
 
@@ -132,9 +185,7 @@ pub fn cmd_get(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
         resp::write_error(out, "ERR wrong number of arguments for 'get' command");
         return CmdResult::Written;
     }
-    let idx = store.shard_for_key(args[1]);
-    let shard = store.lock_read_shard(idx);
-    Store::get_and_write(&shard.data, args[1], now, out);
+    resp::write_optional_bulk_raw(out, &store.get(args[1], now));
     CmdResult::Written
 }
 
@@ -163,36 +214,72 @@ pub fn cmd_getex(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
     }
     let mut ttl = None;
     let mut persist = false;
+    let mut option_seen = false;
     let mut i = 2;
     while i < args.len() {
         if cmd_eq(args[i], b"EX") && i + 1 < args.len() {
-            ttl = Some(Duration::from_secs(parse_u64(args[i + 1]).unwrap_or(0)));
+            if option_seen {
+                resp::write_error(out, "ERR syntax error");
+                return CmdResult::Written;
+            }
+            let secs = match parse_positive_ttl(args[i + 1], "getex", out) {
+                Some(secs) => secs,
+                None => return CmdResult::Written,
+            };
+            ttl = Some(Duration::from_secs(secs));
+            option_seen = true;
             i += 2;
         } else if cmd_eq(args[i], b"PX") && i + 1 < args.len() {
-            ttl = Some(Duration::from_millis(parse_u64(args[i + 1]).unwrap_or(0)));
+            if option_seen {
+                resp::write_error(out, "ERR syntax error");
+                return CmdResult::Written;
+            }
+            let ms = match parse_positive_ttl(args[i + 1], "getex", out) {
+                Some(ms) => ms,
+                None => return CmdResult::Written,
+            };
+            ttl = Some(Duration::from_millis(ms));
+            option_seen = true;
             i += 2;
         } else if cmd_eq(args[i], b"EXAT") && i + 1 < args.len() {
-            let ts = parse_u64(args[i + 1]).unwrap_or(0);
+            if option_seen {
+                resp::write_error(out, "ERR syntax error");
+                return CmdResult::Written;
+            }
+            let ts = match parse_u64_arg(args[i + 1], out) {
+                Some(ts) => ts,
+                None => return CmdResult::Written,
+            };
             let now_ts = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
-            if ts > now_ts {
-                ttl = Some(Duration::from_secs(ts - now_ts));
-            }
+            ttl = Some(Duration::from_secs(ts.saturating_sub(now_ts)));
+            option_seen = true;
             i += 2;
         } else if cmd_eq(args[i], b"PXAT") && i + 1 < args.len() {
-            let ts = parse_u64(args[i + 1]).unwrap_or(0);
+            if option_seen {
+                resp::write_error(out, "ERR syntax error");
+                return CmdResult::Written;
+            }
+            let ts = match parse_u64_arg(args[i + 1], out) {
+                Some(ts) => ts,
+                None => return CmdResult::Written,
+            };
             let now_ts = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_millis() as u64;
-            if ts > now_ts {
-                ttl = Some(Duration::from_millis(ts - now_ts));
-            }
+            ttl = Some(Duration::from_millis(ts.saturating_sub(now_ts)));
+            option_seen = true;
             i += 2;
         } else if cmd_eq(args[i], b"PERSIST") {
+            if option_seen {
+                resp::write_error(out, "ERR syntax error");
+                return CmdResult::Written;
+            }
             persist = true;
+            option_seen = true;
             i += 1;
         } else {
             resp::write_error(out, "ERR syntax error");
@@ -208,12 +295,15 @@ pub fn cmd_getrange(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Inst
         resp::write_error(out, "ERR wrong number of arguments for 'getrange' command");
         return CmdResult::Written;
     }
-    let val = store.getrange(
-        args[1],
-        parse_i64(args[2]).unwrap_or(0),
-        parse_i64(args[3]).unwrap_or(-1),
-        now,
-    );
+    let start = match parse_i64_arg(args[2], out) {
+        Some(n) => n,
+        None => return CmdResult::Written,
+    };
+    let end = match parse_i64_arg(args[3], out) {
+        Some(n) => n,
+        None => return CmdResult::Written,
+    };
+    let val = store.getrange(args[1], start, end, now);
     resp::write_bulk_raw(out, &val);
     CmdResult::Written
 }
@@ -223,15 +313,22 @@ pub fn cmd_setrange(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Inst
         resp::write_error(out, "ERR wrong number of arguments for 'setrange' command");
         return CmdResult::Written;
     }
-    resp::write_integer(
-        out,
-        store.setrange(
-            args[1],
-            parse_u64(args[2]).unwrap_or(0) as usize,
-            args[3],
-            now,
-        ),
-    );
+    let offset_u64 = match parse_u64_arg(args[2], out) {
+        Some(n) => n,
+        None => return CmdResult::Written,
+    };
+    let offset = match usize::try_from(offset_u64) {
+        Ok(offset) => offset,
+        Err(_) => {
+            resp::write_error(out, INTEGER_ERR);
+            return CmdResult::Written;
+        }
+    };
+    if offset.checked_add(args[3].len()).is_none() {
+        resp::write_error(out, INTEGER_ERR);
+        return CmdResult::Written;
+    }
+    resp::write_integer(out, store.setrange(args[1], offset, args[3], now));
     CmdResult::Written
 }
 
@@ -242,9 +339,7 @@ pub fn cmd_mget(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
     }
     resp::write_array_header(out, args.len() - 1);
     for key in &args[1..] {
-        let idx = store.shard_for_key(key);
-        let shard = store.lock_read_shard(idx);
-        Store::get_and_write(&shard.data, key, now, out);
+        resp::write_optional_bulk_raw(out, &store.get(key, now));
     }
     CmdResult::Written
 }
@@ -254,7 +349,11 @@ pub fn cmd_mset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
         resp::write_error(out, "ERR wrong number of arguments for 'mset' command");
         return CmdResult::Written;
     }
-    store.mset_from_args(&args[1..], now);
+    let mut i = 1;
+    while i < args.len() {
+        store.set(args[i], args[i + 1], None, now);
+        i += 2;
+    }
     resp::write_ok(out);
     CmdResult::Written
 }
@@ -374,8 +473,8 @@ pub fn cmd_incrbyfloat(
     let mut shard = store.lock_write_shard(idx);
     let ks = arg_str(args[1]);
     let current: f64 = match shard.data.get(ks) {
-        Some(e) if !e.is_expired_at(now) => match e.value.string_bytes() {
-            Some(s) => {
+        Some(e) if !e.is_expired_at(now) => match &e.value {
+            StoreValue::Str(s) => {
                 let ss = std::str::from_utf8(s).unwrap_or("");
                 if ss.contains(' ') {
                     resp::write_error(out, "ERR value is not a valid float");
@@ -393,7 +492,7 @@ pub fn cmd_incrbyfloat(
                     }
                 }
             }
-            None => {
+            _ => {
                 resp::write_error(
                     out,
                     "WRONGTYPE Operation against a key holding the wrong kind of value",
@@ -415,7 +514,7 @@ pub fn cmd_incrbyfloat(
     };
     let expires_at = shard.data.get(ks).and_then(|e| e.expires_at);
     shard.version += 1;
-    let old = shard.data.insert(
+    shard.data.insert(
         ks.to_string(),
         Entry {
             value: StoreValue::Str(Bytes::from(new_str.clone())),
@@ -423,9 +522,6 @@ pub fn cmd_incrbyfloat(
             lru_clock: store.lru_clock(),
         },
     );
-    if old.is_none() {
-        store.key_added();
-    }
     resp::write_bulk(out, &new_str);
     CmdResult::Written
 }

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -5,7 +5,7 @@
 //! Evicted entries are written to the DiskShard instead of being deleted.
 //! On read miss, entries are transparently promoted back to memory.
 
-use crate::store::{DumpEntry, DumpValue};
+use crate::store::{DumpEntry, DumpValue, StreamGroupDump};
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
@@ -797,6 +797,63 @@ fn read_string(r: &mut impl Read) -> io::Result<String> {
     String::from_utf8(raw).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
+fn write_stream_groups(w: &mut impl Write, groups: &[StreamGroupDump]) -> io::Result<()> {
+    write_u32(w, groups.len() as u32)?;
+    for (name, last_delivered_id, consumers, pending) in groups {
+        write_bytes(w, name.as_bytes())?;
+        write_bytes(w, last_delivered_id.as_bytes())?;
+        write_u32(w, consumers.len() as u32)?;
+        for (consumer, pending_ids) in consumers {
+            write_bytes(w, consumer.as_bytes())?;
+            write_u32(w, pending_ids.len() as u32)?;
+            for id in pending_ids {
+                write_bytes(w, id.as_bytes())?;
+            }
+        }
+        write_u32(w, pending.len() as u32)?;
+        for (id, consumer, delivery_count) in pending {
+            write_bytes(w, id.as_bytes())?;
+            write_bytes(w, consumer.as_bytes())?;
+            write_u32(w, (*delivery_count).min(u32::MAX as u64) as u32)?;
+        }
+    }
+    Ok(())
+}
+
+fn read_stream_groups(r: &mut impl Read) -> io::Result<Vec<StreamGroupDump>> {
+    let group_count = match read_u32(r) {
+        Ok(count) => count as usize,
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+    let mut groups = Vec::with_capacity(group_count);
+    for _ in 0..group_count {
+        let name = read_string(r)?;
+        let last_delivered_id = read_string(r)?;
+        let consumer_count = read_u32(r)? as usize;
+        let mut consumers = Vec::with_capacity(consumer_count);
+        for _ in 0..consumer_count {
+            let consumer = read_string(r)?;
+            let pending_count = read_u32(r)? as usize;
+            let mut pending_ids = Vec::with_capacity(pending_count);
+            for _ in 0..pending_count {
+                pending_ids.push(read_string(r)?);
+            }
+            consumers.push((consumer, pending_ids));
+        }
+        let pending_count = read_u32(r)? as usize;
+        let mut pending = Vec::with_capacity(pending_count);
+        for _ in 0..pending_count {
+            let id = read_string(r)?;
+            let consumer = read_string(r)?;
+            let delivery_count = read_u32(r)? as u64;
+            pending.push((id, consumer, delivery_count));
+        }
+        groups.push((name, last_delivered_id, consumers, pending));
+    }
+    Ok(groups)
+}
+
 pub fn write_single_entry(w: &mut impl Write, entry: &DumpEntry) -> io::Result<()> {
     let type_byte: u8 = match &entry.value {
         DumpValue::Str(_) => b'S',
@@ -842,7 +899,7 @@ pub fn write_single_entry(w: &mut impl Write, entry: &DumpEntry) -> io::Result<(
                 write_f64(w, *score)?;
             }
         }
-        DumpValue::Stream(stream_entries, last_id) => {
+        DumpValue::Stream(stream_entries, last_id, groups) => {
             write_bytes(w, last_id.as_bytes())?;
             write_u32(w, stream_entries.len() as u32)?;
             for (id, fields) in stream_entries {
@@ -853,6 +910,7 @@ pub fn write_single_entry(w: &mut impl Write, entry: &DumpEntry) -> io::Result<(
                     write_bytes(w, v)?;
                 }
             }
+            write_stream_groups(w, groups)?;
         }
         DumpValue::Vector(data, metadata) => {
             write_u32(w, data.len() as u32)?;
@@ -948,7 +1006,8 @@ pub fn read_single_entry(r: &mut impl Read) -> io::Result<(String, DumpValue, i6
                 }
                 entries.push((id, fields));
             }
-            DumpValue::Stream(entries, last_id)
+            let groups = read_stream_groups(r)?;
+            DumpValue::Stream(entries, last_id, groups)
         }
         b'V' => {
             let dims = read_u32(r)? as usize;
@@ -1349,7 +1408,11 @@ mod tests {
                 ),
                 arb_string(),
             )
-                .prop_map(|(entries, last_id)| DumpValue::Stream(entries, last_id)),
+                .prop_map(|(entries, last_id)| DumpValue::Stream(
+                    entries,
+                    last_id,
+                    Vec::new()
+                )),
         ]
     }
 
@@ -1369,7 +1432,9 @@ mod tests {
             (DumpValue::Hash(a), DumpValue::Hash(b)) => a == b,
             (DumpValue::Set(a), DumpValue::Set(b)) => a == b,
             (DumpValue::SortedSet(a), DumpValue::SortedSet(b)) => a == b,
-            (DumpValue::Stream(ae, al), DumpValue::Stream(be, bl)) => ae == be && al == bl,
+            (DumpValue::Stream(ae, al, ag), DumpValue::Stream(be, bl, bg)) => {
+                ae == be && al == bl && ag == bg
+            }
             (DumpValue::Vector(ad, am), DumpValue::Vector(bd, bm)) => ad == bd && am == bm,
             (DumpValue::HyperLogLog(ar, _), DumpValue::HyperLogLog(br, _)) => ar == br,
             (DumpValue::TimeSeries(as_, ar, al), DumpValue::TimeSeries(bs, br, bl)) => {

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -211,6 +211,10 @@ impl Wal {
                 Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
                 Err(_) => break,
             };
+            let payload_start = self.file.stream_position()?;
+            if payload_start + frame_len as u64 > file_len {
+                break;
+            }
 
             let mut buf = vec![0u8; frame_len];
             match self.file.read_exact(&mut buf) {
@@ -243,7 +247,7 @@ impl Wal {
                 Err(_) => continue,
             };
 
-            let mut args = Vec::with_capacity(argc);
+            let mut args = Vec::new();
             let mut valid = true;
             for _ in 0..argc {
                 match read_bytes(&mut cursor) {
@@ -667,6 +671,10 @@ impl DiskShard {
                     Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
                     Err(e) => return Err(e),
                 };
+                let payload_start = self.data_file.stream_position()?;
+                if payload_start + entry_len as u64 > file_len {
+                    break;
+                }
 
                 let mut entry_data = vec![0u8; entry_len];
                 match self.data_file.read_exact(&mut entry_data) {
@@ -787,8 +795,15 @@ fn read_f64(r: &mut impl Read) -> io::Result<f64> {
 
 fn read_bytes(r: &mut impl Read) -> io::Result<Vec<u8>> {
     let len = read_u32(r)? as usize;
-    let mut buf = vec![0u8; len];
-    r.read_exact(&mut buf)?;
+    let mut limited = r.take(len as u64);
+    let mut buf = Vec::new();
+    limited.read_to_end(&mut buf)?;
+    if buf.len() != len {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "short length-prefixed byte string",
+        ));
+    }
     Ok(buf)
 }
 
@@ -957,7 +972,7 @@ pub fn read_single_entry(r: &mut impl Read) -> io::Result<(String, DumpValue, i6
         b'S' => DumpValue::Str(read_bytes(r)?),
         b'L' => {
             let len = read_u32(r)? as usize;
-            let mut items = Vec::with_capacity(len);
+            let mut items = Vec::new();
             for _ in 0..len {
                 items.push(read_bytes(r)?);
             }
@@ -965,7 +980,7 @@ pub fn read_single_entry(r: &mut impl Read) -> io::Result<(String, DumpValue, i6
         }
         b'H' => {
             let len = read_u32(r)? as usize;
-            let mut pairs = Vec::with_capacity(len);
+            let mut pairs = Vec::new();
             for _ in 0..len {
                 let k = read_string(r)?;
                 let v = read_bytes(r)?;
@@ -975,7 +990,7 @@ pub fn read_single_entry(r: &mut impl Read) -> io::Result<(String, DumpValue, i6
         }
         b'T' => {
             let len = read_u32(r)? as usize;
-            let mut members = Vec::with_capacity(len);
+            let mut members = Vec::new();
             for _ in 0..len {
                 members.push(read_string(r)?);
             }
@@ -983,7 +998,7 @@ pub fn read_single_entry(r: &mut impl Read) -> io::Result<(String, DumpValue, i6
         }
         b'Z' => {
             let len = read_u32(r)? as usize;
-            let mut members = Vec::with_capacity(len);
+            let mut members = Vec::new();
             for _ in 0..len {
                 let m = read_string(r)?;
                 let s = read_f64(r)?;
@@ -994,11 +1009,11 @@ pub fn read_single_entry(r: &mut impl Read) -> io::Result<(String, DumpValue, i6
         b'X' => {
             let last_id = read_string(r)?;
             let entry_count = read_u32(r)? as usize;
-            let mut entries = Vec::with_capacity(entry_count);
+            let mut entries = Vec::new();
             for _ in 0..entry_count {
                 let id = read_string(r)?;
                 let field_count = read_u32(r)? as usize;
-                let mut fields = Vec::with_capacity(field_count);
+                let mut fields = Vec::new();
                 for _ in 0..field_count {
                     let k = read_string(r)?;
                     let v = read_bytes(r)?;
@@ -1011,7 +1026,7 @@ pub fn read_single_entry(r: &mut impl Read) -> io::Result<(String, DumpValue, i6
         }
         b'V' => {
             let dims = read_u32(r)? as usize;
-            let mut data = Vec::with_capacity(dims);
+            let mut data = Vec::new();
             for _ in 0..dims {
                 let mut buf = [0u8; 4];
                 r.read_exact(&mut buf)?;
@@ -1035,7 +1050,7 @@ pub fn read_single_entry(r: &mut impl Read) -> io::Result<(String, DumpValue, i6
         }
         b'I' => {
             let sample_count = read_u32(r)? as usize;
-            let mut samples = Vec::with_capacity(sample_count);
+            let mut samples = Vec::new();
             for _ in 0..sample_count {
                 let ts = read_i64(r)?;
                 let val = read_f64(r)?;
@@ -1043,7 +1058,7 @@ pub fn read_single_entry(r: &mut impl Read) -> io::Result<(String, DumpValue, i6
             }
             let retention = read_i64(r)? as u64;
             let label_count = read_u32(r)? as usize;
-            let mut labels = Vec::with_capacity(label_count);
+            let mut labels = Vec::new();
             for _ in 0..label_count {
                 let k = read_string(r)?;
                 let v = read_string(r)?;

--- a/src/eviction.rs
+++ b/src/eviction.rs
@@ -1,4 +1,4 @@
-use crate::store::Store;
+use crate::store::{Store, StoreValue};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EvictionPolicy {
@@ -136,6 +136,9 @@ fn evict_lru(store: &Store, sample_size: usize, volatile_only: bool) -> bool {
             if volatile_only && entry.expires_at.is_none() {
                 continue;
             }
+            if matches!(entry.value, StoreValue::Vector(_)) {
+                continue;
+            }
             sampled += 1;
             if entry.lru_clock < best_clock {
                 best_clock = entry.lru_clock;
@@ -150,8 +153,7 @@ fn evict_lru(store: &Store, sample_size: usize, volatile_only: bool) -> bool {
     }
 
     if let Some(key) = best_key {
-        store.evict_key(best_shard, &key);
-        true
+        store.evict_key(best_shard, &key)
     } else {
         false
     }
@@ -173,16 +175,19 @@ fn evict_random(store: &Store, volatile_only: bool) -> bool {
             shard
                 .data
                 .iter()
-                .find(|(_, e)| e.expires_at.is_some())
+                .find(|(_, e)| e.expires_at.is_some() && !matches!(e.value, StoreValue::Vector(_)))
                 .map(|(k, _)| k.clone())
         } else {
-            shard.data.keys().next().cloned()
+            shard
+                .data
+                .iter()
+                .find(|(_, e)| !matches!(e.value, StoreValue::Vector(_)))
+                .map(|(k, _)| k.clone())
         };
         drop(shard);
 
         if let Some(k) = key {
-            store.evict_key(shard_idx, &k);
-            return true;
+            return store.evict_key(shard_idx, &k);
         }
     }
     false

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,15 +1,24 @@
+use base64::Engine;
 use bytes::BytesMut;
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpSocket;
-use tokio::sync::oneshot;
+use tokio::sync::{broadcast, oneshot};
+use tokio_tungstenite::tungstenite::protocol::Role;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+use tokio_tungstenite::WebSocketStream;
 
 use crate::lua;
 use crate::pubsub::Broker;
 use crate::store::Store;
 use crate::tables::SharedSchemaCache;
 use crate::{CommandExecutor, CommandSession, LuxError};
+
+const WEBSOCKET_ACCEPT_GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 /// Constant-time byte comparison to prevent timing attacks on auth tokens.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
@@ -174,6 +183,12 @@ async fn handle_request(
         return Ok(true);
     }
 
+    let (path, query_string) = match full_path.split_once('?') {
+        Some((p, q)) => (p.to_string(), q.to_string()),
+        None => (full_path.clone(), String::new()),
+    };
+    let params = parse_query_string(&query_string);
+
     let password = &store.config().password;
     if !password.is_empty() {
         let auth = headers
@@ -182,18 +197,30 @@ async fn handle_request(
             .map(|(_, v)| v.as_str())
             .unwrap_or("");
 
-        let token = auth.strip_prefix("Bearer ").unwrap_or("");
-        if !constant_time_eq(token.as_bytes(), password.as_bytes()) {
+        let bearer = auth.strip_prefix("Bearer ").unwrap_or("");
+        let query_token = if path == "/live" {
+            get_param(&params, "token").unwrap_or("")
+        } else {
+            ""
+        };
+        if !constant_time_eq(bearer.as_bytes(), password.as_bytes())
+            && !constant_time_eq(query_token.as_bytes(), password.as_bytes())
+        {
             let body = r#"{"error":"unauthorized"}"#;
             return send_json(socket, 401, "Unauthorized", body).await;
         }
     }
 
-    let (path, query_string) = match full_path.split_once('?') {
-        Some((p, q)) => (p.to_string(), q.to_string()),
-        None => (full_path.clone(), String::new()),
-    };
-    let params = parse_query_string(&query_string);
+    if method == "GET" && path == "/live" {
+        return handle_live_upgrade(
+            socket,
+            &headers,
+            store.clone(),
+            broker.clone(),
+            cache.clone(),
+        )
+        .await;
+    }
 
     // Fast path: table GET queries stream JSON directly without building
     // the full response string in memory first.
@@ -518,6 +545,809 @@ fn get_param<'a>(params: &'a [(String, String)], key: &str) -> Option<&'a str> {
         .iter()
         .find(|(k, _)| k == key)
         .map(|(_, v)| v.as_str())
+}
+
+#[derive(Clone)]
+struct LiveTableSpec {
+    table: String,
+    select: String,
+    where_conditions: Vec<(String, String, Value)>,
+    order_by: Option<(String, String)>,
+    limit: Option<usize>,
+    offset: Option<usize>,
+}
+
+#[derive(Clone)]
+struct LiveVectorNearSpec {
+    vector: Vec<f32>,
+    k: usize,
+    threshold: Option<f32>,
+    filter: Option<(String, String)>,
+}
+
+struct LiveQueryState {
+    query: Value,
+    rows: HashMap<String, Value>,
+}
+
+enum LiveSubscription {
+    Key {
+        pattern: String,
+        receivers: Vec<broadcast::Receiver<crate::pubsub::Message>>,
+    },
+    Channel {
+        channel: String,
+        receiver: broadcast::Receiver<crate::pubsub::Message>,
+    },
+    PubSubPattern {
+        pattern: String,
+        receiver: broadcast::Receiver<crate::pubsub::Message>,
+    },
+    Table {
+        spec: LiveTableSpec,
+        state: LiveQueryState,
+        receivers: Vec<broadcast::Receiver<crate::pubsub::Message>>,
+    },
+    VectorNear {
+        spec: LiveVectorNearSpec,
+        state: LiveQueryState,
+        receiver: broadcast::Receiver<crate::pubsub::Message>,
+    },
+}
+
+enum LiveBrokerEvent {
+    Key {
+        pattern: String,
+        key: String,
+        operation: String,
+    },
+    Message {
+        channel: String,
+        message: String,
+        pattern: Option<String>,
+    },
+}
+
+fn live_broker_event_from_message(message: &crate::pubsub::Message) -> Option<LiveBrokerEvent> {
+    match message.kind {
+        crate::pubsub::MessageKind::PubSub => Some(LiveBrokerEvent::Message {
+            channel: message.channel.clone(),
+            message: String::from_utf8_lossy(&message.payload).to_string(),
+            pattern: message.pattern.clone(),
+        }),
+        crate::pubsub::MessageKind::KeyEvent => Some(LiveBrokerEvent::Key {
+            pattern: message.pattern.clone()?,
+            key: message.channel.clone(),
+            operation: String::from_utf8_lossy(&message.payload).to_string(),
+        }),
+    }
+}
+
+async fn handle_live_upgrade(
+    socket: &mut tokio::net::TcpStream,
+    headers: &[(String, String)],
+    store: Arc<Store>,
+    broker: Broker,
+    cache: SharedSchemaCache,
+) -> std::io::Result<bool> {
+    let Some(key) = header_value(headers, "sec-websocket-key") else {
+        return send_json(
+            socket,
+            400,
+            "Bad Request",
+            r#"{"error":"missing websocket key"}"#,
+        )
+        .await;
+    };
+
+    let accept = websocket_accept_key(key);
+    let response = format!(
+        "HTTP/1.1 101 Switching Protocols\r\n\
+         Upgrade: websocket\r\n\
+         Connection: Upgrade\r\n\
+         Sec-WebSocket-Accept: {accept}\r\n\r\n"
+    );
+    socket.write_all(response.as_bytes()).await?;
+
+    let ws = WebSocketStream::from_raw_socket(socket, Role::Server, None).await;
+    run_live_socket(ws, store, broker, cache).await?;
+    Ok(false)
+}
+
+async fn run_live_socket<S>(
+    mut ws: WebSocketStream<S>,
+    store: Arc<Store>,
+    broker: Broker,
+    cache: SharedSchemaCache,
+) -> std::io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut subscriptions: HashMap<String, LiveSubscription> = HashMap::new();
+    let mut tick = tokio::time::interval(std::time::Duration::from_millis(1));
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            incoming = ws.next() => {
+                let Some(incoming) = incoming else { break; };
+                let incoming = match incoming {
+                    Ok(message) => message,
+                    Err(_) => break,
+                };
+                match incoming {
+                    WsMessage::Text(text) => {
+                        handle_live_client_message(
+                            &mut ws,
+                            &mut subscriptions,
+                            &broker,
+                            &store,
+                            &cache,
+                            &text,
+                        ).await?;
+                    }
+                    WsMessage::Close(_) => break,
+                    WsMessage::Ping(payload) => {
+                        let _ = ws.send(WsMessage::Pong(payload)).await;
+                    }
+                    _ => {}
+                }
+            }
+            _ = tick.tick() => {
+                drain_live_subscription_events(&mut ws, &mut subscriptions, &store, &cache).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_live_client_message<S>(
+    ws: &mut WebSocketStream<S>,
+    subscriptions: &mut HashMap<String, LiveSubscription>,
+    broker: &Broker,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+    text: &str,
+) -> std::io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let parsed: Value = match serde_json::from_str(text) {
+        Ok(value) => value,
+        Err(_) => {
+            send_live_json(ws, json!({"type":"live.error","error":{"code":"INVALID_JSON","message":"invalid json"}})).await?;
+            return Ok(());
+        }
+    };
+
+    let msg_type = parsed.get("type").and_then(Value::as_str).unwrap_or("");
+    let id = parsed
+        .get("id")
+        .or_else(|| parsed.get("subscriptionId"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    if msg_type == "live.unsubscribe" {
+        if !id.is_empty() {
+            stop_live_subscription(broker, subscriptions, &id);
+            send_live_json(ws, json!({"type":"live.unsubscribed","id":id})).await?;
+        }
+        return Ok(());
+    }
+
+    if msg_type != "live.subscribe" {
+        send_live_json(ws, json!({"type":"live.error","id":id,"error":{"code":"UNKNOWN_MESSAGE","message":"unknown live message type"}})).await?;
+        return Ok(());
+    }
+
+    if id.is_empty() {
+        send_live_json(ws, json!({"type":"live.error","error":{"code":"MISSING_ID","message":"live.subscribe requires id"}})).await?;
+        return Ok(());
+    }
+
+    stop_live_subscription(broker, subscriptions, &id);
+    let Some(spec) = parsed.get("spec").or_else(|| parsed.get("query")) else {
+        send_live_json(ws, json!({"type":"live.error","id":id,"error":{"code":"MISSING_SPEC","message":"live.subscribe requires spec"}})).await?;
+        return Ok(());
+    };
+
+    match build_live_subscription(spec, broker, store, cache).await {
+        Ok((subscription, initial_events)) => {
+            subscriptions.insert(id.clone(), subscription);
+            send_live_json(ws, json!({"type":"live.subscribed","id":id})).await?;
+            for event in initial_events {
+                send_live_json(ws, json!({"type":"live.event","id":id,"event":event})).await?;
+            }
+        }
+        Err(error) => {
+            send_live_json(ws, json!({"type":"live.error","id":id,"error":error})).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn build_live_subscription(
+    spec: &Value,
+    broker: &Broker,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> Result<(LiveSubscription, Vec<Value>), Value> {
+    if let Some(pattern) = spec
+        .as_str()
+        .or_else(|| spec.get("key").and_then(Value::as_str))
+    {
+        return Ok((
+            LiveSubscription::Key {
+                pattern: pattern.to_string(),
+                receivers: vec![broker.ksubscribe(pattern)],
+            },
+            Vec::new(),
+        ));
+    }
+
+    let kind = spec.get("kind").and_then(Value::as_str).unwrap_or("");
+    if kind == "key" {
+        let pattern = required_str(spec, "pattern")?;
+        return Ok((
+            LiveSubscription::Key {
+                pattern: pattern.to_string(),
+                receivers: vec![broker.ksubscribe(pattern)],
+            },
+            Vec::new(),
+        ));
+    }
+    if kind == "channel" || spec.get("channel").is_some() {
+        let channel = required_str(spec, "channel")?;
+        return Ok((
+            LiveSubscription::Channel {
+                channel: channel.to_string(),
+                receiver: broker.subscribe(channel),
+            },
+            Vec::new(),
+        ));
+    }
+    if kind == "pubsubPattern" || spec.get("pubsubPattern").is_some() {
+        let pattern = spec
+            .get("pattern")
+            .or_else(|| spec.get("pubsubPattern"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                live_error(
+                    "INVALID_SPEC",
+                    "pubsubPattern subscription requires pattern",
+                )
+            })?;
+        return Ok((
+            LiveSubscription::PubSubPattern {
+                pattern: pattern.to_string(),
+                receiver: broker.psubscribe(pattern),
+            },
+            Vec::new(),
+        ));
+    }
+    if kind == "table" || spec.get("table").is_some() {
+        let table_spec = parse_live_table_spec(spec)?;
+        let receivers = vec![
+            broker.ksubscribe(&table_spec.table),
+            broker.ksubscribe(&format!("_t:{}:row:*", table_spec.table)),
+        ];
+        let rows = fetch_live_table_rows(store, cache, &table_spec)?;
+        let query = json!({"type":"table","table":table_spec.table});
+        let state = LiveQueryState {
+            query: query.clone(),
+            rows: index_live_rows(rows.clone()),
+        };
+        return Ok((
+            LiveSubscription::Table {
+                spec: table_spec,
+                state,
+                receivers,
+            },
+            vec![json!({"kind":"snapshot","scope":"query","query":query,"rows":rows})],
+        ));
+    }
+    if kind == "vector.near" {
+        let vector_spec = parse_live_vector_near_spec(spec)?;
+        let rows = fetch_live_vector_rows(store, &vector_spec);
+        let query =
+            json!({"type":"vector.near","k":vector_spec.k,"threshold":vector_spec.threshold});
+        let state = LiveQueryState {
+            query: query.clone(),
+            rows: index_live_rows(rows.clone()),
+        };
+        return Ok((
+            LiveSubscription::VectorNear {
+                spec: vector_spec,
+                state,
+                receiver: broker.ksubscribe("*"),
+            },
+            vec![json!({"kind":"snapshot","scope":"query","query":query,"rows":rows})],
+        ));
+    }
+
+    Err(live_error(
+        "INVALID_SPEC",
+        "unsupported live subscription spec",
+    ))
+}
+
+async fn drain_live_subscription_events<S>(
+    ws: &mut WebSocketStream<S>,
+    subscriptions: &mut HashMap<String, LiveSubscription>,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> std::io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut events = Vec::new();
+    for subscription in subscriptions.values_mut() {
+        match subscription {
+            LiveSubscription::Key { receivers, .. } | LiveSubscription::Table { receivers, .. } => {
+                for receiver in receivers {
+                    drain_receiver(receiver, &mut events);
+                }
+            }
+            LiveSubscription::Channel { receiver, .. }
+            | LiveSubscription::PubSubPattern { receiver, .. }
+            | LiveSubscription::VectorNear { receiver, .. } => {
+                drain_receiver(receiver, &mut events)
+            }
+        }
+    }
+
+    for event in events {
+        dispatch_live_broker_event(ws, subscriptions, store, cache, event).await?;
+    }
+    Ok(())
+}
+
+fn drain_receiver(
+    receiver: &mut broadcast::Receiver<crate::pubsub::Message>,
+    events: &mut Vec<LiveBrokerEvent>,
+) {
+    loop {
+        match receiver.try_recv() {
+            Ok(message) => {
+                if let Some(event) = live_broker_event_from_message(&message) {
+                    events.push(event);
+                }
+            }
+            Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
+            Err(broadcast::error::TryRecvError::Empty)
+            | Err(broadcast::error::TryRecvError::Closed) => break,
+        }
+    }
+}
+
+async fn dispatch_live_broker_event<S>(
+    ws: &mut WebSocketStream<S>,
+    subscriptions: &mut HashMap<String, LiveSubscription>,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+    event: LiveBrokerEvent,
+) -> std::io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut outgoing = Vec::new();
+    for (id, subscription) in subscriptions.iter_mut() {
+        match (subscription, &event) {
+            (
+                LiveSubscription::Key { pattern, .. },
+                LiveBrokerEvent::Key {
+                    pattern: event_pattern,
+                    key,
+                    operation,
+                },
+            ) if pattern == event_pattern => {
+                outgoing.push((id.clone(), live_key_event(event_pattern, key, operation)));
+            }
+            (
+                LiveSubscription::Channel { channel, .. },
+                LiveBrokerEvent::Message {
+                    channel: event_channel,
+                    message,
+                    pattern: None,
+                },
+            ) if channel == event_channel => {
+                outgoing.push((id.clone(), json!({"kind":"pubsub.message","scope":"pubsub","channel":event_channel,"message":message})));
+            }
+            (
+                LiveSubscription::PubSubPattern { pattern, .. },
+                LiveBrokerEvent::Message {
+                    channel,
+                    message,
+                    pattern: Some(event_pattern),
+                },
+            ) if pattern == event_pattern => {
+                outgoing.push((id.clone(), json!({"kind":"pubsub.message","scope":"pubsub","pattern":event_pattern,"channel":channel,"message":message})));
+            }
+            (
+                LiveSubscription::Table { spec, state, .. },
+                LiveBrokerEvent::Key { key, operation, .. },
+            ) => {
+                if key == &spec.table || key.starts_with(&format!("_t:{}:row:", spec.table)) {
+                    let next = fetch_live_table_rows(store, cache, spec).unwrap_or_default();
+                    outgoing.extend(diff_live_query(
+                        id,
+                        state,
+                        next,
+                        Some(json!({"kind":table_cause_kind(operation),"table":spec.table,"operation":operation,"raw":{"pattern":format!("_t:{}:row:*", spec.table),"key":key,"operation":operation}})),
+                    ));
+                }
+            }
+            (
+                LiveSubscription::VectorNear { spec, state, .. },
+                LiveBrokerEvent::Key { key, operation, .. },
+            ) => {
+                let next = fetch_live_vector_rows(store, spec);
+                outgoing.extend(diff_live_query(
+                    id,
+                    state,
+                    next,
+                    Some(json!({"kind":vector_cause_kind(operation),"key":key,"operation":operation})),
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    for (id, event) in outgoing {
+        send_live_json(ws, json!({"type":"live.event","id":id,"event":event})).await?;
+    }
+    Ok(())
+}
+
+fn stop_live_subscription(
+    broker: &Broker,
+    subscriptions: &mut HashMap<String, LiveSubscription>,
+    id: &str,
+) {
+    let Some(subscription) = subscriptions.remove(id) else {
+        return;
+    };
+    match subscription {
+        LiveSubscription::Key { pattern, .. } => broker.kunsub(&pattern),
+        LiveSubscription::Channel { channel, .. } => broker.unsubscribe_channel(&channel),
+        LiveSubscription::PubSubPattern { pattern, .. } => broker.punsubscribe_pattern(&pattern),
+        LiveSubscription::Table { spec, .. } => {
+            broker.kunsub(&spec.table);
+            broker.kunsub(&format!("_t:{}:row:*", spec.table));
+        }
+        LiveSubscription::VectorNear { .. } => broker.kunsub("*"),
+    }
+}
+
+fn diff_live_query(
+    id: &str,
+    state: &mut LiveQueryState,
+    next_rows: Vec<Value>,
+    cause: Option<Value>,
+) -> Vec<(String, Value)> {
+    let previous = std::mem::take(&mut state.rows);
+    let next = index_live_rows(next_rows);
+    let mut events = Vec::new();
+
+    for (pk, row) in &next {
+        match previous.get(pk) {
+            None => events.push((
+                id.to_string(),
+                json!({"kind":"insert","scope":"query","query":state.query,"pk":pk,"row":row,"previous":null,"cause":cause}),
+            )),
+            Some(before) if row_fingerprint(before) != row_fingerprint(row) => events.push((
+                id.to_string(),
+                json!({"kind":"update","scope":"query","query":state.query,"pk":pk,"row":row,"previous":before,"changed":changed_json_fields(before, row),"cause":cause}),
+            )),
+            _ => {}
+        }
+    }
+
+    for (pk, before) in &previous {
+        if !next.contains_key(pk) {
+            events.push((
+                id.to_string(),
+                json!({"kind":"delete","scope":"query","query":state.query,"pk":pk,"row":null,"previous":before,"cause":cause}),
+            ));
+        }
+    }
+
+    state.rows = next;
+    events
+}
+
+fn parse_live_table_spec(spec: &Value) -> Result<LiveTableSpec, Value> {
+    let table = required_str(spec, "table")?.to_string();
+    let select = spec
+        .get("select")
+        .and_then(Value::as_str)
+        .unwrap_or("*")
+        .to_string();
+    let mut where_conditions = Vec::new();
+    if let Some(where_value) = spec.get("where") {
+        if let Some(array) = where_value.as_array() {
+            for condition in array {
+                where_conditions.push((
+                    required_str(condition, "field")?.to_string(),
+                    condition
+                        .get("op")
+                        .and_then(Value::as_str)
+                        .unwrap_or("=")
+                        .to_string(),
+                    condition.get("value").cloned().unwrap_or(Value::Null),
+                ));
+            }
+        } else if let Some(object) = where_value.as_object() {
+            for (field, value) in object {
+                where_conditions.push((field.clone(), "=".to_string(), value.clone()));
+            }
+        }
+    }
+    let order_by = spec.get("orderBy").and_then(|value| {
+        Some((
+            value.get("field")?.as_str()?.to_string(),
+            value
+                .get("dir")
+                .and_then(Value::as_str)
+                .unwrap_or("asc")
+                .to_string(),
+        ))
+    });
+    let limit = spec
+        .get("limit")
+        .and_then(Value::as_u64)
+        .map(|n| n as usize);
+    let offset = spec
+        .get("offset")
+        .and_then(Value::as_u64)
+        .map(|n| n as usize);
+    Ok(LiveTableSpec {
+        table,
+        select,
+        where_conditions,
+        order_by,
+        limit,
+        offset,
+    })
+}
+
+fn fetch_live_table_rows(
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+    spec: &LiveTableSpec,
+) -> Result<Vec<Value>, Value> {
+    let mut tokens = vec![spec.select.clone(), "FROM".to_string(), spec.table.clone()];
+    if !spec.where_conditions.is_empty() {
+        tokens.push("WHERE".to_string());
+        for (index, (field, op, value)) in spec.where_conditions.iter().enumerate() {
+            if index > 0 {
+                tokens.push("AND".to_string());
+            }
+            tokens.push(field.clone());
+            tokens.push(op.clone());
+            tokens.push(live_value_to_token(value));
+        }
+    }
+    if let Some((field, dir)) = &spec.order_by {
+        tokens.push("ORDER".to_string());
+        tokens.push("BY".to_string());
+        tokens.push(field.clone());
+        tokens.push(dir.to_ascii_uppercase());
+    }
+    if let Some(limit) = spec.limit {
+        tokens.push("LIMIT".to_string());
+        tokens.push(limit.to_string());
+    }
+    if let Some(offset) = spec.offset {
+        tokens.push("OFFSET".to_string());
+        tokens.push(offset.to_string());
+    }
+    let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
+    let plan = crate::tables::parse_select(&refs).map_err(|e| live_error("TSELECT_ERROR", &e))?;
+    match crate::tables::table_select(store, cache, &plan, Instant::now())
+        .map_err(|e| live_error("TSELECT_ERROR", &e))?
+    {
+        crate::tables::SelectResult::Rows(rows) => {
+            Ok(rows.into_iter().map(table_row_to_value).collect())
+        }
+        crate::tables::SelectResult::Aggregate(row) => Ok(vec![table_row_to_value(row)]),
+    }
+}
+
+fn parse_live_vector_near_spec(spec: &Value) -> Result<LiveVectorNearSpec, Value> {
+    let vector = spec
+        .get("vector")
+        .and_then(Value::as_array)
+        .ok_or_else(|| live_error("INVALID_SPEC", "vector.near requires vector"))?
+        .iter()
+        .map(|value| value.as_f64().map(|n| n as f32))
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| live_error("INVALID_SPEC", "vector must contain numbers"))?;
+    let k = spec.get("k").and_then(Value::as_u64).unwrap_or(10) as usize;
+    let threshold = spec
+        .get("threshold")
+        .and_then(Value::as_f64)
+        .map(|n| n as f32);
+    let filter = spec.get("filter").and_then(|value| {
+        Some((
+            value.get("key")?.as_str()?.to_string(),
+            value.get("value")?.as_str()?.to_string(),
+        ))
+    });
+    Ok(LiveVectorNearSpec {
+        vector,
+        k,
+        threshold,
+        filter,
+    })
+}
+
+fn fetch_live_vector_rows(store: &Arc<Store>, spec: &LiveVectorNearSpec) -> Vec<Value> {
+    let (filter_key, filter_value) = spec
+        .filter
+        .as_ref()
+        .map(|(key, value)| (Some(key.as_str()), Some(value.as_str())))
+        .unwrap_or((None, None));
+    store
+        .vsearch(
+            &spec.vector,
+            spec.k,
+            filter_key,
+            filter_value,
+            Instant::now(),
+        )
+        .into_iter()
+        .filter(|(_, similarity, _)| {
+            spec.threshold
+                .is_none_or(|threshold| *similarity >= threshold)
+        })
+        .map(|(key, similarity, metadata)| {
+            let metadata = metadata
+                .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+                .unwrap_or(Value::Null);
+            json!({"id":key,"key":key,"similarity":similarity,"metadata":metadata})
+        })
+        .collect()
+}
+
+async fn send_live_json<S>(ws: &mut WebSocketStream<S>, value: Value) -> std::io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    ws.send(WsMessage::Text(value.to_string()))
+        .await
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::BrokenPipe, e))
+}
+
+fn header_value<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
+}
+
+fn websocket_accept_key(key: &str) -> String {
+    let mut sha1 = sha1_smol::Sha1::new();
+    sha1.update(key.as_bytes());
+    sha1.update(WEBSOCKET_ACCEPT_GUID.as_bytes());
+    base64::engine::general_purpose::STANDARD.encode(sha1.digest().bytes())
+}
+
+fn required_str<'a>(value: &'a Value, field: &str) -> Result<&'a str, Value> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| live_error("INVALID_SPEC", &format!("missing {field}")))
+}
+
+fn live_error(code: &str, message: &str) -> Value {
+    json!({"code":code,"message":message})
+}
+
+fn live_key_event(pattern: &str, key: &str, operation: &str) -> Value {
+    json!({
+        "kind": key_event_kind(operation),
+        "scope": "key",
+        "pattern": pattern,
+        "key": key,
+        "operation": operation,
+    })
+}
+
+fn key_event_kind(operation: &str) -> &'static str {
+    match operation.to_ascii_lowercase().as_str() {
+        "del" | "unlink" => "key.delete",
+        "expire" | "pexpire" | "expireat" | "pexpireat" => "key.expire",
+        "rename" | "renamenx" => "key.rename",
+        "set" | "mset" | "msetnx" | "setex" | "psetex" | "getset" | "vset" => "key.set",
+        "" => "key.unknown",
+        _ => "key.update",
+    }
+}
+
+fn table_cause_kind(operation: &str) -> &'static str {
+    match operation.to_ascii_lowercase().as_str() {
+        "tinsert" => "table.insert",
+        "tupdate" => "table.update",
+        "tdelete" => "table.delete",
+        _ => key_event_kind(operation),
+    }
+}
+
+fn vector_cause_kind(operation: &str) -> &'static str {
+    match operation.to_ascii_lowercase().as_str() {
+        "del" | "unlink" => "vector.delete",
+        _ => "vector.set",
+    }
+}
+
+fn table_row_to_value(row: Vec<(String, String)>) -> Value {
+    let mut object = serde_json::Map::new();
+    for (key, value) in row {
+        object.insert(key, live_string_to_value(&value));
+    }
+    Value::Object(object)
+}
+
+fn live_string_to_value(value: &str) -> Value {
+    if value == "true" {
+        Value::Bool(true)
+    } else if value == "false" {
+        Value::Bool(false)
+    } else if let Ok(n) = value.parse::<i64>() {
+        json!(n)
+    } else if let Ok(n) = value.parse::<f64>() {
+        json!(n)
+    } else {
+        json!(value)
+    }
+}
+
+fn live_value_to_token(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+fn index_live_rows(rows: Vec<Value>) -> HashMap<String, Value> {
+    let mut indexed = HashMap::new();
+    for row in rows {
+        let Some(id) = row.get("id").or_else(|| row.get("key")).and_then(|value| {
+            value
+                .as_str()
+                .map(String::from)
+                .or_else(|| value.as_i64().map(|n| n.to_string()))
+                .or_else(|| value.as_u64().map(|n| n.to_string()))
+        }) else {
+            continue;
+        };
+        indexed.insert(id, row);
+    }
+    indexed
+}
+
+fn row_fingerprint(value: &Value) -> String {
+    value.to_string()
+}
+
+fn changed_json_fields(previous: &Value, next: &Value) -> Vec<String> {
+    let Some(previous) = previous.as_object() else {
+        return Vec::new();
+    };
+    let Some(next) = next.as_object() else {
+        return Vec::new();
+    };
+    let keys: HashSet<String> = previous.keys().chain(next.keys()).cloned().collect();
+    keys.into_iter()
+        .filter(|key| previous.get(key) != next.get(key))
+        .collect()
 }
 
 struct HttpTableQueryParams {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-const HEADER: &[u8; 4] = b"LUX\x01";
+const HEADER_V1: &[u8; 4] = b"LUX\x01";
+const HEADER: &[u8; 4] = b"LUX\x02";
 
 fn snapshot_path(store: &Store) -> String {
     let dir = &store.config().data_dir;
@@ -61,12 +62,6 @@ fn read_f64(r: &mut impl Read) -> io::Result<f64> {
 fn read_string(r: &mut impl Read) -> io::Result<String> {
     let raw = read_bytes(r)?;
     String::from_utf8(raw).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-}
-
-pub fn save(store: &Store) -> io::Result<usize> {
-    let now = Instant::now();
-    let entries = store.dump_all(now);
-    save_entries(store, &entries)
 }
 
 fn save_entries(store: &Store, entries: &[crate::store::DumpEntry]) -> io::Result<usize> {
@@ -142,7 +137,7 @@ fn save_binary(w: &mut impl Write, entries: &[crate::store::DumpEntry]) -> io::R
                     write_f64(w, *score)?;
                 }
             }
-            DumpValue::Stream(stream_entries, last_id) => {
+            DumpValue::Stream(stream_entries, last_id, groups) => {
                 write_bytes(w, last_id.as_bytes())?;
                 write_u32(w, stream_entries.len() as u32)?;
                 for (id, fields) in stream_entries {
@@ -151,6 +146,25 @@ fn save_binary(w: &mut impl Write, entries: &[crate::store::DumpEntry]) -> io::R
                     for (k, v) in fields {
                         write_bytes(w, k.as_bytes())?;
                         write_bytes(w, v)?;
+                    }
+                }
+                write_u32(w, groups.len() as u32)?;
+                for (name, last_delivered_id, consumers, pending) in groups {
+                    write_bytes(w, name.as_bytes())?;
+                    write_bytes(w, last_delivered_id.as_bytes())?;
+                    write_u32(w, consumers.len() as u32)?;
+                    for (consumer, pending_ids) in consumers {
+                        write_bytes(w, consumer.as_bytes())?;
+                        write_u32(w, pending_ids.len() as u32)?;
+                        for id in pending_ids {
+                            write_bytes(w, id.as_bytes())?;
+                        }
+                    }
+                    write_u32(w, pending.len() as u32)?;
+                    for (id, consumer, delivery_count) in pending {
+                        write_bytes(w, id.as_bytes())?;
+                        write_bytes(w, consumer.as_bytes())?;
+                        write_u32(w, (*delivery_count).min(u32::MAX as u64) as u32)?;
                     }
                 }
             }
@@ -205,14 +219,16 @@ fn load_from_reader(store: &Store, mut file: fs::File) -> io::Result<usize> {
     let mut header = [0u8; 4];
     let n = file.read(&mut header)?;
     if n == 4 && &header == HEADER {
-        load_binary(store, &mut io::BufReader::new(file))
+        load_binary(store, &mut io::BufReader::new(file), true)
+    } else if n == 4 && &header == HEADER_V1 {
+        load_binary(store, &mut io::BufReader::new(file), false)
     } else {
         file.seek(SeekFrom::Start(0))?;
         load_legacy(store, file)
     }
 }
 
-fn load_binary(store: &Store, r: &mut impl Read) -> io::Result<usize> {
+fn load_binary(store: &Store, r: &mut impl Read, stream_groups: bool) -> io::Result<usize> {
     let mut count = 0;
     loop {
         let mut type_buf = [0u8; 1];
@@ -283,7 +299,36 @@ fn load_binary(store: &Store, r: &mut impl Read) -> io::Result<usize> {
                     }
                     entries.push((id, fields));
                 }
-                DumpValue::Stream(entries, last_id)
+                let mut groups = Vec::new();
+                if stream_groups {
+                    let group_count = read_u32(r)? as usize;
+                    groups.reserve(group_count);
+                    for _ in 0..group_count {
+                        let name = read_string(r)?;
+                        let last_delivered_id = read_string(r)?;
+                        let consumer_count = read_u32(r)? as usize;
+                        let mut consumers = Vec::with_capacity(consumer_count);
+                        for _ in 0..consumer_count {
+                            let consumer = read_string(r)?;
+                            let pending_count = read_u32(r)? as usize;
+                            let mut pending_ids = Vec::with_capacity(pending_count);
+                            for _ in 0..pending_count {
+                                pending_ids.push(read_string(r)?);
+                            }
+                            consumers.push((consumer, pending_ids));
+                        }
+                        let pending_count = read_u32(r)? as usize;
+                        let mut pending = Vec::with_capacity(pending_count);
+                        for _ in 0..pending_count {
+                            let id = read_string(r)?;
+                            let consumer = read_string(r)?;
+                            let delivery_count = read_u32(r)? as u64;
+                            pending.push((id, consumer, delivery_count));
+                        }
+                        groups.push((name, last_delivered_id, consumers, pending));
+                    }
+                }
+                DumpValue::Stream(entries, last_id, groups)
             }
             b'V' => {
                 let dims = read_u32(r)? as usize;
@@ -468,7 +513,7 @@ fn load_legacy(store: &Store, file: fs::File) -> io::Result<usize> {
                         }
                     }
                 }
-                DumpValue::Stream(entries, last_id_str)
+                DumpValue::Stream(entries, last_id_str, Vec::new())
             }
             _ => continue,
         };
@@ -571,7 +616,7 @@ fn save_legacy_to_path(store: &Store, path: &str) -> io::Result<usize> {
                 .map(|(m, s)| format!("{}\x1e{}", m, s))
                 .collect::<Vec<_>>()
                 .join("\x1f"),
-            DumpValue::Stream(stream_entries, last_id) => {
+            DumpValue::Stream(stream_entries, last_id, _groups) => {
                 let entries_str: Vec<String> = stream_entries
                     .iter()
                     .map(|(id, fields)| {

--- a/src/store.rs
+++ b/src/store.rs
@@ -93,8 +93,6 @@ impl Hasher for FxHasher {
     }
 }
 
-type MsetShardBuckets<'a> = HashMap<usize, Vec<(&'a [u8], &'a [u8])>, FxBuildHasher>;
-
 #[allow(dead_code)]
 pub const MAX_SHARDS: usize = 1024;
 const WRONGTYPE: &str = "WRONGTYPE Operation against a key holding the wrong kind of value";
@@ -621,18 +619,12 @@ impl Store {
     /// the disk shard BEFORE being removed from memory. If the disk write
     /// fails, the entry stays in memory (no silent data loss). The shard
     /// write lock is dropped before disk I/O to avoid blocking other operations.
-    pub fn evict_key(&self, shard_idx: usize, key: &str) {
+    pub fn evict_key(&self, shard_idx: usize, key: &str) -> bool {
         if let Some(ref disk_shards) = self.disk_shards {
-            let mut shard = self.shards[shard_idx].write();
+            let shard = self.shards[shard_idx].write();
             if let Some(entry) = shard.data.get(key) {
                 if matches!(entry.value, StoreValue::Vector(_)) {
-                    let mem = estimate_entry_memory(key, &entry.value);
-                    shard.data.remove(key);
-                    self.key_removed();
-                    shard.used_memory = shard.used_memory.saturating_sub(mem);
-                    self.mem_sub(mem);
-                    shard.version += 1;
-                    return;
+                    return false;
                 }
                 let now = Instant::now();
                 let ttl_ms = entry
@@ -656,7 +648,7 @@ impl Store {
                         key: key.to_string(),
                         error: e.to_string(),
                     });
-                    return;
+                    return false;
                 }
                 if disk.should_compact() {
                     if let Err(e) = disk.compact() {
@@ -674,6 +666,7 @@ impl Store {
                     shard.used_memory = shard.used_memory.saturating_sub(mem);
                     self.mem_sub(mem);
                     shard.version += 1;
+                    return true;
                 }
             }
         } else {
@@ -684,8 +677,10 @@ impl Store {
                 shard.used_memory = shard.used_memory.saturating_sub(mem);
                 self.mem_sub(mem);
                 shard.version += 1;
+                return true;
             }
         }
+        false
     }
 
     fn entry_to_dump(&self, key: &str, value: &StoreValue, ttl_ms: i64) -> DumpEntry {
@@ -1121,60 +1116,6 @@ impl Store {
         shard.version += 1;
         self.set_on_shard(&mut shard.data, key, value, ttl, now);
         self.remove_from_disk(key);
-    }
-
-    pub fn mset_from_args(&self, kv_args: &[&[u8]], now: Instant) {
-        if kv_args.is_empty() {
-            return;
-        }
-        if kv_args.len() == 2 {
-            self.set(kv_args[0], kv_args[1], None, now);
-            return;
-        }
-        let pair_count = kv_args.len() / 2;
-        let tiered = self.disk_shards.is_some();
-        if pair_count <= 8 {
-            let mut pairs = Vec::with_capacity(pair_count);
-            for pair in kv_args.chunks_exact(2) {
-                let key = pair[0];
-                let value = pair[1];
-                pairs.push((self.shard_index(key), key, value));
-            }
-            pairs.sort_unstable_by_key(|(idx, _, _)| *idx);
-            let mut i = 0usize;
-            while i < pairs.len() {
-                let shard_idx = pairs[i].0;
-                let mut shard = self.shards[shard_idx].write();
-                shard.version += 1;
-                while i < pairs.len() && pairs[i].0 == shard_idx {
-                    let (_, key, value) = pairs[i];
-                    self.set_on_shard(&mut shard.data, key, value, None, now);
-                    if tiered {
-                        self.remove_from_disk(key);
-                    }
-                    i += 1;
-                }
-            }
-            return;
-        }
-        let mut by_shard: MsetShardBuckets<'_> =
-            HashMap::with_capacity_and_hasher(kv_args.len().div_ceil(2).min(16), FxBuildHasher);
-        for pair in kv_args.chunks_exact(2) {
-            let key = pair[0];
-            let value = pair[1];
-            let idx = self.shard_index(key);
-            by_shard.entry(idx).or_default().push((key, value));
-        }
-        for (idx, shard_pairs) in by_shard {
-            let mut shard = self.shards[idx].write();
-            shard.version += 1;
-            for (key, value) in shard_pairs {
-                self.set_on_shard(&mut shard.data, key, value, None, now);
-                if tiered {
-                    self.remove_from_disk(key);
-                }
-            }
-        }
     }
 
     pub fn set_nx(&self, key: &[u8], value: &[u8], now: Instant) -> bool {
@@ -2037,7 +1978,7 @@ impl Store {
                 StoreValue::List(list) => {
                     let val = list.pop_front()?;
                     let freed = val.len() + 32;
-                    shard.used_memory -= freed;
+                    shard.used_memory = shard.used_memory.saturating_sub(freed);
                     self.mem_sub(freed);
                     Some(val)
                 }
@@ -2068,7 +2009,7 @@ impl Store {
                 StoreValue::List(list) => {
                     let val = list.pop_back()?;
                     let freed = val.len() + 32;
-                    shard.used_memory -= freed;
+                    shard.used_memory = shard.used_memory.saturating_sub(freed);
                     self.mem_sub(freed);
                     Some(val)
                 }
@@ -2096,7 +2037,7 @@ impl Store {
                 StoreValue::List(list) => {
                     let val = list.pop_back()?;
                     let freed = val.len() + 32;
-                    shard.used_memory -= freed;
+                    shard.used_memory = shard.used_memory.saturating_sub(freed);
                     self.mem_sub(freed);
                     Some(val)
                 }
@@ -3591,6 +3532,7 @@ impl Store {
         self.metrics.used_memory.load(Ordering::Relaxed)
     }
 
+    #[cfg(test)]
     pub fn dump_all(&self, now: Instant) -> Vec<DumpEntry> {
         let mut entries = Vec::new();
         for shard in self.shards.iter() {
@@ -3670,7 +3612,7 @@ impl Store {
                 }
                 StoreValue::SortedSet(tree, scores)
             }
-            DumpValue::Stream(entries_data, last_id_str) => {
+            DumpValue::Stream(entries_data, last_id_str, groups_data) => {
                 let last_id = StreamId::parse(&last_id_str).unwrap_or(StreamId::zero());
                 let mut entries = BTreeMap::new();
                 for (id_str, fields_data) in entries_data {
@@ -3682,10 +3624,60 @@ impl Store {
                         entries.insert(id, fields);
                     }
                 }
+                let inst_now = Instant::now();
+                let mut groups = std::collections::HashMap::new();
+                for (group_name, last_delivered_str, consumers_data, pending_data) in groups_data {
+                    let last_delivered_id =
+                        StreamId::parse(&last_delivered_str).unwrap_or(StreamId::zero());
+                    let mut consumers = std::collections::HashMap::new();
+                    for (consumer_name, pending_ids) in consumers_data {
+                        let pel = pending_ids
+                            .into_iter()
+                            .filter_map(|id| StreamId::parse(&id))
+                            .collect();
+                        consumers.insert(
+                            consumer_name,
+                            Consumer {
+                                pel,
+                                seen_time: inst_now,
+                            },
+                        );
+                    }
+                    let mut pel = BTreeMap::new();
+                    for (id_str, consumer, delivery_count) in pending_data {
+                        if let Some(id) = StreamId::parse(&id_str) {
+                            pel.insert(
+                                id,
+                                PendingEntry {
+                                    consumer: consumer.clone(),
+                                    delivery_time: inst_now,
+                                    delivery_count,
+                                },
+                            );
+                            consumers.entry(consumer).or_insert_with(|| Consumer {
+                                pel: HashSet::new(),
+                                seen_time: inst_now,
+                            });
+                        }
+                    }
+                    for (id, pending) in &pel {
+                        if let Some(consumer) = consumers.get_mut(&pending.consumer) {
+                            consumer.pel.insert(*id);
+                        }
+                    }
+                    groups.insert(
+                        group_name,
+                        ConsumerGroup {
+                            last_delivered_id,
+                            consumers,
+                            pel,
+                        },
+                    );
+                }
                 StoreValue::Stream(StreamData {
                     entries,
                     last_id,
-                    groups: std::collections::HashMap::new(),
+                    groups,
                 })
             }
             DumpValue::Vector(data, metadata) => {
@@ -4837,7 +4829,7 @@ impl Store {
                         freed += member.len() + 32;
                         result.push(member);
                     }
-                    shard.used_memory -= freed;
+                    shard.used_memory = shard.used_memory.saturating_sub(freed);
                     self.mem_sub(freed);
                     Ok(result)
                 }
@@ -4877,7 +4869,7 @@ impl Store {
                         freed += member.len() + 32;
                         result.push(member);
                     }
-                    shard.used_memory -= freed;
+                    shard.used_memory = shard.used_memory.saturating_sub(freed);
                     self.mem_sub(freed);
                     Ok(result)
                 }
@@ -4908,7 +4900,7 @@ impl Store {
                 StoreValue::Set(set) => {
                     let member = set.pop()?;
                     let freed = member.len() + 32;
-                    shard.used_memory -= freed;
+                    shard.used_memory = shard.used_memory.saturating_sub(freed);
                     self.mem_sub(freed);
                     Some(member)
                 }
@@ -5061,21 +5053,6 @@ impl Store {
         let mut shard = self.shards[idx].write();
         shard.version += 1;
         self.zadd_on_shard(&mut shard, key, members, nx, xx, gt, lt, ch, now)
-    }
-
-    /// Hot-path ZADD for a single member with default options.
-    /// Equivalent to: ZADD key score member.
-    pub fn zadd_single_default(
-        &self,
-        key: &[u8],
-        member: &[u8],
-        score: f64,
-        now: Instant,
-    ) -> Result<i64, String> {
-        let idx = self.shard_index(key);
-        let mut shard = self.shards[idx].write();
-        shard.version += 1;
-        self.zadd_single_default_on_shard(&mut shard, key, member, score, now)
     }
 
     /// Hot-path ZADD for a single member with default options.
@@ -6284,7 +6261,36 @@ fn store_value_to_dump_value(value: &StoreValue) -> DumpValue {
                     (id.to_string(), flds)
                 })
                 .collect();
-            DumpValue::Stream(entries, s.last_id.to_string())
+            let groups: Vec<StreamGroupDump> = s
+                .groups
+                .iter()
+                .map(|(name, group)| {
+                    let consumers = group
+                        .consumers
+                        .iter()
+                        .map(|(consumer, data)| {
+                            let mut pending: Vec<String> =
+                                data.pel.iter().map(ToString::to_string).collect();
+                            pending.sort();
+                            (consumer.clone(), pending)
+                        })
+                        .collect();
+                    let pending = group
+                        .pel
+                        .iter()
+                        .map(|(id, entry)| {
+                            (id.to_string(), entry.consumer.clone(), entry.delivery_count)
+                        })
+                        .collect();
+                    (
+                        name.clone(),
+                        group.last_delivered_id.to_string(),
+                        consumers,
+                        pending,
+                    )
+                })
+                .collect();
+            DumpValue::Stream(entries, s.last_id.to_string(), groups)
         }
         StoreValue::Vector(v) => DumpValue::Vector(v.data.clone(), v.metadata.clone()),
         StoreValue::HyperLogLog(regs, cached) => DumpValue::HyperLogLog(regs.clone(), *cached),
@@ -6384,6 +6390,14 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 }
 
 pub type StreamDumpEntry = (String, Vec<(String, Vec<u8>)>);
+pub type StreamConsumerDump = (String, Vec<String>);
+pub type StreamPendingDump = (String, String, u64);
+pub type StreamGroupDump = (
+    String,
+    String,
+    Vec<StreamConsumerDump>,
+    Vec<StreamPendingDump>,
+);
 
 #[derive(Debug)]
 pub enum DumpValue {
@@ -6392,7 +6406,7 @@ pub enum DumpValue {
     Hash(Vec<(String, Vec<u8>)>),
     Set(Vec<String>),
     SortedSet(Vec<(String, f64)>),
-    Stream(Vec<StreamDumpEntry>, String),
+    Stream(Vec<StreamDumpEntry>, String, Vec<StreamGroupDump>),
     Vector(Vec<f32>, Option<String>),
     HyperLogLog(Vec<u8>, u64),
     TimeSeries(Vec<(i64, f64)>, u64, Vec<(String, String)>),

--- a/tests/bitops.rs
+++ b/tests/bitops.rs
@@ -1,0 +1,177 @@
+mod common;
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::thread;
+use std::time::Duration;
+
+fn resp_cmd(args: &[&str]) -> Vec<u8> {
+    let mut buf = format!("*{}\r\n", args.len());
+    for arg in args {
+        buf.push_str(&format!("${}\r\n{}\r\n", arg.len(), arg));
+    }
+    buf.into_bytes()
+}
+
+fn read_all(stream: &mut TcpStream) -> String {
+    let mut data = Vec::with_capacity(4096);
+    let mut buf = [0u8; 8192];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(len) => data.extend_from_slice(&buf[..len]),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => break,
+            Err(_) => break,
+        }
+    }
+    String::from_utf8_lossy(&data).to_string()
+}
+
+fn send_and_read(stream: &mut TcpStream, args: &[&str]) -> String {
+    stream.write_all(&resp_cmd(args)).unwrap();
+    thread::sleep(Duration::from_millis(50));
+    read_all(stream)
+}
+
+struct LuxServer {
+    child: std::process::Child,
+    tmpdir: std::path::PathBuf,
+}
+
+impl Drop for LuxServer {
+    fn drop(&mut self) {
+        common::terminate_child(&mut self.child);
+        let _ = std::fs::remove_dir_all(&self.tmpdir);
+    }
+}
+
+fn start_lux(port: u16) -> LuxServer {
+    let tmpdir =
+        std::env::temp_dir().join(format!("lux_bitops_test_{}_{}", std::process::id(), port));
+    std::fs::create_dir_all(&tmpdir).unwrap();
+    let child = common::lux_command(env!("CARGO_BIN_EXE_lux"))
+        .env("LUX_PORT", port.to_string())
+        .env("LUX_SHARDS", "4")
+        .env("LUX_SAVE_INTERVAL", "0")
+        .env("LUX_DATA_DIR", tmpdir.to_str().unwrap())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start lux");
+
+    let server = LuxServer { child, tmpdir };
+    for _ in 0..40 {
+        if TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            return server;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("lux did not start on port {port}");
+}
+
+fn connect(port: u16) -> TcpStream {
+    let stream = TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+    stream.set_nodelay(true).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .unwrap();
+    stream
+}
+
+#[test]
+fn setbit_getbit_bitcount_and_bitpos() {
+    let port = 17810;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert!(send_and_read(&mut conn, &["SETBIT", "bits", "1", "1"]).contains(":0"));
+    assert!(send_and_read(&mut conn, &["SETBIT", "bits", "9", "1"]).contains(":0"));
+    assert!(send_and_read(&mut conn, &["GETBIT", "bits", "1"]).contains(":1"));
+    assert!(send_and_read(&mut conn, &["GETBIT", "bits", "2"]).contains(":0"));
+    assert!(send_and_read(&mut conn, &["BITCOUNT", "bits"]).contains(":2"));
+    assert!(send_and_read(&mut conn, &["BITCOUNT", "bits", "0", "7", "BIT"]).contains(":1"));
+    assert!(send_and_read(&mut conn, &["BITPOS", "bits", "1"]).contains(":1"));
+    assert!(send_and_read(&mut conn, &["BITPOS", "bits", "0", "0", "7", "BIT"]).contains(":0"));
+}
+
+#[test]
+fn bitop_and_or_xor_not() {
+    let port = 17811;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    send_and_read(&mut conn, &["SETBIT", "a", "0", "1"]);
+    send_and_read(&mut conn, &["SETBIT", "a", "2", "1"]);
+    send_and_read(&mut conn, &["SETBIT", "b", "2", "1"]);
+    send_and_read(&mut conn, &["SETBIT", "b", "3", "1"]);
+
+    assert!(send_and_read(&mut conn, &["BITOP", "AND", "and", "a", "b"]).contains(":1"));
+    assert!(send_and_read(&mut conn, &["GETBIT", "and", "2"]).contains(":1"));
+    assert!(send_and_read(&mut conn, &["GETBIT", "and", "0"]).contains(":0"));
+
+    assert!(send_and_read(&mut conn, &["BITOP", "OR", "or", "a", "b"]).contains(":1"));
+    assert!(send_and_read(&mut conn, &["GETBIT", "or", "0"]).contains(":1"));
+    assert!(send_and_read(&mut conn, &["GETBIT", "or", "3"]).contains(":1"));
+
+    assert!(send_and_read(&mut conn, &["BITOP", "XOR", "xor", "a", "b"]).contains(":1"));
+    assert!(send_and_read(&mut conn, &["GETBIT", "xor", "2"]).contains(":0"));
+
+    assert!(send_and_read(&mut conn, &["BITOP", "NOT", "not", "a"]).contains(":1"));
+    assert!(send_and_read(&mut conn, &["GETBIT", "not", "1"]).contains(":1"));
+}
+
+#[test]
+fn bitop_reports_syntax_and_type_errors() {
+    let port = 17812;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    let bad_bit = send_and_read(&mut conn, &["SETBIT", "bits", "0", "2"]);
+    assert!(bad_bit.contains("ERR bit is not"), "bad bit: {bad_bit}");
+
+    let bad_offset = send_and_read(&mut conn, &["GETBIT", "bits", "-1"]);
+    assert!(
+        bad_offset.contains("ERR bit offset"),
+        "bad offset: {bad_offset}"
+    );
+
+    let bad_not = send_and_read(&mut conn, &["BITOP", "NOT", "dst", "a", "b"]);
+    assert!(
+        bad_not.contains("BITOP NOT requires"),
+        "bad NOT arity: {bad_not}"
+    );
+
+    send_and_read(&mut conn, &["LPUSH", "list", "x"]);
+    let wrongtype = send_and_read(&mut conn, &["GETBIT", "list", "0"]);
+    assert!(wrongtype.contains("WRONGTYPE"), "wrong type: {wrongtype}");
+}
+
+#[test]
+fn bit_commands_reject_invalid_ranges_without_mutating_destination() {
+    let port = 17813;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    send_and_read(&mut conn, &["SETBIT", "src", "0", "1"]);
+    send_and_read(&mut conn, &["SETBIT", "dest", "0", "1"]);
+
+    for cmd in [
+        vec!["BITPOS", "src", "1", "nope"],
+        vec!["BITPOS", "src", "1", "0", "nope"],
+        vec!["BITPOS", "src", "1", "0", "-1", "NOPE"],
+        vec!["BITOP", "BADOP", "dest", "missing"],
+    ] {
+        let resp = send_and_read(&mut conn, &cmd);
+        assert!(
+            resp.starts_with("-ERR"),
+            "expected error for {cmd:?}, got: {resp}"
+        );
+    }
+
+    let resp = send_and_read(&mut conn, &["GETBIT", "dest", "0"]);
+    assert!(
+        resp.contains(":1"),
+        "invalid BITOP should not delete destination: {resp}"
+    );
+}

--- a/tests/collections.rs
+++ b/tests/collections.rs
@@ -1,0 +1,478 @@
+mod common;
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::thread;
+use std::time::Duration;
+
+fn resp_cmd(args: &[&str]) -> Vec<u8> {
+    let mut buf = format!("*{}\r\n", args.len());
+    for arg in args {
+        buf.push_str(&format!("${}\r\n{}\r\n", arg.len(), arg));
+    }
+    buf.into_bytes()
+}
+
+fn read_all(stream: &mut TcpStream) -> String {
+    let mut data = Vec::with_capacity(4096);
+    let mut buf = [0u8; 8192];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(len) => data.extend_from_slice(&buf[..len]),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => break,
+            Err(_) => break,
+        }
+    }
+    String::from_utf8_lossy(&data).to_string()
+}
+
+fn send(stream: &mut TcpStream, args: &[&str]) -> String {
+    stream.write_all(&resp_cmd(args)).unwrap();
+    thread::sleep(Duration::from_millis(50));
+    read_all(stream)
+}
+
+fn assert_has(resp: &str, needle: &str) {
+    assert!(resp.contains(needle), "missing {needle:?}: {resp}");
+}
+
+struct LuxServer {
+    child: std::process::Child,
+    tmpdir: std::path::PathBuf,
+}
+
+impl Drop for LuxServer {
+    fn drop(&mut self) {
+        common::terminate_child(&mut self.child);
+        let _ = std::fs::remove_dir_all(&self.tmpdir);
+    }
+}
+
+fn start_lux(port: u16) -> LuxServer {
+    let tmpdir = std::env::temp_dir().join(format!(
+        "lux_collections_test_{}_{}",
+        std::process::id(),
+        port
+    ));
+    std::fs::create_dir_all(&tmpdir).unwrap();
+    let child = common::lux_command(env!("CARGO_BIN_EXE_lux"))
+        .env("LUX_PORT", port.to_string())
+        .env("LUX_SHARDS", "4")
+        .env("LUX_SAVE_INTERVAL", "0")
+        .env("LUX_DATA_DIR", tmpdir.to_str().unwrap())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start lux");
+
+    let server = LuxServer { child, tmpdir };
+    for _ in 0..40 {
+        if TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            return server;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("lux did not start on port {port}");
+}
+
+fn connect(port: u16) -> TcpStream {
+    let stream = TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+    stream.set_nodelay(true).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .unwrap();
+    stream
+}
+
+#[test]
+fn hash_command_surface() {
+    let port = 17820;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert_has(&send(&mut conn, &["HSET", "h", "a", "1", "b", "2"]), ":2");
+    assert_has(&send(&mut conn, &["HGET", "h", "a"]), "1");
+    assert_has(&send(&mut conn, &["HMGET", "h", "a", "missing", "b"]), "*3");
+    assert_has(&send(&mut conn, &["HGETALL", "h"]), "a");
+    assert_has(&send(&mut conn, &["HKEYS", "h"]), "a");
+    assert_has(&send(&mut conn, &["HVALS", "h"]), "2");
+    assert_has(&send(&mut conn, &["HLEN", "h"]), ":2");
+    assert_has(&send(&mut conn, &["HEXISTS", "h", "a"]), ":1");
+    assert_has(&send(&mut conn, &["HSTRLEN", "h", "a"]), ":1");
+    assert_has(&send(&mut conn, &["HSETNX", "h", "a", "new"]), ":0");
+    assert_has(&send(&mut conn, &["HINCRBY", "h", "n", "3"]), ":3");
+    assert_has(&send(&mut conn, &["HINCRBYFLOAT", "h", "f", "1.5"]), "1.5");
+    assert_has(
+        &send(&mut conn, &["HRANDFIELD", "h", "2", "WITHVALUES"]),
+        "*4",
+    );
+    assert_has(
+        &send(&mut conn, &["HSCAN", "h", "0", "MATCH", "*", "COUNT", "10"]),
+        "*2",
+    );
+    assert_has(&send(&mut conn, &["HDEL", "h", "a", "b"]), ":2");
+}
+
+#[test]
+fn hscan_rejects_invalid_cursor_and_options() {
+    let port = 17827;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert_has(&send(&mut conn, &["HSET", "h", "a", "1", "b", "2"]), ":2");
+
+    for cmd in [
+        vec!["HSCAN", "h", "nope"],
+        vec!["HSCAN", "h", "0", "COUNT", "nope"],
+        vec!["HSCAN", "h", "0", "COUNT", "0"],
+        vec!["HSCAN", "h", "0", "UNKNOWN"],
+    ] {
+        let resp = send(&mut conn, &cmd);
+        assert!(
+            resp.starts_with("-ERR"),
+            "expected error for {cmd:?}, got: {resp}"
+        );
+    }
+
+    assert_has(
+        &send(&mut conn, &["HSCAN", "h", "0", "MATCH", "*", "COUNT", "10"]),
+        "*2",
+    );
+}
+
+#[test]
+fn list_command_surface() {
+    let port = 17821;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert_has(&send(&mut conn, &["LPUSH", "l", "b", "a"]), ":2");
+    assert_has(&send(&mut conn, &["RPUSH", "l", "c", "d"]), ":4");
+    assert_has(&send(&mut conn, &["LLEN", "l"]), ":4");
+    assert_has(&send(&mut conn, &["LINDEX", "l", "0"]), "a");
+    assert_has(
+        &send(&mut conn, &["LINSERT", "l", "BEFORE", "c", "x"]),
+        ":5",
+    );
+    assert_has(&send(&mut conn, &["LPOS", "l", "x"]), ":2");
+    assert_has(&send(&mut conn, &["LRANGE", "l", "0", "-1"]), "x");
+    assert_has(&send(&mut conn, &["LSET", "l", "0", "first"]), "+OK");
+    assert_has(&send(&mut conn, &["LREM", "l", "1", "x"]), ":1");
+    assert_has(&send(&mut conn, &["LTRIM", "l", "0", "2"]), "+OK");
+    assert_has(&send(&mut conn, &["RPOPLPUSH", "l", "other"]), "c");
+    assert_has(
+        &send(&mut conn, &["LMOVE", "other", "l", "LEFT", "RIGHT"]),
+        "c",
+    );
+    assert_has(&send(&mut conn, &["LPOP", "l"]), "first");
+    assert_has(&send(&mut conn, &["RPOP", "l"]), "c");
+}
+
+#[test]
+fn list_commands_reject_invalid_arguments_without_mutating_state() {
+    let port = 17824;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert_has(&send(&mut conn, &["RPUSH", "l", "a", "b", "a", "c"]), ":4");
+    assert_has(&send(&mut conn, &["RPUSH", "dst", "d"]), ":1");
+
+    for cmd in [
+        vec!["LRANGE", "l", "nope", "-1"],
+        vec!["LRANGE", "l", "0", "nope"],
+        vec!["LINDEX", "l", "nope"],
+        vec!["LSET", "l", "nope", "x"],
+        vec!["LREM", "l", "nope", "a"],
+        vec!["LTRIM", "l", "nope", "-1"],
+        vec!["LTRIM", "l", "0", "nope"],
+        vec!["LPOS", "l", "a", "RANK", "nope"],
+        vec!["LPOS", "l", "a", "COUNT", "nope"],
+        vec!["LPOS", "l", "a", "MAXLEN", "nope"],
+        vec!["LPOS", "l", "a", "BADOPT"],
+        vec!["LINSERT", "l", "MIDDLE", "a", "x"],
+        vec!["LMOVE", "l", "dst", "MIDDLE", "LEFT"],
+        vec!["LMOVE", "l", "dst", "LEFT", "MIDDLE"],
+        vec!["BLMOVE", "l", "dst", "LEFT", "MIDDLE", "0"],
+        vec!["BLMOVE", "l", "dst", "LEFT", "RIGHT", "nope"],
+        vec!["BLPOP", "l", "nope"],
+    ] {
+        let resp = send(&mut conn, &cmd);
+        assert!(
+            resp.starts_with("-ERR"),
+            "expected error for {cmd:?}, got: {resp}"
+        );
+    }
+
+    assert_has(&send(&mut conn, &["LLEN", "l"]), ":4");
+    assert_has(&send(&mut conn, &["LRANGE", "l", "0", "-1"]), "a");
+    assert_has(&send(&mut conn, &["LRANGE", "l", "0", "-1"]), "c");
+    assert_has(&send(&mut conn, &["LLEN", "dst"]), ":1");
+    assert_has(&send(&mut conn, &["LRANGE", "dst", "0", "-1"]), "d");
+}
+
+#[test]
+fn set_command_surface() {
+    let port = 17822;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert_has(
+        &send(&mut conn, &["SADD", "a", "one", "two", "three"]),
+        ":3",
+    );
+    assert_has(
+        &send(&mut conn, &["SADD", "b", "two", "three", "four"]),
+        ":3",
+    );
+    assert_has(&send(&mut conn, &["SCARD", "a"]), ":3");
+    assert_has(&send(&mut conn, &["SISMEMBER", "a", "one"]), ":1");
+    assert_has(&send(&mut conn, &["SMISMEMBER", "a", "one", "nope"]), "*2");
+    assert_has(&send(&mut conn, &["SMEMBERS", "a"]), "one");
+    assert_has(&send(&mut conn, &["SRANDMEMBER", "a", "2"]), "*2");
+    assert_has(&send(&mut conn, &["SINTER", "a", "b"]), "two");
+    assert_has(&send(&mut conn, &["SUNION", "a", "b"]), "four");
+    assert_has(&send(&mut conn, &["SDIFF", "a", "b"]), "one");
+    assert_has(&send(&mut conn, &["SINTERCARD", "2", "a", "b"]), ":2");
+    assert_has(&send(&mut conn, &["SUNIONSTORE", "u", "a", "b"]), ":4");
+    assert_has(&send(&mut conn, &["SINTERSTORE", "i", "a", "b"]), ":2");
+    assert_has(&send(&mut conn, &["SDIFFSTORE", "d", "a", "b"]), ":1");
+    assert_has(&send(&mut conn, &["SMOVE", "a", "b", "one"]), ":1");
+    assert_has(
+        &send(&mut conn, &["SSCAN", "b", "0", "MATCH", "*", "COUNT", "10"]),
+        "*2",
+    );
+    assert_has(&send(&mut conn, &["SPOP", "b"]), "$");
+    assert_has(&send(&mut conn, &["SADD", "b", "removable"]), ":1");
+    assert_has(&send(&mut conn, &["SREM", "b", "removable"]), ":1");
+}
+
+#[test]
+fn set_count_commands_reject_invalid_arguments_without_mutating_state() {
+    let port = 17826;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert_has(&send(&mut conn, &["SADD", "s", "a", "b", "c"]), ":3");
+    assert_has(&send(&mut conn, &["SADD", "t", "b", "c"]), ":2");
+
+    for cmd in [
+        vec!["SPOP", "s", "nope"],
+        vec!["SRANDMEMBER", "s", "nope"],
+        vec!["SINTERCARD", "2", "s", "t", "LIMIT", "nope"],
+    ] {
+        let resp = send(&mut conn, &cmd);
+        assert!(
+            resp.starts_with("-ERR"),
+            "expected error for {cmd:?}, got: {resp}"
+        );
+    }
+
+    assert_has(&send(&mut conn, &["SCARD", "s"]), ":3");
+    assert_has(&send(&mut conn, &["SMEMBERS", "s"]), "a");
+    assert_has(&send(&mut conn, &["SMEMBERS", "s"]), "b");
+    assert_has(&send(&mut conn, &["SMEMBERS", "s"]), "c");
+}
+
+#[test]
+fn sorted_set_command_surface() {
+    let port = 17823;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert_has(
+        &send(
+            &mut conn,
+            &["ZADD", "z", "1", "one", "2", "two", "3", "three"],
+        ),
+        ":3",
+    );
+    assert_has(&send(&mut conn, &["ZADD", "z", "NX", "4", "four"]), ":1");
+    assert_has(&send(&mut conn, &["ZADD", "z", "XX", "5", "four"]), ":0");
+    assert_has(&send(&mut conn, &["ZSCORE", "z", "four"]), "5");
+    assert_has(&send(&mut conn, &["ZMSCORE", "z", "one", "missing"]), "*2");
+    assert_has(&send(&mut conn, &["ZRANK", "z", "one"]), ":0");
+    assert_has(&send(&mut conn, &["ZREVRANK", "z", "four"]), ":0");
+    assert_has(&send(&mut conn, &["ZCARD", "z"]), ":4");
+    assert_has(&send(&mut conn, &["ZCOUNT", "z", "1", "5"]), ":4");
+    assert_has(&send(&mut conn, &["ZINCRBY", "z", "2", "one"]), "3");
+    assert_has(
+        &send(&mut conn, &["ZRANGE", "z", "0", "-1", "WITHSCORES"]),
+        "one",
+    );
+    assert_has(&send(&mut conn, &["ZREVRANGE", "z", "0", "1"]), "four");
+    assert_has(&send(&mut conn, &["ZRANGEBYSCORE", "z", "2", "5"]), "two");
+    assert_has(
+        &send(&mut conn, &["ZREVRANGEBYSCORE", "z", "5", "2"]),
+        "four",
+    );
+    assert_has(&send(&mut conn, &["ZPOPMIN", "z", "1"]), "*2");
+    assert_has(&send(&mut conn, &["ZPOPMAX", "z", "1"]), "*2");
+
+    assert_has(&send(&mut conn, &["ZADD", "za", "1", "a", "2", "b"]), ":2");
+    assert_has(&send(&mut conn, &["ZADD", "zb", "2", "b", "3", "c"]), ":2");
+    assert_has(
+        &send(&mut conn, &["ZUNIONSTORE", "zu", "2", "za", "zb"]),
+        ":3",
+    );
+    assert_has(
+        &send(&mut conn, &["ZINTERSTORE", "zi", "2", "za", "zb"]),
+        ":1",
+    );
+    assert_has(
+        &send(&mut conn, &["ZDIFFSTORE", "zd", "2", "za", "zb"]),
+        ":1",
+    );
+    assert_has(
+        &send(
+            &mut conn,
+            &["ZSCAN", "zu", "0", "MATCH", "*", "COUNT", "10"],
+        ),
+        "*2",
+    );
+    assert_has(&send(&mut conn, &["ZREM", "zu", "a"]), ":1");
+    assert_has(
+        &send(&mut conn, &["ZREMRANGEBYSCORE", "zu", "0", "10"]),
+        ":2",
+    );
+
+    assert_has(
+        &send(&mut conn, &["ZADD", "lex", "0", "a", "0", "b", "0", "c"]),
+        ":3",
+    );
+    assert_has(&send(&mut conn, &["ZLEXCOUNT", "lex", "-", "+"]), ":3");
+    assert_has(&send(&mut conn, &["ZRANGEBYLEX", "lex", "-", "+"]), "a");
+    assert_has(&send(&mut conn, &["ZREVRANGEBYLEX", "lex", "+", "-"]), "c");
+    assert_has(
+        &send(&mut conn, &["ZREMRANGEBYLEX", "lex", "[a", "[b"]),
+        ":2",
+    );
+}
+
+#[test]
+fn sorted_set_store_rejects_invalid_arguments_without_mutating_destination() {
+    let port = 17825;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert_has(&send(&mut conn, &["ZADD", "za", "1", "a", "2", "b"]), ":2");
+    assert_has(&send(&mut conn, &["ZADD", "zb", "2", "b", "3", "c"]), ":2");
+    assert_has(
+        &send(&mut conn, &["ZUNIONSTORE", "dest", "2", "za", "zb"]),
+        ":3",
+    );
+
+    for cmd in [
+        vec!["ZUNIONSTORE", "dest", "nope", "za", "zb"],
+        vec!["ZUNIONSTORE", "dest", "0"],
+        vec!["ZUNIONSTORE", "dest", "3", "za", "zb"],
+        vec![
+            "ZUNIONSTORE",
+            "dest",
+            "2",
+            "za",
+            "zb",
+            "WEIGHTS",
+            "nope",
+            "1",
+        ],
+        vec!["ZUNIONSTORE", "dest", "2", "za", "zb", "WEIGHTS", "1"],
+        vec![
+            "ZUNIONSTORE",
+            "dest",
+            "2",
+            "za",
+            "zb",
+            "AGGREGATE",
+            "MEDIAN",
+        ],
+        vec!["ZUNIONSTORE", "dest", "2", "za", "zb", "UNKNOWN"],
+        vec![
+            "ZINTERSTORE",
+            "dest",
+            "2",
+            "za",
+            "zb",
+            "WEIGHTS",
+            "1",
+            "nope",
+        ],
+        vec!["ZDIFFSTORE", "dest", "0"],
+        vec!["ZDIFFSTORE", "dest", "1", "za", "EXTRA"],
+    ] {
+        let resp = send(&mut conn, &cmd);
+        assert!(
+            resp.starts_with("-ERR"),
+            "expected error for {cmd:?}, got: {resp}"
+        );
+    }
+
+    assert_has(&send(&mut conn, &["ZCARD", "dest"]), ":3");
+    assert_has(&send(&mut conn, &["ZSCORE", "dest", "b"]), "4");
+
+    assert_has(
+        &send(
+            &mut conn,
+            &[
+                "ZUNIONSTORE",
+                "weighted",
+                "2",
+                "za",
+                "zb",
+                "WEIGHTS",
+                "2",
+                "3",
+                "AGGREGATE",
+                "MAX",
+            ],
+        ),
+        ":3",
+    );
+    assert_has(&send(&mut conn, &["ZSCORE", "weighted", "c"]), "9");
+}
+
+#[test]
+fn sorted_set_commands_reject_invalid_arguments_without_mutating_state() {
+    let port = 17828;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert_has(
+        &send(
+            &mut conn,
+            &["ZADD", "z", "1", "one", "2", "two", "3", "three"],
+        ),
+        ":3",
+    );
+
+    for cmd in [
+        vec!["ZPOPMIN", "z", "nope"],
+        vec!["ZPOPMAX", "z", "nope"],
+        vec!["ZREMRANGEBYRANK", "z", "nope", "1"],
+        vec!["ZREMRANGEBYRANK", "z", "0", "nope"],
+        vec!["ZREMRANGEBYSCORE", "z", "nope", "2"],
+        vec!["ZREMRANGEBYSCORE", "z", "1", "nope"],
+        vec!["ZRANGE", "z", "nope", "-1"],
+        vec!["ZRANGE", "z", "0", "nope"],
+        vec!["ZRANGE", "z", "0", "-1", "LIMIT", "nope", "1"],
+        vec!["ZRANGE", "z", "0", "-1", "LIMIT", "0", "nope"],
+        vec!["ZRANGEBYSCORE", "z", "nope", "3"],
+        vec!["ZRANGEBYSCORE", "z", "1", "3", "LIMIT", "nope", "1"],
+        vec!["ZSCAN", "z", "nope"],
+        vec!["ZSCAN", "z", "0", "COUNT", "nope"],
+        vec!["ZSCAN", "z", "0", "COUNT", "0"],
+        vec!["ZSCAN", "z", "0", "UNKNOWN"],
+    ] {
+        let resp = send(&mut conn, &cmd);
+        assert!(
+            resp.starts_with("-ERR"),
+            "expected error for {cmd:?}, got: {resp}"
+        );
+    }
+
+    assert_has(&send(&mut conn, &["ZCARD", "z"]), ":3");
+    assert_has(&send(&mut conn, &["ZSCORE", "z", "one"]), "1");
+    assert_has(&send(&mut conn, &["ZSCORE", "z", "two"]), "2");
+    assert_has(&send(&mut conn, &["ZSCORE", "z", "three"]), "3");
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,24 @@
+pub fn lux_command<P: AsRef<std::ffi::OsStr>>(program: P) -> std::process::Command {
+    std::process::Command::new(program)
+}
+
+pub fn terminate_child(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    {
+        let _ = std::process::Command::new("kill")
+            .arg("-TERM")
+            .arg(child.id().to_string())
+            .status();
+
+        for _ in 0..50 {
+            match child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => std::thread::sleep(std::time::Duration::from_millis(20)),
+                Err(_) => return,
+            }
+        }
+    }
+
+    child.kill().ok();
+    child.wait().ok();
+}

--- a/tests/keystrings.rs
+++ b/tests/keystrings.rs
@@ -1,0 +1,251 @@
+mod common;
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::thread;
+use std::time::Duration;
+
+fn resp_cmd(args: &[&str]) -> Vec<u8> {
+    let mut buf = format!("*{}\r\n", args.len());
+    for arg in args {
+        buf.push_str(&format!("${}\r\n{}\r\n", arg.len(), arg));
+    }
+    buf.into_bytes()
+}
+
+fn read_all(stream: &mut TcpStream) -> String {
+    let mut data = Vec::with_capacity(4096);
+    let mut buf = [0u8; 8192];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(len) => data.extend_from_slice(&buf[..len]),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => break,
+            Err(_) => break,
+        }
+    }
+    String::from_utf8_lossy(&data).to_string()
+}
+
+fn send(stream: &mut TcpStream, args: &[&str]) -> String {
+    stream.write_all(&resp_cmd(args)).unwrap();
+    thread::sleep(Duration::from_millis(50));
+    read_all(stream)
+}
+
+fn assert_has(resp: &str, needle: &str) {
+    assert!(resp.contains(needle), "missing {needle:?}: {resp}");
+}
+
+fn assert_error(resp: &str) {
+    assert!(resp.starts_with("-ERR"), "expected error, got: {resp}");
+}
+
+struct LuxServer {
+    child: std::process::Child,
+    tmpdir: std::path::PathBuf,
+}
+
+impl Drop for LuxServer {
+    fn drop(&mut self) {
+        common::terminate_child(&mut self.child);
+        let _ = std::fs::remove_dir_all(&self.tmpdir);
+    }
+}
+
+fn start_lux(port: u16) -> LuxServer {
+    let tmpdir = std::env::temp_dir().join(format!(
+        "lux_keystrings_test_{}_{}",
+        std::process::id(),
+        port
+    ));
+    std::fs::create_dir_all(&tmpdir).unwrap();
+    let child = common::lux_command(env!("CARGO_BIN_EXE_lux"))
+        .env("LUX_PORT", port.to_string())
+        .env("LUX_SHARDS", "4")
+        .env("LUX_SAVE_INTERVAL", "0")
+        .env("LUX_DATA_DIR", tmpdir.to_str().unwrap())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start lux");
+
+    let server = LuxServer { child, tmpdir };
+    for _ in 0..40 {
+        if TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            return server;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("lux did not start on port {port}");
+}
+
+fn connect(port: u16) -> TcpStream {
+    let stream = TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+    stream.set_nodelay(true).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .unwrap();
+    stream
+}
+
+#[test]
+fn string_command_surface() {
+    let port = 17830;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert_has(&send(&mut conn, &["SET", "s", "hello"]), "+OK");
+    assert_has(&send(&mut conn, &["GET", "s"]), "hello");
+    assert_has(&send(&mut conn, &["APPEND", "s", "-world"]), ":11");
+    assert_has(&send(&mut conn, &["STRLEN", "s"]), ":11");
+    assert_has(&send(&mut conn, &["GETRANGE", "s", "0", "4"]), "hello");
+    assert_has(&send(&mut conn, &["SETRANGE", "s", "6", "Lux"]), ":11");
+    assert_has(&send(&mut conn, &["GET", "s"]), "hello-Luxld");
+    assert_has(&send(&mut conn, &["GETSET", "s", "old"]), "hello-Luxld");
+    assert_has(&send(&mut conn, &["GETDEL", "s"]), "old");
+    assert_has(&send(&mut conn, &["GET", "s"]), "$-1");
+
+    assert_has(&send(&mut conn, &["MSET", "a", "1", "b", "2"]), "+OK");
+    assert_has(&send(&mut conn, &["MGET", "a", "b", "missing"]), "*3");
+    assert_has(&send(&mut conn, &["MSETNX", "a", "x", "c", "3"]), ":0");
+    assert_has(&send(&mut conn, &["MSETNX", "c", "3", "d", "4"]), ":1");
+}
+
+#[test]
+fn numeric_string_commands_and_set_options() {
+    let port = 17831;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert_has(&send(&mut conn, &["INCR", "n"]), ":1");
+    assert_has(&send(&mut conn, &["INCRBY", "n", "9"]), ":10");
+    assert_has(&send(&mut conn, &["DECR", "n"]), ":9");
+    assert_has(&send(&mut conn, &["DECRBY", "n", "4"]), ":5");
+    assert_has(&send(&mut conn, &["INCRBYFLOAT", "f", "1.25"]), "1.25");
+
+    assert_has(&send(&mut conn, &["SET", "nx", "first", "NX"]), "+OK");
+    assert_has(&send(&mut conn, &["SET", "nx", "second", "NX"]), "$-1");
+    assert_has(&send(&mut conn, &["SET", "nx", "second", "XX"]), "+OK");
+    assert_has(&send(&mut conn, &["GET", "nx"]), "second");
+
+    assert_has(&send(&mut conn, &["SETEX", "ttl:s", "10", "v"]), "+OK");
+    assert_has(&send(&mut conn, &["PSETEX", "ttl:p", "10000", "v"]), "+OK");
+    assert_has(&send(&mut conn, &["GETEX", "ttl:s", "PERSIST"]), "v");
+}
+
+#[test]
+fn string_commands_reject_invalid_arguments_without_mutating_state() {
+    let port = 17834;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    assert_has(&send(&mut conn, &["SET", "s", "hello"]), "+OK");
+    assert_error(&send(&mut conn, &["GETRANGE", "s", "nope", "1"]));
+    assert_error(&send(&mut conn, &["GETRANGE", "s", "0", "nope"]));
+    assert_error(&send(&mut conn, &["SETRANGE", "s", "nope", "X"]));
+    assert_error(&send(
+        &mut conn,
+        &["SETRANGE", "s", "18446744073709551615", "X"],
+    ));
+    assert_has(&send(&mut conn, &["GET", "s"]), "hello");
+
+    assert_has(&send(&mut conn, &["SET", "ttl", "original"]), "+OK");
+    for cmd in [
+        vec!["SET", "ttl", "replacement", "EX", "nope"],
+        vec!["SET", "ttl", "replacement", "EX", "0"],
+        vec!["SET", "ttl", "replacement", "PX", "nope"],
+        vec!["SET", "ttl", "replacement", "PX", "0"],
+        vec!["GETEX", "ttl", "EX", "nope"],
+        vec!["GETEX", "ttl", "EX", "0"],
+        vec!["GETEX", "ttl", "PX", "nope"],
+        vec!["GETEX", "ttl", "PERSIST", "EX", "10"],
+        vec!["GETEX", "ttl", "EX", "10", "PX", "10"],
+    ] {
+        assert_error(&send(&mut conn, &cmd));
+    }
+    assert_has(&send(&mut conn, &["GET", "ttl"]), "original");
+    assert_has(&send(&mut conn, &["TTL", "ttl"]), ":-1");
+
+    assert_has(&send(&mut conn, &["SET", "psetex", "keep"]), "+OK");
+    assert_error(&send(&mut conn, &["PSETEX", "psetex", "0", "new"]));
+    assert_error(&send(&mut conn, &["PSETEX", "psetex", "nope", "new"]));
+    assert_has(&send(&mut conn, &["GET", "psetex"]), "keep");
+}
+
+#[test]
+fn key_command_surface() {
+    let port = 17832;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    send(&mut conn, &["SET", "k1", "v1"]);
+    send(&mut conn, &["SET", "k2", "v2"]);
+    send(&mut conn, &["LPUSH", "list", "a"]);
+
+    assert_has(&send(&mut conn, &["EXISTS", "k1", "missing"]), ":1");
+    assert_has(&send(&mut conn, &["TYPE", "list"]), "list");
+    assert_has(&send(&mut conn, &["KEYS", "k*"]), "k1");
+    assert_has(
+        &send(&mut conn, &["SCAN", "0", "MATCH", "k*", "COUNT", "10"]),
+        "*2",
+    );
+    assert_has(&send(&mut conn, &["RANDOMKEY"]), "$");
+    assert_has(&send(&mut conn, &["OBJECT", "ENCODING", "k1"]), "embstr");
+    assert_has(&send(&mut conn, &["MEMORY", "USAGE", "k1"]), ":");
+
+    assert_has(&send(&mut conn, &["COPY", "k1", "k3"]), ":1");
+    assert_has(&send(&mut conn, &["GET", "k3"]), "v1");
+    assert_has(&send(&mut conn, &["RENAME", "k3", "renamed"]), "+OK");
+    assert_has(&send(&mut conn, &["RENAMENX", "renamed", "k1"]), ":0");
+    assert_has(&send(&mut conn, &["RENAMENX", "renamed", "fresh"]), ":1");
+    assert_has(&send(&mut conn, &["DEL", "fresh", "missing"]), ":1");
+    assert_has(&send(&mut conn, &["UNLINK", "k2"]), ":1");
+}
+
+#[test]
+fn scan_rejects_invalid_cursor_and_options() {
+    let port = 17835;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    send(&mut conn, &["SET", "k1", "v1"]);
+    send(&mut conn, &["SET", "k2", "v2"]);
+
+    for cmd in [
+        vec!["SCAN", "nope"],
+        vec!["SCAN", "0", "COUNT", "nope"],
+        vec!["SCAN", "0", "COUNT", "0"],
+        vec!["SCAN", "0", "UNKNOWN"],
+    ] {
+        assert_error(&send(&mut conn, &cmd));
+    }
+
+    assert_has(
+        &send(&mut conn, &["SCAN", "0", "MATCH", "k*", "COUNT", "10"]),
+        "*2",
+    );
+}
+
+#[test]
+fn expire_ttl_and_persist_surface() {
+    let port = 17833;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    send(&mut conn, &["SET", "exp", "v"]);
+    assert_has(&send(&mut conn, &["EXPIRE", "exp", "10"]), ":1");
+    assert_has(&send(&mut conn, &["TTL", "exp"]), ":");
+    assert_has(&send(&mut conn, &["PTTL", "exp"]), ":");
+    assert_has(&send(&mut conn, &["EXPIRETIME", "exp"]), ":");
+    assert_has(&send(&mut conn, &["PEXPIRETIME", "exp"]), ":");
+    assert_has(&send(&mut conn, &["PERSIST", "exp"]), ":1");
+    assert_has(&send(&mut conn, &["TTL", "exp"]), ":-1");
+    assert_has(&send(&mut conn, &["PEXPIRE", "exp", "10000"]), ":1");
+    assert_has(
+        &send(&mut conn, &["PEXPIREAT", "exp", "9999999999999"]),
+        ":1",
+    );
+    assert_has(&send(&mut conn, &["EXPIREAT", "exp", "9999999999"]), ":1");
+}

--- a/tests/live_ws.rs
+++ b/tests/live_ws.rs
@@ -1,0 +1,254 @@
+mod common;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::Child;
+use std::time::Duration;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+
+type TestWs = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+struct LuxServer {
+    child: Child,
+    tmpdir: std::path::PathBuf,
+}
+
+impl Drop for LuxServer {
+    fn drop(&mut self) {
+        common::terminate_child(&mut self.child);
+        let _ = std::fs::remove_dir_all(&self.tmpdir);
+    }
+}
+
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn start_lux(resp_port: u16, http_port: u16, password: Option<&str>) -> LuxServer {
+    let bin = std::path::PathBuf::from(env!("CARGO_BIN_EXE_lux"));
+    let tmpdir = std::env::temp_dir().join(format!(
+        "lux_live_ws_test_{}_{}",
+        std::process::id(),
+        http_port
+    ));
+    let _ = std::fs::remove_dir_all(&tmpdir);
+    std::fs::create_dir_all(&tmpdir).unwrap();
+
+    let mut cmd = common::lux_command(&bin);
+    cmd.env("LUX_PORT", resp_port.to_string())
+        .env("LUX_HTTP_PORT", http_port.to_string())
+        .env("LUX_SHARDS", "4")
+        .env("LUX_SAVE_INTERVAL", "0")
+        .env("LUX_DATA_DIR", tmpdir.to_str().unwrap())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    if let Some(password) = password {
+        cmd.env("LUX_PASSWORD", password);
+    }
+
+    let child = cmd.spawn().expect("failed to start lux");
+    let server = LuxServer { child, tmpdir };
+    for _ in 0..80 {
+        if TcpStream::connect(("127.0.0.1", http_port)).is_ok()
+            && TcpStream::connect(("127.0.0.1", resp_port)).is_ok()
+        {
+            return server;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("lux did not start on resp={resp_port} http={http_port}");
+}
+
+async fn connect_live(http_port: u16, password: Option<&str>) -> TestWs {
+    let mut request = format!("ws://127.0.0.1:{http_port}/live")
+        .into_client_request()
+        .unwrap();
+    if let Some(password) = password {
+        request.headers_mut().insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {password}")).unwrap(),
+        );
+    }
+    let (ws, _) = connect_async(request).await.expect("websocket connect");
+    ws
+}
+
+async fn send_json(ws: &mut TestWs, value: Value) {
+    ws.send(Message::Text(value.to_string()))
+        .await
+        .expect("send websocket json");
+}
+
+async fn recv_json(ws: &mut TestWs) -> Value {
+    let message = tokio::time::timeout(Duration::from_secs(3), ws.next())
+        .await
+        .expect("timed out waiting for websocket message")
+        .expect("websocket closed")
+        .expect("websocket error");
+    match message {
+        Message::Text(text) => serde_json::from_str(&text).expect("websocket text should be json"),
+        other => panic!("expected websocket text, got {other:?}"),
+    }
+}
+
+async fn recv_live_event(ws: &mut TestWs, id: &str) -> Value {
+    loop {
+        let message = recv_json(ws).await;
+        if message.get("type").and_then(Value::as_str) == Some("live.event")
+            && message.get("id").and_then(Value::as_str) == Some(id)
+        {
+            return message["event"].clone();
+        }
+    }
+}
+
+fn resp_command(port: u16, args: &[&str]) -> String {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    let mut request = format!("*{}\r\n", args.len());
+    for arg in args {
+        request.push_str(&format!("${}\r\n{}\r\n", arg.len(), arg));
+    }
+    stream.write_all(request.as_bytes()).unwrap();
+
+    let mut response = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                response.extend_from_slice(&buf[..n]);
+                if n < buf.len() {
+                    break;
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => break,
+            Err(e) => panic!("RESP read failed: {e}"),
+        }
+    }
+    String::from_utf8_lossy(&response).to_string()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_websocket_requires_auth_when_password_is_set() {
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start_lux(resp_port, http_port, Some("secret"));
+
+    let err = connect_async(format!("ws://127.0.0.1:{http_port}/live"))
+        .await
+        .expect_err("unauthenticated websocket should be rejected");
+    assert!(err.to_string().contains("401"), "unexpected error: {err}");
+
+    let mut ws = connect_live(http_port, Some("secret")).await;
+    send_json(
+        &mut ws,
+        json!({"type":"live.subscribe","id":"k","spec":{"kind":"key","pattern":"auth:*"}}),
+    )
+    .await;
+    let subscribed = recv_json(&mut ws).await;
+    assert_eq!(subscribed["type"], "live.subscribed");
+    assert_eq!(subscribed["id"], "k");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_websocket_delivers_key_and_pubsub_events() {
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start_lux(resp_port, http_port, None);
+    let mut ws = connect_live(http_port, None).await;
+
+    send_json(
+        &mut ws,
+        json!({"type":"live.subscribe","id":"key-sub","spec":{"kind":"key","pattern":"bench:*"}}),
+    )
+    .await;
+    assert_eq!(recv_json(&mut ws).await["type"], "live.subscribed");
+
+    send_json(
+        &mut ws,
+        json!({"type":"live.subscribe","id":"pubsub-sub","spec":{"kind":"channel","channel":"room:1"}}),
+    )
+    .await;
+    assert_eq!(recv_json(&mut ws).await["type"], "live.subscribed");
+
+    assert!(resp_command(resp_port, &["SET", "bench:one", "1"]).contains("+OK"));
+    let key_event = recv_live_event(&mut ws, "key-sub").await;
+    assert_eq!(key_event["kind"], "key.set");
+    assert_eq!(key_event["key"], "bench:one");
+
+    assert!(resp_command(resp_port, &["PUBLISH", "room:1", "hello"]).contains(":1"));
+    let pubsub_event = recv_live_event(&mut ws, "pubsub-sub").await;
+    assert_eq!(pubsub_event["kind"], "pubsub.message");
+    assert_eq!(pubsub_event["channel"], "room:1");
+    assert_eq!(pubsub_event["message"], "hello");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_websocket_unsubscribe_stops_delivery() {
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start_lux(resp_port, http_port, None);
+    let mut ws = connect_live(http_port, None).await;
+
+    send_json(
+        &mut ws,
+        json!({"type":"live.subscribe","id":"key-sub","spec":{"kind":"key","pattern":"gone:*"}}),
+    )
+    .await;
+    assert_eq!(recv_json(&mut ws).await["type"], "live.subscribed");
+
+    send_json(&mut ws, json!({"type":"live.unsubscribe","id":"key-sub"})).await;
+    let unsubscribed = recv_json(&mut ws).await;
+    assert_eq!(unsubscribed["type"], "live.unsubscribed");
+    assert_eq!(unsubscribed["id"], "key-sub");
+
+    assert!(resp_command(resp_port, &["SET", "gone:one", "1"]).contains("+OK"));
+    let no_event = tokio::time::timeout(Duration::from_millis(250), ws.next()).await;
+    assert!(
+        no_event.is_err(),
+        "unsubscribed websocket received an event"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_websocket_vector_near_receives_vector_changes() {
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start_lux(resp_port, http_port, None);
+    let mut ws = connect_live(http_port, None).await;
+
+    send_json(
+        &mut ws,
+        json!({
+            "type":"live.subscribe",
+            "id":"near",
+            "spec":{"kind":"vector.near","vector":[1.0,0.0],"k":3,"threshold":0.5}
+        }),
+    )
+    .await;
+    assert_eq!(recv_json(&mut ws).await["type"], "live.subscribed");
+    let snapshot = recv_live_event(&mut ws, "near").await;
+    assert_eq!(snapshot["kind"], "snapshot");
+    assert_eq!(snapshot["rows"].as_array().unwrap().len(), 0);
+
+    assert!(resp_command(resp_port, &["VSET", "doc:1", "2", "1.0", "0.0"]).contains("+OK"));
+    let insert = recv_live_event(&mut ws, "near").await;
+    assert_eq!(insert["kind"], "insert");
+    assert_eq!(insert["cause"]["kind"], "vector.set");
+    assert_eq!(insert["cause"]["key"], "doc:1");
+}

--- a/tests/reliability.rs
+++ b/tests/reliability.rs
@@ -1,0 +1,357 @@
+mod common;
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::thread;
+use std::time::Duration;
+
+fn resp_cmd(args: &[&str]) -> Vec<u8> {
+    let mut buf = format!("*{}\r\n", args.len());
+    for arg in args {
+        buf.push_str(&format!("${}\r\n{}\r\n", arg.len(), arg));
+    }
+    buf.into_bytes()
+}
+
+fn read_response(reader: &mut BufReader<TcpStream>) -> String {
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    let line = line.trim_end().to_string();
+
+    if line.starts_with('+') || line.starts_with('-') || line.starts_with(':') {
+        return line;
+    }
+    if let Some(rest) = line.strip_prefix('$') {
+        let len: i64 = rest.parse().unwrap();
+        if len < 0 {
+            return "$-1".to_string();
+        }
+        let mut buf = vec![0u8; (len + 2) as usize];
+        reader.read_exact(&mut buf).expect("read bulk");
+        let s = String::from_utf8_lossy(&buf[..len as usize]).to_string();
+        return format!("${s}");
+    }
+    if let Some(rest) = line.strip_prefix('*') {
+        let count: i64 = rest.parse().unwrap();
+        if count < 0 {
+            return "*-1".to_string();
+        }
+        let mut items = Vec::new();
+        for _ in 0..count {
+            items.push(read_response(reader));
+        }
+        return format!("*{count} [{}]", items.join(", "));
+    }
+    line
+}
+
+fn send(stream: &mut TcpStream, args: &[&str]) -> String {
+    stream.write_all(&resp_cmd(args)).unwrap();
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    read_response(&mut reader)
+}
+
+fn connect(port: u16) -> TcpStream {
+    let stream = TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+    stream.set_nodelay(true).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    stream
+}
+
+fn wait_for_port(port: u16) {
+    for _ in 0..80 {
+        if TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("lux did not start on port {port}");
+}
+
+struct LuxServer {
+    port: u16,
+    child: std::process::Child,
+    tmpdir: std::path::PathBuf,
+}
+
+impl LuxServer {
+    fn start_tiered(port: u16, maxmemory: &str) -> Self {
+        let tmpdir =
+            std::env::temp_dir().join(format!("lux_reliability_{}_{}", std::process::id(), port));
+        let _ = std::fs::remove_dir_all(&tmpdir);
+        std::fs::create_dir_all(&tmpdir).unwrap();
+        let child = Self::spawn(port, &tmpdir, maxmemory);
+        wait_for_port(port);
+        Self {
+            port,
+            child,
+            tmpdir,
+        }
+    }
+
+    fn spawn(port: u16, tmpdir: &std::path::Path, maxmemory: &str) -> std::process::Child {
+        common::lux_command(env!("CARGO_BIN_EXE_lux"))
+            .env("LUX_PORT", port.to_string())
+            .env("LUX_SHARDS", "4")
+            .env("LUX_SAVE_INTERVAL", "0")
+            .env("LUX_MAXMEMORY", maxmemory)
+            .env("LUX_MAXMEMORY_POLICY", "allkeys-lru")
+            .env("LUX_STORAGE_MODE", "tiered")
+            .env("LUX_STORAGE_DIR", tmpdir.join("storage").to_str().unwrap())
+            .env("LUX_DATA_DIR", tmpdir.to_str().unwrap())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("failed to start lux")
+    }
+
+    fn conn(&self) -> TcpStream {
+        connect(self.port)
+    }
+
+    fn crash_and_restart(&mut self, maxmemory: &str) {
+        self.child.kill().ok();
+        self.child.wait().ok();
+        thread::sleep(Duration::from_millis(300));
+        self.child = Self::spawn(self.port, &self.tmpdir, maxmemory);
+        wait_for_port(self.port);
+    }
+}
+
+impl Drop for LuxServer {
+    fn drop(&mut self) {
+        common::terminate_child(&mut self.child);
+        let _ = std::fs::remove_dir_all(&self.tmpdir);
+    }
+}
+
+#[test]
+fn tiered_mixed_datatypes_survive_eviction_snapshot_wal_and_crash() {
+    let mut server = LuxServer::start_tiered(17850, "128kb");
+    let mut conn = server.conn();
+
+    assert_eq!(send(&mut conn, &["SET", "str", "alive"]), "+OK");
+    assert!(send(&mut conn, &["HSET", "hash", "a", "1", "b", "2"]).contains(":2"));
+    assert!(send(&mut conn, &["RPUSH", "list", "a", "b", "c"]).contains(":3"));
+    assert!(send(&mut conn, &["SADD", "set", "x", "y", "z"]).contains(":3"));
+    assert!(send(&mut conn, &["ZADD", "zset", "1.5", "alpha", "2.5", "beta"]).contains(":2"));
+    assert!(send(&mut conn, &["XADD", "stream", "1-0", "field", "value"]).contains("1-0"));
+    assert_eq!(
+        send(&mut conn, &["XGROUP", "CREATE", "stream", "g", "0"]),
+        "+OK"
+    );
+    let read = send(
+        &mut conn,
+        &["XREADGROUP", "GROUP", "g", "c", "STREAMS", "stream", ">"],
+    );
+    assert!(
+        read.contains("value"),
+        "stream pending setup failed: {read}"
+    );
+    assert!(send(&mut conn, &["PFADD", "hll", "a", "b", "c", "d"]).contains(":1"));
+    assert!(send(&mut conn, &["TSADD", "ts", "1000", "42.5"]).contains(":1000"));
+    assert_eq!(
+        send(
+            &mut conn,
+            &[
+                "VSET",
+                "vec",
+                "3",
+                "1.0",
+                "0.0",
+                "0.0",
+                "META",
+                r#"{"kind":"sentinel"}"#,
+            ],
+        ),
+        "+OK"
+    );
+
+    let filler = "x".repeat(8192);
+    for i in 0..80 {
+        assert_eq!(
+            send(&mut conn, &["SET", &format!("filler:{i}"), &filler]),
+            "+OK"
+        );
+    }
+
+    let cold = send(&mut conn, &["GET", "str"]);
+    assert!(
+        cold.contains("alive"),
+        "tiered cold read before restart: {cold}"
+    );
+
+    let save = send(&mut conn, &["SAVE"]);
+    assert!(save.contains("OK"), "SAVE failed before crash: {save}");
+
+    assert_eq!(
+        send(&mut conn, &["SET", "wal_only", "after_snapshot"]),
+        "+OK"
+    );
+    drop(conn);
+
+    server.crash_and_restart("20mb");
+    let mut conn = server.conn();
+
+    assert!(send(&mut conn, &["GET", "str"]).contains("alive"));
+    assert!(send(&mut conn, &["HGET", "hash", "b"]).contains("2"));
+    assert!(send(&mut conn, &["LRANGE", "list", "0", "-1"]).contains("c"));
+    assert!(send(&mut conn, &["SISMEMBER", "set", "y"]).contains(":1"));
+    assert!(send(&mut conn, &["ZSCORE", "zset", "beta"]).contains("2.5"));
+    assert!(send(&mut conn, &["XLEN", "stream"]).contains(":1"));
+    assert!(send(&mut conn, &["XPENDING", "stream", "g"]).contains(":1"));
+    assert!(send(&mut conn, &["PFCOUNT", "hll"]).contains(":4"));
+    assert!(send(&mut conn, &["TSGET", "ts"]).contains("42.5"));
+    assert!(send(&mut conn, &["VGET", "vec"]).contains("sentinel"));
+    assert!(send(&mut conn, &["GET", "wal_only"]).contains("after_snapshot"));
+}
+
+#[test]
+fn malformed_resp_storm_does_not_crash_server() {
+    let server = LuxServer::start_tiered(17851, "1mb");
+
+    for i in 0..250 {
+        let mut conn = server.conn();
+        let payload = match i % 5 {
+            0 => b"*3\r\n$3\r\nSET\r\n$1\r\na\r\n$999\r\nshort\r\n".to_vec(),
+            1 => b"*2\r\n$4\r\nHSET\r\n$1\r\nh\r\n".to_vec(),
+            2 => b"*4\r\n$4\r\nXADD\r\n$1\r\ns\r\n$6\r\nbad-id\r\n$1\r\nf\r\n".to_vec(),
+            3 => vec![0xff, 0x00, b'*', b'9', b'\r', b'\n', b'?', b'\r', b'\n'],
+            _ => format!("not resp at all {i}\r\n").into_bytes(),
+        };
+        let _ = conn.write_all(&payload);
+    }
+
+    let mut conn = server.conn();
+    let pong = send(&mut conn, &["PING"]);
+    assert_eq!(
+        pong, "+PONG",
+        "server stopped responding after malformed storm"
+    );
+
+    let ok = send(&mut conn, &["SET", "still", "works"]);
+    assert_eq!(ok, "+OK", "server should still accept normal writes");
+    assert!(send(&mut conn, &["GET", "still"]).contains("works"));
+}
+
+#[test]
+fn malformed_resp_protocol_error_closes_only_bad_connection() {
+    let server = LuxServer::start_tiered(17857, "1mb");
+    let mut bad = server.conn();
+    bad.write_all(b"*1048577\r\n").unwrap();
+
+    let mut reader = BufReader::new(bad.try_clone().unwrap());
+    let error = read_response(&mut reader);
+    assert!(
+        error.contains("RESP array count exceeds maximum"),
+        "malformed client should receive protocol error, got: {error}"
+    );
+
+    let mut good = server.conn();
+    assert_eq!(send(&mut good, &["PING"]), "+PONG");
+    assert_eq!(send(&mut good, &["SET", "after_bad_resp", "ok"]), "+OK");
+    assert!(send(&mut good, &["GET", "after_bad_resp"]).contains("ok"));
+}
+
+fn manual_snapshot_command_does_not_double_replay_wal(port: u16, command: &str) {
+    let mut server = LuxServer::start_tiered(port, "1mb");
+    let mut conn = server.conn();
+
+    for _ in 0..10 {
+        assert!(send(&mut conn, &["INCR", "counter"]).starts_with(':'));
+    }
+    let before = send(&mut conn, &["GET", "counter"]);
+    assert!(before.contains("10"), "counter before snapshot: {before}");
+
+    let snapshot = send(&mut conn, &[command]);
+    assert!(
+        snapshot.contains("OK") || snapshot.contains("Background saving started"),
+        "{command} failed: {snapshot}"
+    );
+    drop(conn);
+
+    server.crash_and_restart("1mb");
+    let mut conn = server.conn();
+    let after = send(&mut conn, &["GET", "counter"]);
+    assert!(
+        after.contains("10"),
+        "{command} must not leave stale WAL frames that double-apply INCR after restart: {after}"
+    );
+}
+
+#[test]
+fn manual_save_truncates_wal_after_successful_snapshot() {
+    manual_snapshot_command_does_not_double_replay_wal(17853, "SAVE");
+}
+
+#[test]
+fn manual_bgsave_truncates_wal_after_successful_snapshot() {
+    manual_snapshot_command_does_not_double_replay_wal(17854, "BGSAVE");
+}
+
+#[test]
+fn concurrent_tiered_writers_survive_restart_with_consistent_counter() {
+    let mut server = LuxServer::start_tiered(17852, "256kb");
+    let addr = format!("127.0.0.1:{}", server.port);
+    let workers = 6;
+    let per_worker = 80;
+
+    let handles: Vec<_> = (0..workers)
+        .map(|worker| {
+            let addr = addr.clone();
+            thread::spawn(move || {
+                let mut conn = TcpStream::connect(addr).unwrap();
+                conn.set_nodelay(true).unwrap();
+                conn.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+                for i in 0..per_worker {
+                    let key = format!("w:{worker}:{i}");
+                    assert_eq!(
+                        send(&mut conn, &["SET", &key, &format!("value:{worker}:{i}")]),
+                        "+OK"
+                    );
+                    assert!(send(
+                        &mut conn,
+                        &["HSET", &format!("h:{worker}"), &i.to_string(), "v"]
+                    )
+                    .starts_with(':'));
+                    assert!(
+                        send(&mut conn, &["SADD", &format!("s:{worker}"), &i.to_string()])
+                            .starts_with(':')
+                    );
+                    assert!(send(&mut conn, &["INCR", "global_counter"]).starts_with(':'));
+                    if i % 10 == 0 {
+                        assert!(send(&mut conn, &["GET", &key]).contains("value"));
+                    }
+                }
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let mut conn = server.conn();
+    let expected = (workers * per_worker).to_string();
+    let before_restart_counter = send(&mut conn, &["GET", "global_counter"]);
+    assert!(
+        before_restart_counter.contains(&expected),
+        "counter should include all concurrent increments before restart; expected {expected}, got {before_restart_counter}"
+    );
+    assert!(send(&mut conn, &["SAVE"]).contains("OK"));
+    drop(conn);
+
+    server.crash_and_restart("20mb");
+    let mut conn = server.conn();
+    let after_restart_counter = send(&mut conn, &["GET", "global_counter"]);
+    assert!(
+        after_restart_counter.contains(&expected),
+        "counter should survive restart; expected {expected}, got {after_restart_counter}"
+    );
+    assert!(send(&mut conn, &["GET", "w:0:0"]).contains("value:0:0"));
+    assert!(send(&mut conn, &["GET", "w:5:79"]).contains("value:5:79"));
+    assert!(send(&mut conn, &["HLEN", "h:3"]).contains(":80"));
+    assert!(send(&mut conn, &["SCARD", "s:4"]).contains(":80"));
+}

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -1,0 +1,235 @@
+mod common;
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::thread;
+use std::time::Duration;
+
+fn resp_cmd(args: &[&str]) -> Vec<u8> {
+    let mut buf = format!("*{}\r\n", args.len());
+    for arg in args {
+        buf.push_str(&format!("${}\r\n{}\r\n", arg.len(), arg));
+    }
+    buf.into_bytes()
+}
+
+fn read_all(stream: &mut TcpStream) -> String {
+    let mut data = Vec::with_capacity(4096);
+    let mut buf = [0u8; 8192];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(len) => data.extend_from_slice(&buf[..len]),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => break,
+            Err(_) => break,
+        }
+    }
+    String::from_utf8_lossy(&data).to_string()
+}
+
+fn send_and_read(stream: &mut TcpStream, args: &[&str]) -> String {
+    stream.write_all(&resp_cmd(args)).unwrap();
+    thread::sleep(Duration::from_millis(50));
+    read_all(stream)
+}
+
+fn pos(resp: &str, value: &str) -> usize {
+    resp.find(&format!("\r\n{value}\r\n"))
+        .unwrap_or_else(|| panic!("missing bulk payload {value:?}: {resp}"))
+}
+
+struct LuxServer {
+    child: std::process::Child,
+    tmpdir: std::path::PathBuf,
+}
+
+impl Drop for LuxServer {
+    fn drop(&mut self) {
+        common::terminate_child(&mut self.child);
+        let _ = std::fs::remove_dir_all(&self.tmpdir);
+    }
+}
+
+fn start_lux(port: u16) -> LuxServer {
+    let tmpdir =
+        std::env::temp_dir().join(format!("lux_sort_test_{}_{}", std::process::id(), port));
+    std::fs::create_dir_all(&tmpdir).unwrap();
+    let child = common::lux_command(env!("CARGO_BIN_EXE_lux"))
+        .env("LUX_PORT", port.to_string())
+        .env("LUX_SHARDS", "4")
+        .env("LUX_SAVE_INTERVAL", "0")
+        .env("LUX_DATA_DIR", tmpdir.to_str().unwrap())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start lux");
+
+    let server = LuxServer { child, tmpdir };
+    for _ in 0..40 {
+        if TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            return server;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("lux did not start on port {port}");
+}
+
+fn connect(port: u16) -> TcpStream {
+    let stream = TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+    stream.set_nodelay(true).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .unwrap();
+    stream
+}
+
+#[test]
+fn sort_numeric_desc_and_limit() {
+    let port = 17800;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    send_and_read(&mut conn, &["RPUSH", "nums", "3", "1", "2", "10"]);
+    let resp = send_and_read(&mut conn, &["SORT", "nums", "DESC", "LIMIT", "1", "2"]);
+    assert!(
+        resp.contains("*2"),
+        "LIMIT should return two elements: {resp}"
+    );
+    assert!(
+        pos(&resp, "3") < pos(&resp, "2"),
+        "DESC numeric order: {resp}"
+    );
+}
+
+#[test]
+fn sort_alpha_set_members() {
+    let port = 17801;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    send_and_read(&mut conn, &["SADD", "words", "pear", "apple", "banana"]);
+    let resp = send_and_read(&mut conn, &["SORT", "words", "ALPHA"]);
+    assert!(
+        pos(&resp, "apple") < pos(&resp, "banana"),
+        "ALPHA should sort lexically: {resp}"
+    );
+    assert!(
+        pos(&resp, "banana") < pos(&resp, "pear"),
+        "ALPHA should sort lexically: {resp}"
+    );
+}
+
+#[test]
+fn sort_by_external_weights_and_get_hash_fields() {
+    let port = 17802;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    send_and_read(&mut conn, &["RPUSH", "ids", "1", "2", "3"]);
+    send_and_read(&mut conn, &["SET", "weight:1", "30"]);
+    send_and_read(&mut conn, &["SET", "weight:2", "10"]);
+    send_and_read(&mut conn, &["SET", "weight:3", "20"]);
+    send_and_read(&mut conn, &["HSET", "user:1", "name", "Ada"]);
+    send_and_read(&mut conn, &["HSET", "user:2", "name", "Linus"]);
+    send_and_read(&mut conn, &["HSET", "user:3", "name", "Grace"]);
+
+    let resp = send_and_read(
+        &mut conn,
+        &[
+            "SORT",
+            "ids",
+            "BY",
+            "weight:*",
+            "GET",
+            "#",
+            "GET",
+            "user:*->name",
+        ],
+    );
+    assert!(
+        pos(&resp, "2") < pos(&resp, "Linus"),
+        "GET # and hash field should be paired for id 2 first: {resp}"
+    );
+    assert!(
+        pos(&resp, "Linus") < pos(&resp, "3"),
+        "weight order: {resp}"
+    );
+    assert!(
+        pos(&resp, "Grace") < pos(&resp, "1"),
+        "weight order: {resp}"
+    );
+}
+
+#[test]
+fn sort_store_writes_list_and_sort_ro_rejects_store() {
+    let port = 17803;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    send_and_read(&mut conn, &["RPUSH", "nums", "4", "2", "3"]);
+    let stored = send_and_read(&mut conn, &["SORT", "nums", "STORE", "sorted:nums"]);
+    assert!(
+        stored.contains(":3"),
+        "STORE should write three elements: {stored}"
+    );
+
+    let range = send_and_read(&mut conn, &["LRANGE", "sorted:nums", "0", "-1"]);
+    assert!(
+        pos(&range, "2") < pos(&range, "3"),
+        "stored list should be sorted: {range}"
+    );
+
+    let readonly = send_and_read(&mut conn, &["SORT_RO", "nums", "STORE", "bad"]);
+    assert!(
+        readonly.contains("ERR syntax error"),
+        "SORT_RO STORE must be rejected: {readonly}"
+    );
+}
+
+#[test]
+fn sort_rejects_invalid_limit_without_writing_store_destination() {
+    let port = 17805;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    send_and_read(&mut conn, &["RPUSH", "nums", "4", "2", "3"]);
+    send_and_read(&mut conn, &["RPUSH", "dest", "original"]);
+
+    for cmd in [
+        vec!["SORT", "nums", "LIMIT", "nope", "1", "STORE", "dest"],
+        vec!["SORT", "nums", "LIMIT", "0", "nope", "STORE", "dest"],
+        vec!["SORT", "nums", "LIMIT", "-1", "1", "STORE", "dest"],
+        vec!["SORT", "nums", "LIMIT", "0", "-1", "STORE", "dest"],
+    ] {
+        let resp = send_and_read(&mut conn, &cmd);
+        assert!(
+            resp.starts_with("-ERR"),
+            "expected error for {cmd:?}, got: {resp}"
+        );
+    }
+
+    let range = send_and_read(&mut conn, &["LRANGE", "dest", "0", "-1"]);
+    assert!(
+        range.contains("original"),
+        "invalid SORT STORE should not replace destination: {range}"
+    );
+}
+
+#[test]
+fn sort_reports_wrongtype_and_numeric_conversion_errors() {
+    let port = 17804;
+    let _server = start_lux(port);
+    let mut conn = connect(port);
+
+    send_and_read(&mut conn, &["SET", "plain", "value"]);
+    let wrongtype = send_and_read(&mut conn, &["SORT", "plain"]);
+    assert!(wrongtype.contains("WRONGTYPE"), "wrong type: {wrongtype}");
+
+    send_and_read(&mut conn, &["RPUSH", "badnums", "a", "b"]);
+    let numeric = send_and_read(&mut conn, &["SORT", "badnums"]);
+    assert!(
+        numeric.contains("can't be converted into double"),
+        "non-numeric sort should fail without ALPHA: {numeric}"
+    );
+}

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -1,0 +1,512 @@
+mod common;
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+#[derive(Clone, Debug, PartialEq)]
+enum Resp {
+    Simple(String),
+    Error(String),
+    Int(i64),
+    Bulk(Option<String>),
+    Array(Vec<Resp>),
+}
+
+fn resp_cmd(args: &[String]) -> Vec<u8> {
+    let mut buf = format!("*{}\r\n", args.len()).into_bytes();
+    for arg in args {
+        buf.extend_from_slice(format!("${}\r\n", arg.len()).as_bytes());
+        buf.extend_from_slice(arg.as_bytes());
+        buf.extend_from_slice(b"\r\n");
+    }
+    buf
+}
+
+fn read_resp(reader: &mut BufReader<TcpStream>) -> Resp {
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read response line");
+    let line = line.trim_end_matches(['\r', '\n']).to_string();
+    let Some(prefix) = line.as_bytes().first().copied() else {
+        panic!("empty RESP line");
+    };
+    match prefix {
+        b'+' => Resp::Simple(line[1..].to_string()),
+        b'-' => Resp::Error(line[1..].to_string()),
+        b':' => Resp::Int(line[1..].parse().expect("integer response")),
+        b'$' => {
+            let len: i64 = line[1..].parse().expect("bulk length");
+            if len < 0 {
+                Resp::Bulk(None)
+            } else {
+                let mut data = vec![0u8; len as usize + 2];
+                reader.read_exact(&mut data).expect("read bulk body");
+                Resp::Bulk(Some(
+                    String::from_utf8_lossy(&data[..len as usize]).to_string(),
+                ))
+            }
+        }
+        b'*' => {
+            let len: i64 = line[1..].parse().expect("array length");
+            if len < 0 {
+                Resp::Array(Vec::new())
+            } else {
+                let mut values = Vec::with_capacity(len as usize);
+                for _ in 0..len {
+                    values.push(read_resp(reader));
+                }
+                Resp::Array(values)
+            }
+        }
+        _ => panic!("unexpected RESP line: {line:?}"),
+    }
+}
+
+fn send(conn: &mut TcpStream, args: &[String]) -> Resp {
+    conn.write_all(&resp_cmd(args)).expect("write command");
+    let mut reader = BufReader::new(conn.try_clone().expect("clone connection"));
+    read_resp(&mut reader)
+}
+
+fn cmd(args: &[&str]) -> Vec<String> {
+    args.iter().map(|s| s.to_string()).collect()
+}
+
+fn wait_for_port(port: u16) {
+    for _ in 0..80 {
+        if TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("lux did not start on port {port}");
+}
+
+struct LuxServer {
+    port: u16,
+    child: std::process::Child,
+    tmpdir: std::path::PathBuf,
+}
+
+impl LuxServer {
+    fn start(port: u16, tiered: bool) -> Self {
+        let tmpdir = std::env::temp_dir().join(format!(
+            "lux_stress_{}_{}_{}",
+            std::process::id(),
+            port,
+            if tiered { "tiered" } else { "memory" }
+        ));
+        let _ = std::fs::remove_dir_all(&tmpdir);
+        std::fs::create_dir_all(&tmpdir).unwrap();
+        let child = Self::spawn(port, &tmpdir, tiered);
+        wait_for_port(port);
+        Self {
+            port,
+            child,
+            tmpdir,
+        }
+    }
+
+    fn spawn(port: u16, tmpdir: &std::path::Path, tiered: bool) -> std::process::Child {
+        let mut command = common::lux_command(env!("CARGO_BIN_EXE_lux"));
+        command
+            .env("LUX_PORT", port.to_string())
+            .env("LUX_SHARDS", "4")
+            .env("LUX_SAVE_INTERVAL", "0")
+            .env("LUX_DATA_DIR", tmpdir.to_str().unwrap())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        if tiered {
+            command
+                .env("LUX_STORAGE_MODE", "tiered")
+                .env("LUX_STORAGE_DIR", tmpdir.join("storage").to_str().unwrap())
+                .env("LUX_MAXMEMORY", "256kb")
+                .env("LUX_MAXMEMORY_POLICY", "allkeys-lru");
+        }
+        command.spawn().expect("failed to start lux")
+    }
+
+    fn conn(&self) -> TcpStream {
+        let stream = TcpStream::connect(format!("127.0.0.1:{}", self.port)).unwrap();
+        stream.set_nodelay(true).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        stream
+    }
+
+    fn restart(&mut self, tiered: bool) {
+        common::terminate_child(&mut self.child);
+        self.child = Self::spawn(self.port, &self.tmpdir, tiered);
+        wait_for_port(self.port);
+    }
+
+    fn crash_and_restart(&mut self, tiered: bool) {
+        self.child.kill().ok();
+        self.child.wait().ok();
+        self.child = Self::spawn(self.port, &self.tmpdir, tiered);
+        wait_for_port(self.port);
+    }
+}
+
+impl Drop for LuxServer {
+    fn drop(&mut self) {
+        common::terminate_child(&mut self.child);
+        let _ = std::fs::remove_dir_all(&self.tmpdir);
+    }
+}
+
+#[derive(Default)]
+struct Model {
+    strings: BTreeMap<String, String>,
+    counters: BTreeMap<String, i64>,
+    hashes: BTreeMap<String, BTreeMap<String, String>>,
+    sets: BTreeMap<String, BTreeSet<String>>,
+    lists: BTreeMap<String, VecDeque<String>>,
+}
+
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0
+    }
+
+    fn usize(&mut self, max: usize) -> usize {
+        (self.next() as usize) % max
+    }
+}
+
+fn assert_resp(actual: Resp, expected: Resp, op: usize, command: &[String], seed: u64) {
+    assert_eq!(
+        actual, expected,
+        "stress mismatch at op {op}, seed {seed}, command {command:?}"
+    );
+}
+
+fn assert_command(
+    lux: &mut TcpStream,
+    redis: Option<&mut TcpStream>,
+    command: &[String],
+    expected: Resp,
+    op: usize,
+    seed: u64,
+) {
+    assert_resp(send(lux, command), expected.clone(), op, command, seed);
+    if let Some(redis) = redis {
+        assert_resp(send(redis, command), expected, op, command, seed);
+    }
+}
+
+fn redis_addr_from_env() -> Option<String> {
+    if std::env::var("LUX_STRESS_DIFF_REDIS").ok().as_deref() != Some("1") {
+        return None;
+    }
+    let raw = std::env::var("REDIS_URL").unwrap_or_else(|_| "127.0.0.1:6379".to_string());
+    Some(
+        raw.trim_start_matches("redis://")
+            .trim_end_matches('/')
+            .to_string(),
+    )
+}
+
+fn run_model_stress(seed: u64, port: u16, tiered: bool, redis_addr: Option<String>) {
+    let iters: usize = std::env::var("LUX_STRESS_ITERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2_000);
+    let prefix = format!("stress:{seed:x}:{}:", std::process::id());
+    let mut rng = Rng::new(seed);
+    let mut model = Model::default();
+    let mut server = LuxServer::start(port, tiered);
+    let mut conn = server.conn();
+    let mut redis = redis_addr.map(|addr| {
+        let stream = TcpStream::connect(&addr)
+            .unwrap_or_else(|e| panic!("failed to connect to Redis/Valkey at {addr}: {e}"));
+        stream.set_nodelay(true).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        stream
+    });
+
+    for op in 0..iters {
+        match rng.usize(14) {
+            0 => {
+                let key = format!("{prefix}str:{}", rng.usize(32));
+                let value = format!("v:{}:{}", op, rng.usize(10_000));
+                let command = vec!["SET".into(), key.clone(), value.clone()];
+                model.strings.insert(key, value);
+                assert_command(
+                    &mut conn,
+                    redis.as_mut(),
+                    &command,
+                    Resp::Simple("OK".into()),
+                    op,
+                    seed,
+                );
+            }
+            1 => {
+                let key = format!("{prefix}str:{}", rng.usize(32));
+                let expected = Resp::Bulk(model.strings.get(&key).cloned());
+                let command = vec!["GET".into(), key];
+                assert_command(&mut conn, redis.as_mut(), &command, expected, op, seed);
+            }
+            2 => {
+                let key = format!("{prefix}ctr:{}", rng.usize(16));
+                let next = model.counters.entry(key.clone()).or_insert(0);
+                *next += 1;
+                let command = vec!["INCR".into(), key];
+                assert_command(
+                    &mut conn,
+                    redis.as_mut(),
+                    &command,
+                    Resp::Int(*next),
+                    op,
+                    seed,
+                );
+            }
+            3 => {
+                let key = format!("{prefix}hash:{}", rng.usize(16));
+                let field = format!("f{}", rng.usize(16));
+                let value = format!("hv:{}:{}", op, rng.usize(10_000));
+                let hash = model.hashes.entry(key.clone()).or_default();
+                let is_new = !hash.contains_key(&field);
+                hash.insert(field.clone(), value.clone());
+                let command = vec!["HSET".into(), key, field, value];
+                assert_command(
+                    &mut conn,
+                    redis.as_mut(),
+                    &command,
+                    Resp::Int(if is_new { 1 } else { 0 }),
+                    op,
+                    seed,
+                );
+            }
+            4 => {
+                let key = format!("{prefix}hash:{}", rng.usize(16));
+                let field = format!("f{}", rng.usize(16));
+                let expected =
+                    Resp::Bulk(model.hashes.get(&key).and_then(|h| h.get(&field)).cloned());
+                let command = vec!["HGET".into(), key, field];
+                assert_command(&mut conn, redis.as_mut(), &command, expected, op, seed);
+            }
+            5 => {
+                let key = format!("{prefix}set:{}", rng.usize(16));
+                let member = format!("m{}", rng.usize(64));
+                let set = model.sets.entry(key.clone()).or_default();
+                let added = set.insert(member.clone());
+                let command = vec!["SADD".into(), key, member];
+                assert_command(
+                    &mut conn,
+                    redis.as_mut(),
+                    &command,
+                    Resp::Int(if added { 1 } else { 0 }),
+                    op,
+                    seed,
+                );
+            }
+            6 => {
+                let key = format!("{prefix}set:{}", rng.usize(16));
+                let member = format!("m{}", rng.usize(64));
+                let exists = model
+                    .sets
+                    .get(&key)
+                    .is_some_and(|set| set.contains(&member));
+                let command = vec!["SISMEMBER".into(), key, member];
+                assert_command(
+                    &mut conn,
+                    redis.as_mut(),
+                    &command,
+                    Resp::Int(if exists { 1 } else { 0 }),
+                    op,
+                    seed,
+                );
+            }
+            7 | 8 => {
+                let key = format!("{prefix}list:{}", rng.usize(16));
+                let value = format!("lv:{}:{}", op, rng.usize(10_000));
+                let list = model.lists.entry(key.clone()).or_default();
+                let left = rng.usize(2) == 0;
+                if left {
+                    list.push_front(value.clone());
+                } else {
+                    list.push_back(value.clone());
+                }
+                let command = vec![if left { "LPUSH" } else { "RPUSH" }.into(), key, value];
+                assert_command(
+                    &mut conn,
+                    redis.as_mut(),
+                    &command,
+                    Resp::Int(list.len() as i64),
+                    op,
+                    seed,
+                );
+            }
+            9 => {
+                let key = format!("{prefix}list:{}", rng.usize(16));
+                let left = rng.usize(2) == 0;
+                let expected = model.lists.get_mut(&key).and_then(|list| {
+                    if left {
+                        list.pop_front()
+                    } else {
+                        list.pop_back()
+                    }
+                });
+                let command = vec![if left { "LPOP" } else { "RPOP" }.into(), key];
+                assert_command(
+                    &mut conn,
+                    redis.as_mut(),
+                    &command,
+                    Resp::Bulk(expected),
+                    op,
+                    seed,
+                );
+            }
+            10 => {
+                let key = format!("{prefix}str:{}", rng.usize(32));
+                let existed = model.strings.remove(&key).is_some();
+                let command = vec!["DEL".into(), key];
+                assert_command(
+                    &mut conn,
+                    redis.as_mut(),
+                    &command,
+                    Resp::Int(if existed { 1 } else { 0 }),
+                    op,
+                    seed,
+                );
+            }
+            11 => {
+                let key = format!("{prefix}ctr:{}", rng.usize(16));
+                let existed = model.counters.remove(&key).is_some();
+                let command = vec!["DEL".into(), key];
+                assert_command(
+                    &mut conn,
+                    redis.as_mut(),
+                    &command,
+                    Resp::Int(if existed { 1 } else { 0 }),
+                    op,
+                    seed,
+                );
+            }
+            12 => {
+                let key = format!("{prefix}hash:{}", rng.usize(16));
+                let existed = model.hashes.remove(&key).is_some();
+                let command = vec!["DEL".into(), key];
+                assert_command(
+                    &mut conn,
+                    redis.as_mut(),
+                    &command,
+                    Resp::Int(if existed { 1 } else { 0 }),
+                    op,
+                    seed,
+                );
+            }
+            _ => {
+                let crashed = tiered && rng.usize(2) == 0;
+                drop(conn);
+                if crashed {
+                    server.crash_and_restart(tiered);
+                } else {
+                    conn = server.conn();
+                    let save = cmd(&["SAVE"]);
+                    let saved = send(&mut conn, &save);
+                    assert!(
+                        matches!(saved, Resp::Simple(_)),
+                        "SAVE failed at op {op}, seed {seed}: {saved:?}"
+                    );
+                    drop(conn);
+                    server.restart(tiered);
+                }
+                conn = server.conn();
+                verify_model(&mut conn, &model, seed);
+            }
+        }
+    }
+
+    verify_model(&mut conn, &model, seed);
+}
+
+fn verify_model(conn: &mut TcpStream, model: &Model, seed: u64) {
+    for (key, value) in &model.strings {
+        let command = vec!["GET".into(), key.clone()];
+        assert_resp(
+            send(conn, &command),
+            Resp::Bulk(Some(value.clone())),
+            usize::MAX,
+            &command,
+            seed,
+        );
+    }
+    for (key, value) in &model.counters {
+        let command = vec!["GET".into(), key.clone()];
+        assert_resp(
+            send(conn, &command),
+            Resp::Bulk(Some(value.to_string())),
+            usize::MAX,
+            &command,
+            seed,
+        );
+    }
+    for (key, hash) in &model.hashes {
+        for (field, value) in hash {
+            let command = vec!["HGET".into(), key.clone(), field.clone()];
+            assert_resp(
+                send(conn, &command),
+                Resp::Bulk(Some(value.clone())),
+                usize::MAX,
+                &command,
+                seed,
+            );
+        }
+    }
+    for (key, set) in &model.sets {
+        for member in set {
+            let command = vec!["SISMEMBER".into(), key.clone(), member.clone()];
+            assert_resp(
+                send(conn, &command),
+                Resp::Int(1),
+                usize::MAX,
+                &command,
+                seed,
+            );
+        }
+    }
+    for (key, list) in &model.lists {
+        let command = vec!["LRANGE".into(), key.clone(), "0".into(), "-1".into()];
+        let expected = Resp::Array(
+            list.iter()
+                .map(|value| Resp::Bulk(Some(value.clone())))
+                .collect(),
+        );
+        assert_resp(send(conn, &command), expected, usize::MAX, &command, seed);
+    }
+}
+
+#[test]
+fn deterministic_model_stress_memory_mode() {
+    run_model_stress(0x5154_4c55_584d_454d, 17920, false, None);
+}
+
+#[test]
+fn deterministic_model_stress_tiered_mode() {
+    run_model_stress(0x5154_4c55_5854_4945, 17921, true, None);
+}
+
+#[test]
+fn optional_redis_differential_core_subset() {
+    let Some(redis_addr) = redis_addr_from_env() else {
+        eprintln!("skipping Redis/Valkey differential stress; set LUX_STRESS_DIFF_REDIS=1");
+        return;
+    };
+    run_model_stress(0x5154_4c55_5844_4946, 17922, false, Some(redis_addr));
+}

--- a/tests/tables.rs
+++ b/tests/tables.rs
@@ -1,6 +1,8 @@
 use std::io::{BufRead, BufReader, Read as IoRead, Write};
 use std::net::{TcpListener, TcpStream};
 use std::process::{Child, Command};
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 fn start_server(port: u16) -> Child {
@@ -26,11 +28,15 @@ fn start_server(port: u16) -> Child {
 }
 
 fn alloc_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("bind ephemeral port")
-        .local_addr()
-        .expect("ephemeral socket should have local addr")
-        .port()
+    static NEXT_PORT: OnceLock<AtomicU16> = OnceLock::new();
+    let start = 20_000 + (std::process::id() % 20_000) as u16;
+    let next = NEXT_PORT.get_or_init(|| AtomicU16::new(start));
+    loop {
+        let port = next.fetch_add(1, Ordering::Relaxed);
+        if TcpListener::bind(("127.0.0.1", port)).is_ok() {
+            return port;
+        }
+    }
 }
 
 fn wait_for_port(port: u16) {


### PR DESCRIPTION
## Summary
- Harden core command and data handling across strings, collections, sorting, snapshots, disk, and eviction paths
- Add native /live websocket subscriptions for keys, pub/sub, table queries, and vector.near queries
- Add focused regression, stress, and websocket integration coverage
- Bump Lux to 0.13.0

## Verification
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test -- --skip fuzz
- cargo test --test live_ws

## Release note
Release candidate for `v0.13.0`