### PR TITLE
Fix pipelined EVALSHA deadlock and make BZPOP wakeups event-driven

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -764,6 +764,13 @@ impl EmbeddedClient {
             }
 
             self.runtime.store.add_total_commands(batch.len());
+            if has_write {
+                for command in batch {
+                    if command_is_fast_path_write(command) {
+                        notify_zset_waiters_for_command(&self.runtime.broker, command);
+                    }
+                }
+            }
             if emit_key_events {
                 for argv in &write_argvs {
                     let refs = argv.iter().map(Vec::as_slice).collect::<Vec<_>>();
@@ -811,6 +818,9 @@ impl EmbeddedClient {
             .shard_executor
             .apply_mset_batches(pairs_by_shard, now);
 
+        for command in commands {
+            notify_zset_waiters_for_command(&self.runtime.broker, command);
+        }
         if emit_key_events {
             for key in event_keys {
                 self.runtime.broker.enqueue_key_event(key, b"MSET");
@@ -1646,6 +1656,9 @@ impl EmbeddedClient {
         };
 
         self.runtime.store.add_total_commands(1);
+        if command_is_fast_path_write(command) && !matches!(command, Command::MSet { .. }) {
+            notify_zset_waiters_for_command(&self.runtime.broker, command);
+        }
         if let Some(argv) = write_argv.take() {
             let refs = argv.iter().map(Vec::as_slice).collect::<Vec<_>>();
             fire_key_events(&self.runtime.broker, &refs);
@@ -3121,10 +3134,115 @@ fn cmd_eq_fast(input: &[u8], expected: &[u8]) -> bool {
 
 #[inline(always)]
 fn fire_key_events(broker: &Broker, args: &[&[u8]]) {
-    if args.len() < 2 || !broker.has_key_subs() {
+    if args.len() < 2 {
+        return;
+    }
+    if !broker.has_key_subs() {
         return;
     }
     fire_key_events_slow(broker, args);
+}
+
+#[inline(always)]
+fn wake_zset_waiters_for_key(broker: &Broker, key: &[u8]) {
+    broker.wake_zset_waiters(arg_str(key));
+}
+
+fn notify_zset_waiters_for_command(broker: &Broker, command: &Command<'_>) {
+    if !broker.has_zset_waiters() || !command_is_fast_path_write(command) {
+        return;
+    }
+
+    match command {
+        Command::FlushDb | Command::FlushAll => {}
+        Command::MSet { pairs } | Command::MSetNx { pairs } => {
+            for (key, _) in pairs {
+                wake_zset_waiters_for_key(broker, key);
+            }
+        }
+        Command::Del { keys } | Command::Unlink { keys } => {
+            for key in keys {
+                wake_zset_waiters_for_key(broker, key);
+            }
+        }
+        Command::Rename { key, new_key } | Command::RenameNx { key, new_key } => {
+            wake_zset_waiters_for_key(broker, key);
+            wake_zset_waiters_for_key(broker, new_key);
+        }
+        Command::Set { key, .. }
+        | Command::GetSet { key, .. }
+        | Command::SetNx { key, .. }
+        | Command::SetEx { key, .. }
+        | Command::PSetEx { key, .. }
+        | Command::Append { key, .. }
+        | Command::Incr { key }
+        | Command::Decr { key }
+        | Command::IncrBy { key, .. }
+        | Command::DecrBy { key, .. }
+        | Command::Expire { key, .. }
+        | Command::Persist { key }
+        | Command::LPush { key, .. }
+        | Command::RPush { key, .. }
+        | Command::LPop { key }
+        | Command::RPop { key }
+        | Command::HSet { key, .. }
+        | Command::HIncrBy { key, .. }
+        | Command::HDel { key, .. }
+        | Command::SAdd { key, .. }
+        | Command::SRem { key, .. }
+        | Command::SPop { key }
+        | Command::ZAdd { key, .. }
+        | Command::ZRem { key, .. }
+        | Command::ZIncrBy { key, .. }
+        | Command::GeoAdd { key, .. }
+        | Command::XAdd { key, .. } => wake_zset_waiters_for_key(broker, key),
+        _ => {}
+    }
+}
+
+fn notify_zset_waiters_for_script_keys(broker: &Broker, keys: &[Vec<u8>]) {
+    if !broker.has_zset_waiters() {
+        return;
+    }
+    for key in keys {
+        broker.wake_zset_waiters(arg_str(key));
+    }
+}
+
+fn notify_zset_waiters_for_write(broker: &Broker, args: &[&[u8]]) {
+    if !broker.has_zset_waiters() || args.len() < 2 || !crate::eviction::is_write_command(args[0]) {
+        return;
+    }
+
+    let cmd = args[0];
+    if cmd_eq_fast(cmd, b"FLUSHDB") || cmd_eq_fast(cmd, b"FLUSHALL") {
+        return;
+    }
+    if cmd_eq_fast(cmd, b"EVAL") || cmd_eq_fast(cmd, b"EVALSHA") {
+        let num_keys = args
+            .get(2)
+            .and_then(|value| arg_str(value).parse::<usize>().ok())
+            .unwrap_or(0);
+        let end = 3 + num_keys.min(args.len().saturating_sub(3));
+        for key in &args[3..end] {
+            wake_zset_waiters_for_key(broker, key);
+        }
+    } else if cmd_eq_fast(cmd, b"MSET") || cmd_eq_fast(cmd, b"MSETNX") {
+        let mut i = 1;
+        while i < args.len() {
+            wake_zset_waiters_for_key(broker, args[i]);
+            i += 2;
+        }
+    } else if cmd_eq_fast(cmd, b"DEL") || cmd_eq_fast(cmd, b"UNLINK") {
+        for key in &args[1..] {
+            wake_zset_waiters_for_key(broker, key);
+        }
+    } else if cmd_eq_fast(cmd, b"RENAME") && args.len() >= 3 {
+        wake_zset_waiters_for_key(broker, args[1]);
+        wake_zset_waiters_for_key(broker, args[2]);
+    } else {
+        wake_zset_waiters_for_key(broker, args[1]);
+    }
 }
 
 #[inline(never)]
@@ -3226,7 +3344,9 @@ fn handle_tx_cmd(
                         cmd::execute_with_wal(store, schema_cache, broker, &refs, write_buf, now)
                     };
                     match cmd_result {
-                        CmdResult::Written => {}
+                        CmdResult::Written => {
+                            notify_zset_waiters_for_write(broker, &refs);
+                        }
                         CmdResult::Authenticated => {
                             *authenticated = true;
                         }
@@ -3582,7 +3702,6 @@ impl CommandExecutor {
         }
 
         if has_special || !all_single_key_rw {
-            let script_guard = self.store.script_read_guard();
             for command in commands {
                 let args = command.argv();
                 if !session.authenticated && !is_public_without_auth_cmd(args[0]) {
@@ -3605,22 +3724,23 @@ impl CommandExecutor {
                     continue;
                 }
 
-                let cmd_result = cmd::execute_with_wal(
-                    &self.store,
-                    &self.schema_cache,
-                    &self.broker,
-                    args,
-                    write_buf,
-                    now,
-                );
+                let cmd_result = {
+                    let _guard = self.store.script_read_guard();
+                    cmd::execute_with_wal(
+                        &self.store,
+                        &self.schema_cache,
+                        &self.broker,
+                        args,
+                        write_buf,
+                        now,
+                    )
+                };
                 if let Some(action) =
                     self.apply_cmd_result(cmd_result, args, session, write_buf, now)
                 {
-                    drop(script_guard);
                     return Some(action);
                 }
             }
-            drop(script_guard);
             return None;
         }
 
@@ -3651,6 +3771,11 @@ impl CommandExecutor {
                 write_shard_execution_error(write_buf, err);
                 return None;
             }
+            for (offset, command) in commands[i..batch_end].iter().enumerate() {
+                if flags[i + offset] == cmd::PipelineAccess::Write {
+                    notify_zset_waiters_for_write(&self.broker, command.argv());
+                }
+            }
 
             i = batch_end;
         }
@@ -3667,6 +3792,7 @@ impl CommandExecutor {
     ) -> Option<CmdResult> {
         match cmd_result {
             CmdResult::Written => {
+                notify_zset_waiters_for_write(&self.broker, args);
                 fire_key_events(&self.broker, args);
                 None
             }
@@ -3749,6 +3875,7 @@ impl CommandExecutor {
                     &argv,
                     now,
                 );
+                notify_zset_waiters_for_script_keys(&self.broker, &keys);
                 None
             }
             CmdResult::ScriptOp => {
@@ -4118,7 +4245,8 @@ async fn handle_connection(
                         timeout,
                         pop_min,
                     } => {
-                        handle_block_zpop(&mut socket, &store, &keys, timeout, pop_min).await?;
+                        handle_block_zpop(&mut socket, &store, &broker, &keys, timeout, pop_min)
+                            .await?;
                     }
                     _ => {}
                 }
@@ -4350,6 +4478,7 @@ fn handle_eval(
 async fn handle_block_zpop(
     socket: &mut tokio::net::TcpStream,
     store: &Arc<Store>,
+    broker: &Broker,
     keys: &[String],
     timeout: std::time::Duration,
     pop_min: bool,
@@ -4358,37 +4487,71 @@ async fn handle_block_zpop(
     let mut write_buf = BytesMut::new();
 
     loop {
-        let now = Instant::now();
-        for key in keys {
-            let result = if pop_min {
-                store.zpopmin(key.as_bytes(), 1, now)
-            } else {
-                store.zpopmax(key.as_bytes(), 1, now)
-            };
-            if let Ok(items) = result {
-                if !items.is_empty() {
-                    let (member, score) = &items[0];
-                    resp::write_array_header(&mut write_buf, 3);
-                    resp::write_bulk(&mut write_buf, key);
-                    resp::write_bulk(&mut write_buf, member);
-                    let score_str = if score.fract() == 0.0 && score.abs() < 1e15 {
-                        format!("{}", *score as i64)
-                    } else {
-                        format!("{}", score)
-                    };
-                    resp::write_bulk(&mut write_buf, &score_str);
-                    return socket.write_all(&write_buf).await;
-                }
-            }
+        if write_zpop_response(store, keys, pop_min, &mut write_buf) {
+            return socket.write_all(&write_buf).await;
         }
 
-        if tokio::time::Instant::now() >= deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
             resp::write_null_array(&mut write_buf);
             return socket.write_all(&write_buf).await;
         }
 
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let waiter_id = broker.next_waiter_id();
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(1);
+        for key in keys {
+            broker.register_zset_waiter(
+                key,
+                pubsub::BlockedZPopRequest {
+                    tx: tx.clone(),
+                    waiter_id,
+                },
+            );
+        }
+        drop(tx);
+
+        if write_zpop_response(store, keys, pop_min, &mut write_buf) {
+            broker.remove_zset_waiters_by_id(keys, waiter_id);
+            return socket.write_all(&write_buf).await;
+        }
+
+        let woke = tokio::select! {
+            val = rx.recv() => val.is_some(),
+            _ = tokio::time::sleep(remaining) => false,
+        };
+        broker.remove_zset_waiters_by_id(keys, waiter_id);
+        if !woke {
+            resp::write_null_array(&mut write_buf);
+            return socket.write_all(&write_buf).await;
+        }
     }
+}
+
+fn write_zpop_response(store: &Store, keys: &[String], pop_min: bool, out: &mut BytesMut) -> bool {
+    let now = Instant::now();
+    for key in keys {
+        let result = if pop_min {
+            store.zpopmin(key.as_bytes(), 1, now)
+        } else {
+            store.zpopmax(key.as_bytes(), 1, now)
+        };
+        if let Ok(items) = result {
+            if !items.is_empty() {
+                let (member, score) = &items[0];
+                resp::write_array_header(out, 3);
+                resp::write_bulk(out, key);
+                resp::write_bulk(out, member);
+                let score_str = if score.fract() == 0.0 && score.abs() < 1e15 {
+                    format!("{}", *score as i64)
+                } else {
+                    format!("{}", score)
+                };
+                resp::write_bulk(out, &score_str);
+                return true;
+            }
+        }
+    }
+    false
 }
 
 fn handle_script_op(out: &mut BytesMut, script_engine: &lua::ScriptEngine, args: &[&[u8]]) {

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -55,6 +55,11 @@ pub struct BlockedPopRequest {
     pub waiter_id: u64,
 }
 
+pub struct BlockedZPopRequest {
+    pub tx: mpsc::Sender<()>,
+    pub waiter_id: u64,
+}
+
 #[derive(Clone)]
 pub struct Broker {
     channels: Arc<parking_lot::RwLock<HashMap<String, broadcast::Sender<Message>>>>,
@@ -71,6 +76,8 @@ pub struct Broker {
     key_event_counters: Arc<KeyEventCounters>,
     list_waiters: Arc<parking_lot::Mutex<HashMap<String, VecDeque<BlockedPopRequest>>>>,
     list_waiter_count: Arc<AtomicU64>,
+    zset_waiters: Arc<parking_lot::Mutex<HashMap<String, Vec<BlockedZPopRequest>>>>,
+    zset_waiter_count: Arc<AtomicU64>,
     stream_waiters: Arc<parking_lot::Mutex<HashMap<String, Vec<mpsc::Sender<()>>>>>,
     waiter_counter: Arc<AtomicU64>,
 }
@@ -117,6 +124,8 @@ impl Broker {
             key_event_counters: Arc::new(KeyEventCounters::new()),
             list_waiters: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             list_waiter_count: Arc::new(AtomicU64::new(0)),
+            zset_waiters: Arc::new(parking_lot::Mutex::new(HashMap::new())),
+            zset_waiter_count: Arc::new(AtomicU64::new(0)),
             stream_waiters: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             waiter_counter: Arc::new(AtomicU64::new(0)),
         }
@@ -188,6 +197,46 @@ impl Broker {
                 let removed = before - queue.len();
                 if removed > 0 {
                     self.list_waiter_count
+                        .fetch_sub(removed as u64, Ordering::Relaxed);
+                }
+                if queue.is_empty() {
+                    waiters.remove(key);
+                }
+            }
+        }
+    }
+
+    pub fn has_zset_waiters(&self) -> bool {
+        self.zset_waiter_count.load(Ordering::Relaxed) > 0
+    }
+
+    pub fn register_zset_waiter(&self, key: &str, req: BlockedZPopRequest) {
+        let mut waiters = self.zset_waiters.lock();
+        waiters.entry(key.to_string()).or_default().push(req);
+        self.zset_waiter_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn wake_zset_waiters(&self, key: &str) {
+        let mut waiters = self.zset_waiters.lock();
+        let Some(senders) = waiters.remove(key) else {
+            return;
+        };
+        self.zset_waiter_count
+            .fetch_sub(senders.len() as u64, Ordering::Relaxed);
+        for req in senders {
+            let _ = req.tx.try_send(());
+        }
+    }
+
+    pub fn remove_zset_waiters_by_id(&self, keys: &[String], id: u64) {
+        let mut waiters = self.zset_waiters.lock();
+        for key in keys {
+            if let Some(queue) = waiters.get_mut(key) {
+                let before = queue.len();
+                queue.retain(|r| r.waiter_id != id);
+                let removed = before - queue.len();
+                if removed > 0 {
+                    self.zset_waiter_count
                         .fetch_sub(removed as u64, Ordering::Relaxed);
                 }
                 if queue.is_empty() {

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -76,3 +76,28 @@ fn blmove_immediate() {
     let resp2 = send_and_read(&mut conn, &["LRANGE", "dst", "0", "-1"]);
     assert!(resp2.contains("item"), "dst has item: {resp2}");
 }
+
+#[test]
+fn bzpopmin_wait_does_not_block_other_clients() {
+    let server = LuxServer::start();
+    let mut blocker = server.conn();
+    blocker
+        .set_read_timeout(Some(Duration::from_millis(5000)))
+        .unwrap();
+
+    blocker
+        .write_all(&resp_cmd(&["BZPOPMIN", "marker", "5"]))
+        .unwrap();
+    thread::sleep(Duration::from_millis(200));
+
+    let mut observer = server.conn();
+    let pong = send_and_read(&mut observer, &["PING"]);
+    assert!(pong.contains("PONG"), "PING while blocked: {pong}");
+
+    let mut pusher = server.conn();
+    send_and_read(&mut pusher, &["ZADD", "marker", "1", "wake"]);
+
+    let resp = read_all(&mut blocker);
+    assert!(resp.contains("marker"), "key: {resp}");
+    assert!(resp.contains("wake"), "member: {resp}");
+}

--- a/tests/live_ws.rs
+++ b/tests/live_ws.rs
@@ -3,7 +3,7 @@ mod common;
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{json, Value};
 use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpStream;
 use std::process::Child;
 use std::time::Duration;
 use tokio_tungstenite::connect_async;
@@ -26,12 +26,9 @@ impl Drop for LuxServer {
     }
 }
 
-fn free_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
+fn free_port_pair() -> (u16, u16) {
+    let ports = common::free_ports(2);
+    (ports[0], ports[1])
 }
 
 fn start_lux(resp_port: u16, http_port: u16, password: Option<&str>) -> LuxServer {
@@ -222,8 +219,7 @@ fn resp_command(port: u16, args: &[&str]) -> String {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn live_websocket_requires_auth_when_password_is_set() {
-    let resp_port = free_port();
-    let http_port = free_port();
+    let (resp_port, http_port) = free_port_pair();
     let _server = start_lux(resp_port, http_port, Some("secret"));
 
     let err = connect_async(format!("ws://127.0.0.1:{http_port}/live"))
@@ -244,8 +240,7 @@ async fn live_websocket_requires_auth_when_password_is_set() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn live_websocket_requires_lux_auth_token_when_auth_is_enabled() {
-    let resp_port = free_port();
-    let http_port = free_port();
+    let (resp_port, http_port) = free_port_pair();
     let _server = start_lux_with_env(
         resp_port,
         http_port,
@@ -308,8 +303,7 @@ async fn live_websocket_requires_lux_auth_token_when_auth_is_enabled() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn live_websocket_delivers_key_and_pubsub_events() {
-    let resp_port = free_port();
-    let http_port = free_port();
+    let (resp_port, http_port) = free_port_pair();
     let _server = start_lux(resp_port, http_port, None);
     let mut ws = connect_live(http_port, None).await;
 
@@ -341,8 +335,7 @@ async fn live_websocket_delivers_key_and_pubsub_events() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn live_websocket_table_subscription_receives_http_insert() {
-    let resp_port = free_port();
-    let http_port = free_port();
+    let (resp_port, http_port) = free_port_pair();
     let _server = start_lux(resp_port, http_port, None);
 
     let (status, created) = http_json_request(
@@ -406,8 +399,7 @@ async fn live_websocket_table_subscription_receives_http_insert() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn live_websocket_join_reacts_to_joined_table_insert() {
-    let resp_port = free_port();
-    let http_port = free_port();
+    let (resp_port, http_port) = free_port_pair();
     let _server = start_lux(resp_port, http_port, None);
 
     let (status, created) = http_json_request(
@@ -481,8 +473,7 @@ async fn live_websocket_join_reacts_to_joined_table_insert() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn live_websocket_unsubscribe_stops_delivery() {
-    let resp_port = free_port();
-    let http_port = free_port();
+    let (resp_port, http_port) = free_port_pair();
     let _server = start_lux(resp_port, http_port, None);
     let mut ws = connect_live(http_port, None).await;
 
@@ -508,8 +499,7 @@ async fn live_websocket_unsubscribe_stops_delivery() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn live_websocket_vector_near_receives_vector_changes() {
-    let resp_port = free_port();
-    let http_port = free_port();
+    let (resp_port, http_port) = free_port_pair();
     let _server = start_lux(resp_port, http_port, None);
     let mut ws = connect_live(http_port, None).await;
 
@@ -541,8 +531,7 @@ async fn live_websocket_vector_near_receives_vector_changes() {
 // (custom PK + FLOAT column) used by realtime apps.
 #[tokio::test]
 async fn live_table_events_with_custom_pk() {
-    let resp_port = free_port();
-    let http_port = free_port();
+    let (resp_port, http_port) = free_port_pair();
     let pw = "secret-pw-live";
     let _server = start_lux_with_env(
         resp_port,
@@ -614,8 +603,7 @@ async fn live_table_events_with_custom_pk() {
 // way an explicit TDELETE does. Covers the realtime half of table-row TTL.
 #[tokio::test]
 async fn live_table_row_ttl_emits_delete() {
-    let resp_port = free_port();
-    let http_port = free_port();
+    let (resp_port, http_port) = free_port_pair();
     let _server = start_lux(resp_port, http_port, None);
 
     let (status, created) = http_json_request(
@@ -660,8 +648,7 @@ async fn live_table_row_ttl_emits_delete() {
 // Multi-row insert (HTTP array body) with ?ttl applies the TTL to every row.
 #[tokio::test]
 async fn http_array_insert_applies_ttl_to_each() {
-    let resp_port = free_port();
-    let http_port = free_port();
+    let (resp_port, http_port) = free_port_pair();
     let _server = start_lux(resp_port, http_port, None);
 
     let (status, _) = http_json_request(
@@ -712,8 +699,7 @@ async fn http_array_insert_applies_ttl_to_each() {
 // exactly like the swarm/cursors use case but with no signup.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn live_anonymous_session_subscribes_granted_table() {
-    let resp_port = free_port();
-    let http_port = free_port();
+    let (resp_port, http_port) = free_port_pair();
     let _server = start_lux_with_env(
         resp_port,
         http_port,

--- a/tests/lua.rs
+++ b/tests/lua.rs
@@ -1,5 +1,8 @@
 mod common;
-use common::{send_and_read, LuxServer};
+use common::{read_all, resp_cmd, send_and_read, LuxServer};
+use std::io::Write;
+use std::thread;
+use std::time::Duration;
 
 #[test]
 fn eval_return_integer() {
@@ -57,6 +60,26 @@ fn evalsha_after_script_load() {
         .trim();
     let resp = send_and_read(&mut conn, &["EVALSHA", sha, "0"]);
     assert!(resp.contains(":99"), "evalsha returns 99: {resp}");
+}
+
+#[test]
+fn pipelined_evalsha_does_not_deadlock() {
+    let server = LuxServer::start();
+    let mut conn = server.conn();
+    let resp = send_and_read(&mut conn, &["SCRIPT", "LOAD", "return 123"]);
+    let sha = resp
+        .lines()
+        .find(|l| l.len() > 10 && !l.starts_with('$'))
+        .unwrap_or("")
+        .trim();
+
+    let mut pipeline = resp_cmd(&["EVALSHA", sha, "0"]);
+    pipeline.extend_from_slice(&resp_cmd(&["PING"]));
+    conn.write_all(&pipeline).unwrap();
+    thread::sleep(Duration::from_millis(50));
+    let resp = read_all(&mut conn);
+    assert!(resp.contains(":123"), "evalsha response: {resp}");
+    assert!(resp.contains("PONG"), "ping response: {resp}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This fixes a pipelined Lua deadlock and hardens blocking sorted-set pops:

- Pipelined `EVAL`/`EVALSHA` no longer holds the script read lock while applying deferred script results.
- `BZPOPMIN` and `BZPOPMAX` now use broker-managed sorted-set waiters instead of polling while idle.
- Regression tests cover idle `BZPOPMIN` responsiveness and pipelined `EVALSHA` lock behavior.

## Root Cause

The pipelined Lua deadlock came from holding `Store::script_read_guard()` across `apply_cmd_result`. When a deferred `EVAL` or `EVALSHA` result reached `handle_eval`, it tried to acquire `Store::script_write_guard()` while the read guard was still held. Once a writer was pending, later script readers also blocked, so unrelated commands such as `PING` could stop responding.

Blocking sorted-set pops previously looped with a timed sleep when no item was available. This made `BZPOPMIN`/`BZPOPMAX` depend on polling rather than the write paths that can make a blocked key ready. The replacement uses explicit waiters and write-driven wakeups, matching the existing blocking-list and stream waiter model more closely.

## Changes

- Add sorted-set waiter tracking to `Broker`.
- Register `BZPOPMIN`/`BZPOPMAX` callers as zset waiters and wake them when writes or scripts touch relevant keys.
- Recheck zset contents before waiting and again after waiter registration to avoid missed wakeups.
- Notify zset waiters from fast-path writes, MSET batching, generic command execution, transactions, pipelined shard batches, and script-key paths.
- Narrow pipelined script read-lock lifetime to the actual command execution call before applying deferred `EVAL`/`EVALSHA` results.

## Validation

```sh
cargo clippy --all-targets -- -D warnings
cargo test --lib --tests -- --skip fuzz
```

## Pre-Fix Repro

### Pipelined Lua Deadlock

Before the `src/lib.rs` script-lock fix, any pipelined `EVALSHA` could deadlock Lux. The pipeline path held `Store::script_read_guard()` across `apply_cmd_result`, then `handle_eval` tried to acquire `Store::script_write_guard()` for the deferred Lua script. A pending writer then blocked later readers, so unrelated commands such as `PING` stopped responding.

Minimal repro from the root of an unpatched Lux checkout:

```sh
rm -rf /tmp/lux-pipeline-deadlock
LUX_PORT=16380 \
LUX_SHARDS=4 \
LUX_SAVE_INTERVAL=0 \
LUX_DATA_DIR=/tmp/lux-pipeline-deadlock \
cargo run --bin lux
```

In another shell:

```sh
node - <<'NODE'
const net = require('node:net');

const command = (args) =>
  `*${args.length}\r\n${args.map((arg) => `$${Buffer.byteLength(arg)}\r\n${arg}\r\n`).join('')}`;

const request = (payload, done) =>
  new Promise((resolve, reject) => {
    const socket = net.connect({ host: '127.0.0.1', port: 16380 });
    const timer = setTimeout(() => {
      socket.destroy();
      reject(new Error('timeout'));
    }, 3000);
    let data = '';
    socket.on('connect', () => socket.write(payload));
    socket.on('data', (chunk) => {
      data += chunk.toString('utf8');
      if (done(data)) {
        clearTimeout(timer);
        socket.end();
        resolve(data);
      }
    });
    socket.on('error', reject);
  });

(async () => {
  const shaResp = await request(
    command(['SCRIPT', 'LOAD', 'return 123']),
    (data) => /\$40\r\n[0-9a-f]{40}\r\n/.test(data),
  );
  const sha = shaResp.match(/[0-9a-f]{40}/)[0];

  // Pre-fix: this pipelined request never completed.
  console.log(await request(
    command(['EVALSHA', sha, '0']) + command(['PING']),
    (data) => data.includes(':123') && data.includes('PONG'),
  ));

  // Pre-fix: after the deadlock, even a new connection timed out.
  console.log(await request(command(['PING']), (data) => data.includes('PONG')));
})().catch((error) => {
  console.error(error);
  process.exit(1);
});
NODE
```

The fixed behavior is that the pipelined request returns both `:123` and `+PONG`, and the follow-up `PING` returns `+PONG`.

The same failure can be reproduced with BullMQ, because its workers pipeline Lua scripts during startup. With the Lux server above still running, run this from any directory with Node available:

```sh
tmpdir="$(mktemp -d)"
cd "$tmpdir"
npm init -y >/dev/null
npm install bullmq@5.71.1 >/dev/null
node - <<'NODE'
const { Worker } = require('bullmq');

const connection = { host: '127.0.0.1', port: 16380 };
const workers = [
  new Worker('queueA', async () => null, { connection, concurrency: 2 }),
  new Worker('queueB', async () => null, { connection, concurrency: 2 }),
];

setTimeout(async () => {
  const net = require('node:net');
  const socket = net.connect(connection);
  const timer = setTimeout(() => {
    socket.destroy();
    console.error('PING timed out');
    process.exit(1);
  }, 3000);
  socket.on('connect', () => socket.write('*1\r\n$4\r\nPING\r\n'));
  socket.on('data', async (chunk) => {
    clearTimeout(timer);
    console.log(chunk.toString('utf8'));
    await Promise.allSettled(workers.map((worker) => worker.close()));
    socket.end();
    process.exit(0);
  });
}, 1500);
NODE
```

Before the fix, the `PING` timed out after the workers started. With the fix, it returns `+PONG`.

### BZPOP Polling Baseline

This PR changes the implementation because polling is the wrong primitive for a blocking command. The new behavior is event-driven:

- register blocked `BZPOPMIN`/`BZPOPMAX` callers as sorted-set waiters;
- wake waiters from writes and script-key paths that may make watched keys ready;
- recheck the sorted set before waiting and after waiter registration to avoid missed wakeups.

The regression test for this path asserts the intended contract: a blocked `BZPOPMIN` does not prevent another client from receiving `PONG`, and a subsequent `ZADD` wakes the blocked client with the pushed member.