### PR TITLE
fix(sdk): improve browser sdk

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -12,10 +12,14 @@ bun i @luxdb/sdk
 
 ## Browser app client
 
-Use a publishable key in browser code. The browser client persists auth sessions in browser storage by default.
+Use a publishable key in browser code. The browser client persists auth sessions
+in the shared `lux-auth-session` cookie by default.
+Like Supabase's SSR client, `createBrowserClient` returns a singleton in browser
+environments, broadcasts auth changes across tabs, and recovers the cookie-backed
+session when the document becomes visible.
 
 ```ts
-import { createBrowserClient } from "@luxdb/sdk";
+import { createBrowserClient } from "@luxdb/sdk/browser";
 
 const lux = createBrowserClient(
   "https://api.luxdb.dev/v1/my-project",
@@ -251,9 +255,12 @@ const { data: users, error } = await admin.auth.listUsers();
 ## SSR client
 
 Use `createServerClient` with your framework's cookie methods to persist sessions on the server.
+The SSR and browser clients share the `lux-auth-session` cookie by default, so a
+session created in a SvelteKit action is available to the browser client after
+the response is applied.
 
 ```ts
-import { createServerClient } from "@luxdb/sdk";
+import { createServerClient } from "@luxdb/sdk/ssr";
 
 const lux = createServerClient(
   "https://api.luxdb.dev/v1/my-project",
@@ -261,6 +268,35 @@ const lux = createServerClient(
   { cookies }
 );
 ```
+
+In SvelteKit, create the server client with the request-local `cookies` object:
+
+```ts
+// src/hooks.server.ts or +page.server.ts
+const lux = createServerClient(url, publishableKey, {
+  cookies: {
+    getAll: () => cookies.getAll(),
+    setAll: (cookiesToSet) => {
+      cookiesToSet.forEach(({ name, value, options }) => {
+        cookies.set(name, value, options);
+      });
+    },
+  },
+});
+```
+
+`setAll` batches cookie updates and every item always includes concrete cookie
+options. When your framework adapter also controls response headers, apply the
+second `headers` argument to the response; Lux supplies private/no-store headers
+for responses that update auth cookies.
+
+On server contexts that can only read request cookies, `setAll` may be omitted.
+The client can read the existing session, but sign-in, refresh, and sign-out
+cookie changes cannot be persisted from that context.
+
+The default session cookie is intentionally not `HttpOnly`, because the browser
+client must read it and refresh the session. Override `auth.storage` on the
+browser client if you want a different persistence strategy.
 
 ## Direct Lux/Redis-compatible access
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -10,7 +10,8 @@
             "browser": {
                 "types": "./dist/types/index.browser.d.ts",
                 "import": "./dist/esm/index.browser.js",
-                "require": "./dist/cjs/index.browser.js"
+                "require": "./dist/cjs/index.browser.js",
+                "default": "./dist/esm/index.browser.js"
             },
             "types": "./dist/types/index.d.ts",
             "import": "./dist/esm/index.js",
@@ -41,6 +42,10 @@
             "require": "./dist/cjs/ssr.js",
             "default": "./dist/esm/ssr.js"
         }
+    },
+    "browser": {
+        "./dist/esm/index.js": "./dist/esm/index.browser.js",
+        "./dist/cjs/index.js": "./dist/cjs/index.browser.js"
     },
     "files": ["dist"],
     "scripts": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@luxdb/sdk",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "Official Lux TypeScript SDK for app data, auth, tables, vectors, realtime, and Redis-compatible direct access",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",

--- a/sdk/src/auth.ts
+++ b/sdk/src/auth.ts
@@ -117,8 +117,8 @@ export interface LuxAuthSession {
 }
 
 export interface LuxAuthSessionResult {
-	session: LuxAuthSession | null;
-	user: LuxAuthUser | null;
+	session: LuxAuthSession;
+	user: LuxAuthUser;
 }
 
 export interface LuxAuthKey {
@@ -218,8 +218,13 @@ export class LuxAuthClient {
 	private refreshMarginSeconds: number;
 	private currentSession: LuxAuthSession | null = null;
 	private loadedSession = false;
+	private storedSessionRaw: string | null = null;
 	private refreshTimer: ReturnType<typeof setTimeout> | null = null;
 	private listeners = new Set<LuxAuthStateChangeCallback>();
+	private broadcastChannel?: {
+		postMessage(message: unknown): void;
+		addEventListener(type: string, listener: (event: { data?: unknown }) => void): void;
+	};
 
 	constructor(options: LuxAuthOptions = {}) {
 		this.httpUrl = options.httpUrl?.replace(/\/+$/, '');
@@ -234,6 +239,7 @@ export class LuxAuthClient {
 		if (this.authToken) {
 			this.currentSession = null;
 		}
+		this.initializeBrowserLifecycle();
 	}
 
 	async getSession(): Promise<LuxResult<{ session: LuxAuthSession | null }>> {
@@ -245,11 +251,19 @@ export class LuxAuthClient {
 	}
 
 	private async getSessionValue(): Promise<LuxAuthSession | null> {
-		await this.loadStoredSession();
+		if (this.loadedSession) {
+			// Reconcile storage before auth operations, but do not emit a
+			// synthetic event. For example, signOut after an SSR redirect must
+			// emit only SIGNED_OUT; emitting SIGNED_IN first can start a
+			// competing SvelteKit invalidation while the cookie still exists.
+			await this.recoverStoredSession(false);
+		} else {
+			await this.loadStoredSession();
+		}
 		if (this.currentSession && isExpired(this.currentSession, this.refreshMarginSeconds)) {
 			if (this.autoRefreshToken && this.currentSession.refresh_token) {
 				const refreshed = await this.refreshSession(this.currentSession.refresh_token);
-				return refreshed.data?.session ?? null;
+				return refreshed.error ? null : refreshed.data.session;
 			}
 			await this.clearSessionValue();
 			return null;
@@ -284,10 +298,10 @@ export class LuxAuthClient {
 		return this.currentSession;
 	}
 
-	async clearSession(): Promise<LuxResult<null>> {
+	async clearSession(): Promise<LuxResult<true>> {
 		try {
 			await this.clearSessionValue();
-			return ok(null);
+			return ok(true);
 		} catch (error) {
 			return err('LUX_AUTH_SESSION_ERROR', 'Failed to clear auth session', toLuxError(error));
 		}
@@ -297,11 +311,13 @@ export class LuxAuthClient {
 		this.authToken = undefined;
 		this.currentSession = null;
 		this.loadedSession = true;
+		this.storedSessionRaw = null;
 		this.clearRefreshTimer();
 		if (this.persistSession && this.storage) {
 			await this.storage.removeItem(this.storageKey);
 		}
 		this.emit('SIGNED_OUT', null);
+		this.broadcast('SIGNED_OUT', null);
 	}
 
 	onAuthStateChange(callback: LuxAuthStateChangeCallback): LuxAuthSubscription {
@@ -372,12 +388,16 @@ export class LuxAuthClient {
 
 	async consumeOAuthRedirect(url = browserLocation()): Promise<LuxResult<LuxAuthSessionResult>> {
 		try {
-			if (!url) return ok({ session: null, user: null });
+			if (!url) {
+				return err('LUX_AUTH_OAUTH_ERROR', 'OAuth redirect URL is missing');
+			}
 			const parsed = new URL(url);
 			const params = new URLSearchParams(parsed.hash.replace(/^#/, ''));
 			const accessToken = params.get('access_token');
 			const refreshToken = params.get('refresh_token');
-			if (!accessToken || !refreshToken) return ok({ session: null, user: null });
+			if (!accessToken || !refreshToken) {
+				return err('LUX_AUTH_OAUTH_ERROR', 'OAuth redirect is missing session tokens');
+			}
 			const session = normalizeSession({
 				access_token: accessToken,
 				refresh_token: refreshToken,
@@ -385,16 +405,13 @@ export class LuxAuthClient {
 				token_type: 'bearer',
 				user: { id: '', email: '' },
 			});
-				if (this.httpUrl) {
-					const user = await this.getUser(accessToken);
-					if (user.error) return user as LuxResult<LuxAuthSessionResult>;
-					if (!user.data?.user) {
-						return err('LUX_AUTH_USER_ERROR', 'OAuth redirect token did not resolve to a user');
-					}
-					session.user = user.data.user;
-				}
+			if (this.httpUrl) {
+				const user = await this.getUser(accessToken);
+				if (user.error) return user as LuxResult<LuxAuthSessionResult>;
+				session.user = user.data.user;
+			}
 			await this.saveSession(session, 'SIGNED_IN');
-			return ok({ session: this.currentSession, user: this.currentSession?.user ?? null });
+			return ok({ session, user: session.user });
 		} catch (error) {
 			return err('LUX_AUTH_OAUTH_ERROR', 'Failed to consume OAuth redirect', toLuxError(error));
 		}
@@ -417,12 +434,12 @@ export class LuxAuthClient {
 		}
 	}
 
-	async getUser(session?: Pick<LuxAuthSession, 'access_token'> | string): Promise<LuxResult<{ user: LuxAuthUser | null }>> {
+	async getUser(session?: Pick<LuxAuthSession, 'access_token'> | string): Promise<LuxResult<{ user: LuxAuthUser }>> {
 		if (!session) {
 			await this.getSessionValue();
 		}
 		try {
-			return ok(await this.requestRaw<{ user: LuxAuthUser | null }>('/auth/v1/user', {
+			return ok(await this.requestRaw<{ user: LuxAuthUser }>('/auth/v1/user', {
 				method: 'GET',
 				token: this.tokenFrom(session),
 			}));
@@ -431,7 +448,7 @@ export class LuxAuthClient {
 		}
 	}
 
-	async logout(sessionOrRefreshToken?: Pick<LuxAuthSession, 'access_token' | 'refresh_token'> | string): Promise<LuxResult<null>> {
+	async logout(sessionOrRefreshToken?: Pick<LuxAuthSession, 'access_token' | 'refresh_token'> | string): Promise<LuxResult<true>> {
 		if (!sessionOrRefreshToken) {
 			sessionOrRefreshToken = await this.getSessionValue() ?? undefined;
 		}
@@ -441,20 +458,35 @@ export class LuxAuthClient {
 		const refreshToken = typeof sessionOrRefreshToken === 'string'
 			? undefined
 			: sessionOrRefreshToken?.refresh_token;
+		let logoutError: unknown;
 		try {
 			await this.requestRaw('/auth/v1/logout', {
 				method: 'POST',
 				token,
 				body: JSON.stringify(refreshToken ? { refresh_token: refreshToken } : {}),
 			});
-			await this.clearSessionValue();
-			return ok(null);
 		} catch (error) {
-			return err('LUX_AUTH_LOGOUT_ERROR', 'Failed to log out', toLuxError(error));
+			logoutError = error;
 		}
+
+		try {
+			// Local sign-out must not depend on the remote session still being
+			// valid. The server may already have revoked or expired it.
+			await this.clearSessionValue();
+		} catch (error) {
+			return err('LUX_AUTH_LOGOUT_ERROR', 'Failed to clear the local auth session', {
+				logout: logoutError ? toLuxError(logoutError) : null,
+				storage: toLuxError(error),
+			});
+		}
+
+		if (logoutError) {
+			return err('LUX_AUTH_LOGOUT_ERROR', 'Remote logout failed; local session was cleared', toLuxError(logoutError));
+		}
+		return ok(true);
 	}
 
-	async signOut(): Promise<LuxResult<null>> {
+	async signOut(): Promise<LuxResult<true>> {
 		return this.logout();
 	}
 
@@ -495,13 +527,13 @@ export class LuxAuthClient {
 		}
 	}
 
-	async revokeGrant(grantId: string): Promise<LuxResult<null>> {
+	async revokeGrant(grantId: string): Promise<LuxResult<true>> {
 		try {
 			await this.requestRaw(`/auth/v1/admin/grants/${encodeURIComponent(grantId)}`, {
 				method: 'DELETE',
 				secret: true,
 			});
-			return ok(null);
+			return ok(true);
 		} catch (error) {
 			return err('LUX_AUTH_ADMIN_ERROR', 'Failed to revoke grant', toLuxError(error));
 		}
@@ -559,13 +591,13 @@ export class LuxAuthClient {
 		}
 	}
 
-	async revokeApiKey(keyId: string): Promise<LuxResult<null>> {
+	async revokeApiKey(keyId: string): Promise<LuxResult<true>> {
 		try {
 			await this.requestRaw(`/auth/v1/admin/keys/${encodeURIComponent(keyId)}`, {
 				method: 'DELETE',
 				secret: true,
 			});
-			return ok(null);
+			return ok(true);
 		} catch (error) {
 			return err('LUX_AUTH_ADMIN_ERROR', 'Failed to revoke API key', toLuxError(error));
 		}
@@ -604,6 +636,7 @@ export class LuxAuthClient {
 		this.loadedSession = true;
 		if (!this.persistSession || !this.storage) return;
 		const raw = await this.storage.getItem(this.storageKey);
+		this.storedSessionRaw = raw;
 		if (!raw) return;
 		try {
 			const session = normalizeSession(JSON.parse(raw));
@@ -619,11 +652,14 @@ export class LuxAuthClient {
 		this.currentSession = session;
 		this.authToken = session.access_token;
 		this.loadedSession = true;
+		const raw = JSON.stringify(session);
+		this.storedSessionRaw = raw;
 		if (this.persistSession && this.storage) {
-			await this.storage.setItem(this.storageKey, JSON.stringify(session));
+			await this.storage.setItem(this.storageKey, raw);
 		}
 		this.scheduleRefresh(session);
 		this.emit(event, session);
+		this.broadcast(event, raw);
 	}
 
 	private scheduleRefresh(session: LuxAuthSession): void {
@@ -642,6 +678,84 @@ export class LuxAuthClient {
 			clearTimeout(this.refreshTimer);
 			this.refreshTimer = null;
 		}
+	}
+
+	private initializeBrowserLifecycle(): void {
+		if (!this.persistSession || typeof globalThis === 'undefined') return;
+		const document = (globalThis as any).document;
+		if (!document) return;
+
+		const BroadcastChannelImpl = (globalThis as any).BroadcastChannel;
+		if (BroadcastChannelImpl) {
+			this.broadcastChannel = new BroadcastChannelImpl(this.storageKey);
+			this.broadcastChannel?.addEventListener('message', (event) => {
+				const message = event.data as {
+					event?: LuxAuthChangeEvent;
+					raw?: string | null;
+				} | undefined;
+				if (!message || !('raw' in message)) return;
+				void this.applyExternalSession(message.raw ?? null, message.event);
+			});
+		}
+
+		if (document?.addEventListener) {
+			document.addEventListener('visibilitychange', () => {
+				if (document.visibilityState === 'visible') {
+					void this.recoverStoredSession(true);
+				}
+			});
+		}
+	}
+
+	private async recoverStoredSession(notify: boolean): Promise<void> {
+		if (!this.persistSession || !this.storage) return;
+		const raw = await this.storage.getItem(this.storageKey);
+		await this.applyExternalSession(
+			raw,
+			undefined,
+			notify,
+		);
+	}
+
+	private async applyExternalSession(
+		raw: string | null,
+		event?: LuxAuthChangeEvent,
+		notify = true,
+	): Promise<void> {
+		if (raw === this.storedSessionRaw) return;
+
+		const previousSession = this.currentSession;
+		this.storedSessionRaw = raw;
+		this.loadedSession = true;
+
+		if (!raw) {
+			this.currentSession = null;
+			this.authToken = undefined;
+			this.clearRefreshTimer();
+			if (notify && previousSession) this.emit('SIGNED_OUT', null);
+			return;
+		}
+
+		try {
+			const session = normalizeSession(JSON.parse(raw));
+			this.currentSession = session;
+			this.authToken = session.access_token;
+			this.scheduleRefresh(session);
+			if (notify) {
+				this.emit(event ?? (previousSession ? 'SESSION_UPDATED' : 'SIGNED_IN'), session);
+			}
+		} catch {
+			this.currentSession = null;
+			this.authToken = undefined;
+			this.clearRefreshTimer();
+			this.storedSessionRaw = null;
+			await this.storage?.removeItem(this.storageKey);
+			if (notify && previousSession) this.emit('SIGNED_OUT', null);
+		}
+	}
+
+	private broadcast(event: LuxAuthChangeEvent, raw: string | null): void {
+		this.broadcastChannel?.postMessage({ event, raw });
 	}
 
 	private emit(event: LuxAuthChangeEvent, session: LuxAuthSession | null): void {

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -1,19 +1,64 @@
-import { createClient, type LuxProjectOptions } from './project';
+import { createClient, type LuxProjectClient, type LuxProjectOptions } from './project';
 import type { LuxSchema } from './types';
+import {
+	browserCookieStorage,
+	DEFAULT_SESSION_COOKIE,
+	DEFAULT_SESSION_COOKIE_OPTIONS,
+	type LuxBrowserCookieMethods,
+	type LuxCookieOptions,
+} from './cookies';
 
-export interface LuxBrowserClientOptions extends Omit<LuxProjectOptions, 'url' | 'key'> {}
+export type {
+	LuxBrowserCookieMethods,
+	LuxCookie,
+	LuxCookieOptions,
+	LuxCookieToSet,
+	LuxServerCookieMethods,
+} from './cookies';
+
+export interface LuxBrowserClientOptions extends Omit<LuxProjectOptions, 'url' | 'key' | 'auth'> {
+	isSingleton?: boolean;
+	cookies?: LuxBrowserCookieMethods;
+	auth?: NonNullable<LuxProjectOptions['auth']> & {
+		cookieOptions?: LuxCookieOptions;
+	};
+}
+
+let browserClient: LuxProjectClient<any> | undefined;
 
 export function createBrowserClient<DB extends Record<string, object> = LuxSchema>(
 	url: string,
 	key: string,
 	options: LuxBrowserClientOptions = {},
-) {
-	return createClient<DB>(url, key, {
-		...options,
+): LuxProjectClient<DB> {
+	const {
+		cookieOptions,
+		...authOptions
+	} = options.auth ?? {};
+	const resolvedCookieOptions = {
+		...DEFAULT_SESSION_COOKIE_OPTIONS,
+		...cookieOptions,
+	};
+	const usesDefaultCookieStorage = authOptions.storage === undefined;
+	const isBrowser = typeof globalThis !== 'undefined' && Boolean((globalThis as any).document);
+	const isSingleton = options.isSingleton ?? isBrowser;
+	if (isSingleton && browserClient) return browserClient as LuxProjectClient<DB>;
+
+	const client = createClient<DB>(url, key, {
+		fetch: options.fetch,
+		websocket: options.websocket,
 		auth: {
 			persistSession: true,
 			autoRefreshToken: true,
-			...(options.auth ?? {}),
+			...authOptions,
+			storageKey: authOptions.storageKey ?? (
+				usesDefaultCookieStorage ? DEFAULT_SESSION_COOKIE : 'lux.auth.session'
+			),
+			storage: usesDefaultCookieStorage
+				? browserCookieStorage(resolvedCookieOptions, options.cookies)
+				: authOptions.storage,
 		},
 	});
+	if (isSingleton) browserClient = client;
+	return client;
 }

--- a/sdk/src/cookies.ts
+++ b/sdk/src/cookies.ts
@@ -50,6 +50,7 @@ export const AUTH_COOKIE_RESPONSE_HEADERS: Record<string, string> = {
 };
 
 const BASE64_PREFIX = 'base64-';
+const MAX_COOKIE_CHUNK_SIZE = 3180;
 
 export function browserCookieStorage(
 	options: LuxCookieOptions,
@@ -75,29 +76,83 @@ export function cookieStorage(
 	return {
 		async getItem(key) {
 			const allCookies = await cookies.getAll() ?? [];
-			const cookie = allCookies.find(({ name }) => name === key);
-			if (!cookie) return null;
-			return decodeCookieValue(cookie.value);
+			const value = combineCookieChunks(key, allCookies);
+			if (value == null) return null;
+			return decodeCookieValue(value);
 		},
 		async setItem(key, value) {
+			const allCookies = await cookies.getAll() ?? [];
+			const encodedValue = encodeCookieValue(value);
+			const chunks = createCookieChunks(key, encodedValue);
+			const chunkNames = new Set(chunks.map(({ name }) => name));
+			const staleCookies = allCookies
+				.filter(({ name }) => isCookieChunk(name, key) && !chunkNames.has(name))
+				.map(({ name }) => expiredCookie(name, options));
 			await setAll(
-				[{ name: key, value: encodeCookieValue(value), options }],
+				[
+					...staleCookies,
+					...chunks.map(({ name, value }) => ({ name, value, options })),
+				],
 				AUTH_COOKIE_RESPONSE_HEADERS,
 			);
 		},
 		async removeItem(key) {
+			const allCookies = await cookies.getAll() ?? [];
+			const cookieNames = allCookies
+				.filter(({ name }) => isCookieChunk(name, key))
+				.map(({ name }) => name);
+			if (cookieNames.length === 0) cookieNames.push(key);
 			await setAll(
-				[{
-					name: key,
-					value: '',
-					options: {
-						...options,
-						expires: new Date(0),
-						maxAge: 0,
-					},
-				}],
+				cookieNames.map((name) => expiredCookie(name, options)),
 				AUTH_COOKIE_RESPONSE_HEADERS,
 			);
+		},
+	};
+}
+
+function createCookieChunks(key: string, value: string): LuxCookie[] {
+	if (value.length <= MAX_COOKIE_CHUNK_SIZE) {
+		return [{ name: key, value }];
+	}
+	const chunks: LuxCookie[] = [];
+	for (let offset = 0; offset < value.length; offset += MAX_COOKIE_CHUNK_SIZE) {
+		chunks.push({
+			name: `${key}.${chunks.length}`,
+			value: value.slice(offset, offset + MAX_COOKIE_CHUNK_SIZE),
+		});
+	}
+	return chunks;
+}
+
+function combineCookieChunks(key: string, cookies: LuxCookie[]): string | null {
+	const cookieByName = new Map(cookies.map(({ name, value }) => [name, value]));
+	const unchunked = cookieByName.get(key);
+	if (unchunked != null) return unchunked;
+
+	const chunks: string[] = [];
+	for (let index = 0; ; index++) {
+		const chunk = cookieByName.get(`${key}.${index}`);
+		if (chunk == null) break;
+		chunks.push(chunk);
+	}
+	return chunks.length > 0 ? chunks.join('') : null;
+}
+
+function isCookieChunk(name: string, key: string): boolean {
+	if (name === key) return true;
+	if (!name.startsWith(`${key}.`)) return false;
+	const suffix = name.slice(key.length + 1);
+	return suffix === '0' || /^[1-9][0-9]*$/.test(suffix);
+}
+
+function expiredCookie(name: string, options: LuxCookieOptions): LuxCookieToSet {
+	return {
+		name,
+		value: '',
+		options: {
+			...options,
+			expires: new Date(0),
+			maxAge: 0,
 		},
 	};
 }

--- a/sdk/src/cookies.ts
+++ b/sdk/src/cookies.ts
@@ -1,0 +1,181 @@
+import type { LuxAuthStorage } from './auth';
+
+export interface LuxCookieOptions {
+	domain?: string;
+	expires?: Date;
+	httpOnly?: boolean;
+	maxAge?: number;
+	path?: string;
+	sameSite?: 'lax' | 'strict' | 'none';
+	secure?: boolean;
+}
+
+export interface LuxCookie {
+	name: string;
+	value: string;
+}
+
+export interface LuxCookieToSet extends LuxCookie {
+	options: LuxCookieOptions;
+}
+
+export interface LuxBrowserCookieMethods {
+	getAll(): LuxCookie[] | null | Promise<LuxCookie[] | null>;
+	setAll(
+		cookies: LuxCookieToSet[],
+		headers: Record<string, string>,
+	): void | Promise<void>;
+}
+
+export interface LuxServerCookieMethods {
+	getAll(): LuxCookie[] | null | Promise<LuxCookie[] | null>;
+	setAll?(
+		cookies: LuxCookieToSet[],
+		headers: Record<string, string>,
+	): void | Promise<void>;
+}
+
+export const DEFAULT_SESSION_COOKIE = 'lux-auth-session';
+
+export const DEFAULT_SESSION_COOKIE_OPTIONS: LuxCookieOptions = {
+	httpOnly: false,
+	path: '/',
+	sameSite: 'lax',
+};
+
+export const AUTH_COOKIE_RESPONSE_HEADERS: Record<string, string> = {
+	'Cache-Control': 'private, no-cache, no-store, must-revalidate, max-age=0',
+	Expires: '0',
+	Pragma: 'no-cache',
+};
+
+const BASE64_PREFIX = 'base64-';
+
+export function browserCookieStorage(
+	options: LuxCookieOptions,
+	cookies: LuxBrowserCookieMethods = documentCookieMethods(),
+): LuxAuthStorage {
+	return cookieStorage(cookies, options, true);
+}
+
+export function cookieStorage(
+	cookies: LuxServerCookieMethods,
+	options: LuxCookieOptions,
+	requireSetAll = false,
+): LuxAuthStorage {
+	const setAll = cookies.setAll ?? (() => {
+		if (requireSetAll) {
+			throw new Error('Lux browser cookie methods require setAll');
+		}
+		console.warn(
+			'Lux server client needs setAll to persist auth cookie changes. ' +
+			'This server context can read sessions, but sign-in, refresh, and sign-out cookie updates will not persist.',
+		);
+	});
+	return {
+		async getItem(key) {
+			const allCookies = await cookies.getAll() ?? [];
+			const cookie = allCookies.find(({ name }) => name === key);
+			if (!cookie) return null;
+			return decodeCookieValue(cookie.value);
+		},
+		async setItem(key, value) {
+			await setAll(
+				[{ name: key, value: encodeCookieValue(value), options }],
+				AUTH_COOKIE_RESPONSE_HEADERS,
+			);
+		},
+		async removeItem(key) {
+			await setAll(
+				[{
+					name: key,
+					value: '',
+					options: {
+						...options,
+						expires: new Date(0),
+						maxAge: 0,
+					},
+				}],
+				AUTH_COOKIE_RESPONSE_HEADERS,
+			);
+		},
+	};
+}
+
+function encodeCookieValue(value: string): string {
+	const bytes = new TextEncoder().encode(value);
+	let binary = '';
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return BASE64_PREFIX + globalThis.btoa(binary)
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=+$/, '');
+}
+
+function decodeCookieValue(value: string): string {
+	if (value.startsWith(BASE64_PREFIX)) {
+		const encoded = value.slice(BASE64_PREFIX.length)
+			.replace(/-/g, '+')
+			.replace(/_/g, '/');
+		const padded = encoded.padEnd(Math.ceil(encoded.length / 4) * 4, '=');
+		const binary = globalThis.atob(padded);
+		const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+		return new TextDecoder().decode(bytes);
+	}
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+}
+
+function documentCookieMethods(): LuxBrowserCookieMethods {
+	return {
+		getAll() {
+			const document = browserDocument();
+			if (!document) return [];
+			return parseCookies(document.cookie);
+		},
+		setAll(cookies) {
+			const document = browserDocument();
+			if (!document) return;
+			for (const { name, value, options } of cookies) {
+				document.cookie = serializeCookie(name, value, options);
+			}
+		},
+	};
+}
+
+function browserDocument(): { cookie: string } | null {
+	if (typeof globalThis === 'undefined') return null;
+	return (globalThis as any).document ?? null;
+}
+
+function parseCookies(cookieHeader: string): LuxCookie[] {
+	const cookies: LuxCookie[] = [];
+	for (const part of cookieHeader.split(';')) {
+		const cookie = part.trim();
+		const separator = cookie.indexOf('=');
+		if (separator < 0) continue;
+		cookies.push({
+			name: cookie.slice(0, separator),
+			value: cookie.slice(separator + 1),
+		});
+	}
+	return cookies;
+}
+
+function serializeCookie(name: string, value: string, options: LuxCookieOptions): string {
+	const parts = [`${name}=${value}`];
+	if (options.domain) parts.push(`Domain=${options.domain}`);
+	if (options.expires) parts.push(`Expires=${options.expires.toUTCString()}`);
+	if (options.maxAge != null) parts.push(`Max-Age=${Math.floor(options.maxAge)}`);
+	if (options.path) parts.push(`Path=${options.path}`);
+	if (options.sameSite) parts.push(`SameSite=${capitalize(options.sameSite)}`);
+	if (options.secure) parts.push('Secure');
+	return parts.join('; ');
+}
+
+function capitalize(value: string): string {
+	return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/sdk/src/index.browser.ts
+++ b/sdk/src/index.browser.ts
@@ -45,7 +45,14 @@ export { createBrowserClient } from './browser';
 export { LuxStorageBucketClient, LuxStorageNamespace } from './storage';
 export type { LuxBrowserClientOptions } from './browser';
 export { createServerClient } from './ssr';
-export type { LuxCookieMethods, LuxCookieOptions, LuxServerClientOptions } from './ssr';
+export type {
+	LuxBrowserCookieMethods,
+	LuxCookie,
+	LuxCookieOptions,
+	LuxCookieToSet,
+	LuxServerCookieMethods,
+	LuxServerClientOptions,
+} from './ssr';
 export type {
 	LuxLiveResult,
 	LuxProjectLiveEvent,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -50,7 +50,14 @@ export { createBrowserClient } from './browser';
 export { LuxStorageBucketClient, LuxStorageNamespace } from './storage';
 export type { LuxBrowserClientOptions } from './browser';
 export { createServerClient } from './ssr';
-export type { LuxCookieMethods, LuxCookieOptions, LuxServerClientOptions } from './ssr';
+export type {
+	LuxBrowserCookieMethods,
+	LuxCookie,
+	LuxCookieOptions,
+	LuxCookieToSet,
+	LuxServerCookieMethods,
+	LuxServerClientOptions,
+} from './ssr';
 export type {
 	LuxLiveResult,
 	LuxProjectLiveEvent,

--- a/sdk/src/ssr.ts
+++ b/sdk/src/ssr.ts
@@ -1,22 +1,20 @@
 import { createClient, type LuxProjectOptions } from './project';
-import type { LuxAuthStorage } from './auth';
 import type { LuxSchema } from './types';
+import {
+	cookieStorage,
+	DEFAULT_SESSION_COOKIE,
+	DEFAULT_SESSION_COOKIE_OPTIONS,
+	type LuxServerCookieMethods,
+	type LuxCookieOptions,
+} from './cookies';
 
-export interface LuxCookieOptions {
-	domain?: string;
-	expires?: Date;
-	httpOnly?: boolean;
-	maxAge?: number;
-	path?: string;
-	sameSite?: 'lax' | 'strict' | 'none';
-	secure?: boolean;
-}
-
-export interface LuxCookieMethods {
-	get(name: string): string | null | undefined | Promise<string | null | undefined>;
-	set?(name: string, value: string, options?: LuxCookieOptions): void | Promise<void>;
-	remove?(name: string, options?: LuxCookieOptions): void | Promise<void>;
-}
+export type {
+	LuxBrowserCookieMethods,
+	LuxCookie,
+	LuxCookieOptions,
+	LuxCookieToSet,
+	LuxServerCookieMethods,
+} from './cookies';
 
 export interface LuxServerClientOptions extends Omit<LuxProjectOptions, 'url' | 'key' | 'auth'> {
 	auth?: Omit<NonNullable<LuxProjectOptions['auth']>, 'storage'> & {
@@ -27,20 +25,18 @@ export interface LuxServerClientOptions extends Omit<LuxProjectOptions, 'url' | 
 	 * for a stateless backend client (secret key, or `setSession` per request):
 	 * `createServerClient(url, key)` then works with no cookie plumbing.
 	 */
-	cookies?: LuxCookieMethods;
+	cookies?: LuxServerCookieMethods;
 }
-
-const DEFAULT_COOKIE = 'lux-auth-session';
 
 export function createServerClient<DB extends Record<string, object> = LuxSchema>(
 	url: string,
 	key: string,
 	options: LuxServerClientOptions = {},
 ) {
-	const storageKey = options.auth?.storageKey ?? DEFAULT_COOKIE;
-	const cookieOptions = options.auth?.cookieOptions ?? {
-		path: '/',
-		sameSite: 'lax',
+	const storageKey = options.auth?.storageKey ?? DEFAULT_SESSION_COOKIE;
+	const cookieOptions = {
+		...DEFAULT_SESSION_COOKIE_OPTIONS,
+		...options.auth?.cookieOptions,
 	};
 	const { cookieOptions: _cookieOptions, ...authOptions } = options.auth ?? {};
 
@@ -55,23 +51,7 @@ export function createServerClient<DB extends Record<string, object> = LuxSchema
 			autoRefreshToken: false,
 			...authOptions,
 			storageKey,
-			storage: hasCookies ? cookieStorage(options.cookies as LuxCookieMethods, cookieOptions) : null,
+			storage: hasCookies ? cookieStorage(options.cookies as LuxServerCookieMethods, cookieOptions) : null,
 		},
 	});
-}
-
-function cookieStorage(cookies: LuxCookieMethods, options: LuxCookieOptions): LuxAuthStorage {
-	return {
-		async getItem(key) {
-			return await cookies.get(key) ?? null;
-		},
-		async setItem(key, value) {
-			if (!cookies.set) return;
-			await cookies.set(key, value, options);
-		},
-		async removeItem(key) {
-			if (!cookies.remove) return;
-			await cookies.remove(key, { ...options, maxAge: 0, expires: new Date(0) });
-		},
-	};
 }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -68,9 +68,12 @@ export interface LuxError {
 	details?: unknown;
 }
 
-export interface LuxResult<T> {
-	data: T | null;
-	error: LuxError | null;
+export type LuxResult<T> = {
+	data: T;
+	error: null;
+} | {
+	data: null;
+	error: LuxError;
 }
 
 type SchemaSafeParse<T> = { success: true; data: T } | { success: false; error: unknown };

--- a/sdk/tests/auth.test.ts
+++ b/sdk/tests/auth.test.ts
@@ -69,6 +69,83 @@ describe('LuxAuthClient session state', () => {
 		expect(events).toContain('SIGNED_OUT:none');
 	});
 
+	test('broadcasts browser auth changes across clients', async () => {
+		const originalDocument = (globalThis as any).document;
+		const originalBroadcastChannel = (globalThis as any).BroadcastChannel;
+		const channels = new Map<string, Set<FakeBroadcastChannel>>();
+		(globalThis as any).document = {
+			visibilityState: 'visible',
+			addEventListener() {},
+		};
+		(globalThis as any).BroadcastChannel = class extends FakeBroadcastChannel {
+			constructor(name: string) {
+				super(name, channels);
+			}
+		};
+
+		try {
+			const sharedStorage = memoryStorage();
+			const first = new LuxAuthClient({
+				persistSession: true,
+				autoRefreshToken: false,
+				storage: sharedStorage,
+				storageKey: 'lux.broadcast.session',
+			});
+			const second = new LuxAuthClient({
+				persistSession: true,
+				autoRefreshToken: false,
+				storage: sharedStorage,
+				storageKey: 'lux.broadcast.session',
+			});
+			const events: string[] = [];
+			let resolveInitial!: () => void;
+			const initial = new Promise<void>((resolve) => {
+				resolveInitial = resolve;
+			});
+			second.onAuthStateChange((event, nextSession) => {
+				events.push(`${event}:${nextSession?.access_token ?? 'none'}`);
+				if (event === 'INITIAL_SESSION') resolveInitial();
+			});
+			await initial;
+
+			await first.setSession(session({ access_token: 'broadcast-token' }));
+			await Promise.resolve();
+
+			expect(events).toContain('SESSION_UPDATED:broadcast-token');
+			expect((await second.getSession()).data?.session?.access_token)
+				.toBe('broadcast-token');
+		} finally {
+			if (originalDocument === undefined) delete (globalThis as any).document;
+			else (globalThis as any).document = originalDocument;
+			if (originalBroadcastChannel === undefined) delete (globalThis as any).BroadcastChannel;
+			else (globalThis as any).BroadcastChannel = originalBroadcastChannel;
+		}
+	});
+
+	test('signOut clears local state when remote logout fails', async () => {
+		const storage = memoryStorage();
+		const auth = new LuxAuthClient({
+			httpUrl: 'http://localhost:3957/v1/project',
+			fetch: (async () => new Response(
+				JSON.stringify({ error: 'session already revoked' }),
+				{ status: 401 },
+			)) as typeof fetch,
+			persistSession: true,
+			autoRefreshToken: false,
+			storage,
+		});
+		await auth.setSession(session());
+
+		const events: string[] = [];
+		auth.onAuthStateChange((event) => events.push(event));
+		const result = await auth.signOut();
+
+		expect(result.error?.code).toBe('LUX_AUTH_LOGOUT_ERROR');
+		expect(storage.data.has('lux.auth.session')).toBe(false);
+		expect((await auth.getSession()).data?.session).toBeNull();
+		expect(events).toContain('SIGNED_OUT');
+	});
+
 	test('signInWithPassword stores returned session and sends project apikey', async () => {
 		const storage = memoryStorage();
 		let seen: { url: string; headers: Record<string, string>; body: any } | null = null;
@@ -192,4 +269,37 @@ describe('LuxAuthClient session state', () => {
 		expect(authorization).toBe('Bearer access');
 		expect(storage.data.has('lux.auth.session')).toBe(true);
 	});
+
+	test('consumeOAuthRedirect returns an error when callback tokens are missing', async () => {
+		const auth = new LuxAuthClient();
+
+		const result = await auth.consumeOAuthRedirect('https://app.example.com/auth/callback');
+
+		expect(result.data).toBeNull();
+		expect(result.error?.code).toBe('LUX_AUTH_OAUTH_ERROR');
+	});
 });
+
+class FakeBroadcastChannel {
+	private listeners = new Set<(event: { data?: unknown }) => void>();
+
+	constructor(
+		private name: string,
+		private channels: Map<string, Set<FakeBroadcastChannel>>,
+	) {
+		const peers = channels.get(name) ?? new Set();
+		peers.add(this);
+		channels.set(name, peers);
+	}
+
+	addEventListener(_type: string, listener: (event: { data?: unknown }) => void) {
+		this.listeners.add(listener);
+	}
+
+	postMessage(data: unknown) {
+		for (const peer of this.channels.get(this.name) ?? []) {
+			if (peer === this) continue;
+			for (const listener of peer.listeners) listener({ data });
+		}
+	}
+}

--- a/sdk/tests/browser-ssr.test.ts
+++ b/sdk/tests/browser-ssr.test.ts
@@ -108,6 +108,89 @@ describe('browser and SSR clients', () => {
 		expect(cookies.has('lux-auth-session')).toBe(false);
 	});
 
+	test('server client chunks large session cookies and restores them', async () => {
+		const cookies = new Map<string, string>();
+		const client = createServerClient('http://localhost:3957/v1/project', 'lux_pub_test', {
+			cookies: cookieMethods(cookies),
+		});
+		const largeAccessToken = 'access-token-'.repeat(400);
+
+		await client.auth.setSession({
+			access_token: largeAccessToken,
+			refresh_token: 'refresh-token',
+			expires_in: 3600,
+			token_type: 'bearer',
+			user: { id: 'usr_chunked', email: 'chunked@example.com' },
+		});
+
+		expect(cookies.has('lux-auth-session')).toBe(false);
+		expect(cookies.has('lux-auth-session.0')).toBe(true);
+		expect(cookies.has('lux-auth-session.1')).toBe(true);
+		for (const [name, value] of cookies) {
+			if (name.startsWith('lux-auth-session.')) {
+				expect(value.length).toBeLessThanOrEqual(3180);
+			}
+		}
+
+		const restored = createServerClient('http://localhost:3957/v1/project', 'lux_pub_test', {
+			cookies: cookieMethods(cookies),
+		});
+		expect((await restored.auth.getSession()).data?.session?.access_token)
+			.toBe(largeAccessToken);
+	});
+
+	test('session cookie updates remove stale chunks', async () => {
+		const cookies = new Map<string, string>();
+		const client = createServerClient('http://localhost:3957/v1/project', 'lux_pub_test', {
+			cookies: cookieMethods(cookies),
+		});
+
+		await client.auth.setSession({
+			access_token: 'large-'.repeat(1200),
+			refresh_token: 'refresh-token',
+			expires_in: 3600,
+			token_type: 'bearer',
+			user: { id: 'usr_chunks', email: 'chunks@example.com' },
+		});
+		expect(cookies.has('lux-auth-session.2')).toBe(true);
+
+		await client.auth.setSession({
+			access_token: 'small-access-token',
+			refresh_token: 'refresh-token',
+			expires_in: 3600,
+			token_type: 'bearer',
+			user: { id: 'usr_chunks', email: 'chunks@example.com' },
+		});
+
+		expect(cookies.has('lux-auth-session')).toBe(true);
+		expect([...cookies.keys()].some((name) => name.startsWith('lux-auth-session.')))
+			.toBe(false);
+		expect((await client.auth.getSession()).data?.session?.access_token)
+			.toBe('small-access-token');
+	});
+
+	test('clearing a session removes every cookie chunk', async () => {
+		const cookies = new Map<string, string>();
+		const client = createServerClient('http://localhost:3957/v1/project', 'lux_pub_test', {
+			cookies: cookieMethods(cookies),
+		});
+
+		await client.auth.setSession({
+			access_token: 'large-'.repeat(1200),
+			refresh_token: 'refresh-token',
+			expires_in: 3600,
+			token_type: 'bearer',
+			user: { id: 'usr_clear_chunks', email: 'clear-chunks@example.com' },
+		});
+		expect([...cookies.keys()].some((name) => name.startsWith('lux-auth-session.')))
+			.toBe(true);
+
+		await client.auth.clearSession();
+
+		expect([...cookies.keys()].some((name) => name === 'lux-auth-session' ||
+			name.startsWith('lux-auth-session.'))).toBe(false);
+	});
+
 	test('server client can read cookies when setAll is unavailable', async () => {
 		const cookies = new Map<string, string>();
 		const writer = createServerClient('http://localhost:3957/v1/project', 'lux_pub_test', {

--- a/sdk/tests/browser-ssr.test.ts
+++ b/sdk/tests/browser-ssr.test.ts
@@ -2,11 +2,18 @@ import { describe, expect, test } from 'bun:test';
 import { createBrowserClient } from '../src/browser';
 import { createServerClient } from '../src/ssr';
 import { createBrowserClient as rootCreateBrowserClient, createServerClient as rootCreateServerClient } from '../src';
+import {
+	createBrowserClient as browserRootCreateBrowserClient,
+	createServerClient as browserRootCreateServerClient,
+} from '../src/index.browser';
+import type { LuxBrowserCookieMethods, LuxCookieOptions } from '../src/cookies';
 
 describe('browser and SSR clients', () => {
 	test('browser and SSR helpers are exported from package root', () => {
 		expect(rootCreateBrowserClient).toBe(createBrowserClient);
 		expect(rootCreateServerClient).toBe(createServerClient);
+		expect(browserRootCreateBrowserClient).toBe(createBrowserClient);
+		expect(browserRootCreateServerClient).toBe(createServerClient);
 	});
 
 	test('browser client persists sessions by default', async () => {
@@ -33,14 +40,43 @@ describe('browser and SSR clients', () => {
 		expect(storage.has('lux.auth.session')).toBe(true);
 	});
 
+	test('browser client accepts getAll and setAll cookie methods', async () => {
+		const cookies = new Map<string, string>();
+		let optionsWereProvided = false;
+		const client = createBrowserClient(
+			'http://localhost:3957/v1/project',
+			'lux_pub_test',
+			{
+				isSingleton: false,
+				auth: { autoRefreshToken: false },
+				cookies: cookieMethods(cookies, (options) => {
+					optionsWereProvided = options.path === '/';
+				}),
+			},
+		);
+
+		await client.auth.setSession({
+			access_token: 'access-token',
+			refresh_token: 'refresh-token',
+			expires_in: 3600,
+			token_type: 'bearer',
+			user: { id: 'usr_browser', email: 'browser@example.com' },
+		});
+
+		expect(cookies.has('lux-auth-session')).toBe(true);
+		expect(optionsWereProvided).toBe(true);
+		expect((await client.auth.getSession()).data?.session?.user.id).toBe('usr_browser');
+	});
+
 	test('server client stores sessions through cookie methods', async () => {
 		const cookies = new Map<string, string>();
+		let writtenOptions: Record<string, unknown> | undefined;
+		let writtenHeaders: Record<string, string> | undefined;
 		const client = createServerClient('http://localhost:3957/v1/project', 'lux_pub_test', {
-			cookies: {
-				get: (name) => cookies.get(name),
-				set: (name, value) => cookies.set(name, value),
-				remove: (name) => cookies.delete(name),
-			},
+			cookies: cookieMethods(cookies, (options, headers) => {
+				writtenOptions = options;
+				writtenHeaders = headers;
+			}),
 		});
 
 		await client.auth.setSession({
@@ -51,19 +87,224 @@ describe('browser and SSR clients', () => {
 			user: { id: 'usr_123', email: 'user@example.com' },
 		});
 		expect(cookies.has('lux-auth-session')).toBe(true);
+		expect(writtenOptions).toMatchObject({
+			httpOnly: false,
+			path: '/',
+			sameSite: 'lax',
+		});
+		expect(writtenHeaders).toMatchObject({
+			'Cache-Control': 'private, no-cache, no-store, must-revalidate, max-age=0',
+			Expires: '0',
+			Pragma: 'no-cache',
+		});
 
 		const restored = createServerClient('http://localhost:3957/v1/project', 'lux_pub_test', {
-			cookies: {
-				get: (name) => cookies.get(name),
-				set: (name, value) => cookies.set(name, value),
-				remove: (name) => cookies.delete(name),
-			},
+			cookies: cookieMethods(cookies),
 		});
 
 		expect((await restored.auth.getSession()).data?.session?.access_token).toBe('access-token');
 
 		await restored.auth.clearSession();
 		expect(cookies.has('lux-auth-session')).toBe(false);
+	});
+
+	test('server client can read cookies when setAll is unavailable', async () => {
+		const cookies = new Map<string, string>();
+		const writer = createServerClient('http://localhost:3957/v1/project', 'lux_pub_test', {
+			cookies: cookieMethods(cookies),
+		});
+		await writer.auth.setSession({
+			access_token: 'read-only-access-token',
+			refresh_token: 'read-only-refresh-token',
+			expires_in: 3600,
+			token_type: 'bearer',
+			user: { id: 'usr_read_only', email: 'readonly@example.com' },
+		});
+
+		const reader = createServerClient('http://localhost:3957/v1/project', 'lux_pub_test', {
+			cookies: {
+				getAll: () => [...cookies].map(([name, value]) => ({ name, value })),
+			},
+		});
+
+		expect((await reader.auth.getSession()).data?.session?.access_token)
+			.toBe('read-only-access-token');
+	});
+
+	test('browser and SSR clients share the default session cookie', async () => {
+		const cookies = new Map<string, string>();
+		const server = createServerClient('http://localhost:3957/v1/project', 'lux_pub_test', {
+			cookies: cookieMethods(cookies),
+		});
+
+		await server.auth.setSession({
+			access_token: 'server-access-token',
+			refresh_token: 'server-refresh-token',
+			expires_in: 3600,
+			token_type: 'bearer',
+			user: { id: 'usr_shared', email: 'shared@example.com' },
+		});
+
+		const originalDocument = (globalThis as any).document;
+		const browserCookies = new Map<string, string>([
+			['lux-auth-session', cookies.get('lux-auth-session')!],
+		]);
+		(globalThis as any).document = createCookieDocument(browserCookies);
+
+		try {
+			const browser = createBrowserClient(
+				'http://localhost:3957/v1/project',
+				'lux_pub_test',
+				{ isSingleton: false, auth: { autoRefreshToken: false } },
+			);
+
+			expect((await browser.auth.getSession()).data?.session?.access_token)
+				.toBe('server-access-token');
+
+			await browser.auth.setSession({
+				access_token: 'browser-access-token',
+				refresh_token: 'browser-refresh-token',
+				expires_in: 3600,
+				token_type: 'bearer',
+				user: { id: 'usr_shared', email: 'shared@example.com' },
+			});
+
+			cookies.set('lux-auth-session', browserCookies.get('lux-auth-session')!);
+			const nextServer = createServerClient(
+				'http://localhost:3957/v1/project',
+				'lux_pub_test',
+				{
+					cookies: cookieMethods(cookies),
+				},
+			);
+			expect((await nextServer.auth.getSession()).data?.session?.access_token)
+				.toBe('browser-access-token');
+		} finally {
+			if (originalDocument === undefined) {
+				delete (globalThis as any).document;
+			} else {
+				(globalThis as any).document = originalDocument;
+			}
+		}
+	});
+
+	test('browser auth recovers cookie changes when the document becomes visible', async () => {
+		const originalDocument = (globalThis as any).document;
+		const browserCookies = new Map<string, string>();
+		const document = createCookieDocument(browserCookies);
+		(globalThis as any).document = document;
+
+		try {
+			const browser = createBrowserClient(
+				'http://localhost:3957/v1/project',
+				'lux_pub_test',
+				{ isSingleton: false, auth: { autoRefreshToken: false } },
+			);
+			const events: string[] = [];
+			const subscription = browser.auth.onAuthStateChange((event, session) => {
+				events.push(`${event}:${session?.access_token ?? 'none'}`);
+			});
+
+			await waitFor(() => events.includes('INITIAL_SESSION:none'));
+
+			browserCookies.set('lux-auth-session', encodeSessionCookie({
+				access_token: 'ssr-access-token',
+				refresh_token: 'ssr-refresh-token',
+				expires_in: 3600,
+				token_type: 'bearer',
+				user: { id: 'usr_ssr', email: 'ssr@example.com' },
+			}));
+			document.dispatchVisibilityChange('visible');
+			await waitFor(() => events.includes('SIGNED_IN:ssr-access-token'));
+
+			browserCookies.delete('lux-auth-session');
+			document.dispatchVisibilityChange('visible');
+			await waitFor(() => events.includes('SIGNED_OUT:none'));
+
+			subscription.unsubscribe();
+		} finally {
+			if (originalDocument === undefined) {
+				delete (globalThis as any).document;
+			} else {
+				(globalThis as any).document = originalDocument;
+			}
+		}
+	});
+
+	test('client sign out reconciles a session created by an SSR redirect', async () => {
+		const originalDocument = (globalThis as any).document;
+		const browserCookies = new Map<string, string>();
+		(globalThis as any).document = createCookieDocument(browserCookies);
+		let authorization = '';
+
+		try {
+			const browser = createBrowserClient(
+				'http://localhost:3957/v1/project',
+				'lux_pub_test',
+				{
+					isSingleton: false,
+					auth: { autoRefreshToken: false },
+					fetch: (async (_input: RequestInfo | URL, init?: RequestInit) => {
+						authorization = String(
+							(init?.headers as Record<string, string> | undefined)?.Authorization ?? '',
+						);
+						return new Response('{}', { status: 200 });
+					}) as typeof fetch,
+				},
+			);
+			const events: string[] = [];
+			browser.auth.onAuthStateChange((event) => events.push(event));
+
+			// The singleton was created on the sign-in page before the server
+			// action wrote a session cookie.
+			expect((await browser.auth.getSession()).data?.session).toBeNull();
+
+			// SvelteKit applies Set-Cookie and performs a client-side redirect,
+			// without reloading the browser client or changing visibility.
+			browserCookies.set('lux-auth-session', encodeSessionCookie({
+				access_token: 'ssr-access-token',
+				refresh_token: 'ssr-refresh-token',
+				expires_in: 3600,
+				token_type: 'bearer',
+				user: { id: 'usr_ssr', email: 'ssr@example.com' },
+			}));
+
+			const result = await browser.auth.signOut();
+
+			expect(result.error).toBeNull();
+			expect(authorization).toBe('Bearer ssr-access-token');
+			expect(browserCookies.has('lux-auth-session')).toBe(false);
+			expect(events.filter((event) => event === 'SIGNED_IN')).toHaveLength(0);
+			expect(events.filter((event) => event === 'SIGNED_OUT')).toHaveLength(1);
+		} finally {
+			if (originalDocument === undefined) {
+				delete (globalThis as any).document;
+			} else {
+				(globalThis as any).document = originalDocument;
+			}
+		}
+	});
+
+	test('browser client is a singleton by default in browser environments', () => {
+		const originalDocument = (globalThis as any).document;
+		(globalThis as any).document = createCookieDocument(new Map());
+		try {
+			const first = createBrowserClient(
+				'http://localhost:3957/v1/project-singleton',
+				'lux_pub_singleton',
+			);
+			const second = createBrowserClient(
+				'http://localhost:3957/v1/project-singleton',
+				'lux_pub_singleton',
+			);
+			expect(second).toBe(first);
+		} finally {
+			if (originalDocument === undefined) {
+				delete (globalThis as any).document;
+			} else {
+				(globalThis as any).document = originalDocument;
+			}
+		}
 	});
 
 	test('server client works without cookies (stateless backend)', async () => {
@@ -86,3 +327,67 @@ describe('browser and SSR clients', () => {
 		expect((await fresh.auth.getSession()).data?.session).toBeNull();
 	});
 });
+
+function createCookieDocument(cookies: Map<string, string>): {
+	cookie: string;
+	visibilityState: string;
+	addEventListener(type: string, listener: () => void): void;
+	dispatchVisibilityChange(state: string): void;
+} {
+	const listeners = new Set<() => void>();
+	return {
+		visibilityState: 'visible',
+		get cookie() {
+			return [...cookies].map(([name, value]) => `${name}=${value}`).join('; ');
+		},
+		set cookie(serialized: string) {
+			const [pair, ...attributes] = serialized.split(';').map((part) => part.trim());
+			const separator = pair.indexOf('=');
+			const name = pair.slice(0, separator);
+			const value = pair.slice(separator + 1);
+			const removesCookie = attributes.some((attribute) =>
+				attribute.toLowerCase() === 'max-age=0'
+			);
+			if (removesCookie) cookies.delete(name);
+			else cookies.set(name, value);
+		},
+		addEventListener(type: string, listener: () => void) {
+			if (type === 'visibilitychange') listeners.add(listener);
+		},
+		dispatchVisibilityChange(state: string) {
+			this.visibilityState = state;
+			for (const listener of listeners) listener();
+		},
+	};
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) throw new Error('Timed out waiting for condition');
+		await Bun.sleep(10);
+	}
+}
+
+function cookieMethods(
+	cookies: Map<string, string>,
+	onSet?: (options: LuxCookieOptions, headers: Record<string, string>) => void,
+): LuxBrowserCookieMethods {
+	return {
+		getAll: () => [...cookies].map(([name, value]) => ({ name, value })),
+		setAll: (cookiesToSet, headers) => {
+			for (const { name, value, options } of cookiesToSet) {
+				onSet?.(options, headers);
+				if (options.maxAge === 0) cookies.delete(name);
+				else cookies.set(name, value);
+			}
+		},
+	};
+}
+
+function encodeSessionCookie(session: Record<string, unknown>): string {
+	const bytes = new TextEncoder().encode(JSON.stringify(session));
+	let binary = '';
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return `base64-${btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')}`;
+}


### PR DESCRIPTION
## Summary

Improves browser and SSR support in the TypeScript SDK by sharing cookie-backed auth sessions while keeping Node-only `ioredis` code out of browser bundles.

## Changes

- Route browser package imports through the browser-safe entrypoint.
- Prevent `ioredis` from leaking into browser bundles.
- Persist browser and SSR sessions in the shared `lux-auth-session` cookie.
- Add framework-friendly `getAll`/`setAll` cookie adapters.
- Synchronize auth changes across tabs using `BroadcastChannel`.
- Reconcile cookie changes after SSR redirects and visibility changes.
- Make browser clients singletons by default in browser environments.
- Ensure sign-out clears local state even if remote logout fails.
- Improve auth result typing and OAuth error handling.
- Add SvelteKit cookie integration documentation.
- Preserve custom auth storage as an opt-out from cookie storage.

## Testing

- SDK build passes.
- All 44 SDK tests pass.
- Added coverage for browser/SSR cookie sharing, cross-tab synchronization, session recovery, singleton behavior, and logout handling.