### PR TITLE
feat(sdk): sync cookie session across tabs

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@luxdb/sdk",
-    "version": "2.8.1",
+    "version": "2.8.2",
     "description": "Official Lux TypeScript SDK for app data, auth, tables, vectors, realtime, and Redis-compatible direct access",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",

--- a/sdk/src/auth.ts
+++ b/sdk/src/auth.ts
@@ -331,6 +331,30 @@ export class LuxAuthClient {
 		};
 	}
 
+	async syncSessionFromStorage(
+		storage: LuxAuthStorage | null = this.storage,
+		options: { broadcast?: boolean } = {},
+	): Promise<LuxResult<{ session: LuxAuthSession | null }>> {
+		try {
+			if (!this.persistSession || !storage) return ok({ session: this.currentSession });
+			const previousSession = this.currentSession;
+			const previousRaw = this.storedSessionRaw;
+			const raw = await storage.getItem(this.storageKey);
+			const event: LuxAuthChangeEvent = raw
+				? (previousSession ? 'SESSION_UPDATED' : 'SIGNED_IN')
+				: 'SIGNED_OUT';
+
+			await this.applyExternalSession(raw, undefined, true);
+			if (options.broadcast && raw !== previousRaw) {
+				if (raw && this.currentSession) this.broadcast(event, raw);
+				else if (!raw && previousSession) this.broadcast('SIGNED_OUT', null);
+			}
+			return ok({ session: this.currentSession });
+		} catch (error) {
+			return err('LUX_AUTH_SESSION_ERROR', 'Failed to sync auth session', toLuxError(error));
+		}
+	}
+
 	async signUp(options: LuxSignUpOptions): Promise<LuxResult<LuxAuthSessionResult>> {
 		try {
 			const session = await this.requestRaw<LuxAuthSession>('/auth/v1/signup', {
@@ -709,7 +733,7 @@ export class LuxAuthClient {
 					raw?: string | null;
 				} | undefined;
 				if (!message || !('raw' in message)) return;
-				void this.applyExternalSession(message.raw ?? null, message.event);
+				void this.applyBroadcastSession(message.raw ?? null, message.event);
 			});
 		}
 
@@ -730,6 +754,22 @@ export class LuxAuthClient {
 			undefined,
 			notify,
 		);
+	}
+
+	private async applyBroadcastSession(
+		raw: string | null,
+		event?: LuxAuthChangeEvent,
+	): Promise<void> {
+		if (this.persistSession && this.storage) {
+			try {
+				if (raw) await this.storage.setItem(this.storageKey, raw);
+				else await this.storage.removeItem(this.storageKey);
+			} catch {
+				// A broadcast should still update the live client state even if
+				// this tab cannot persist the mirrored storage write.
+			}
+		}
+		await this.applyExternalSession(raw, event);
 	}
 
 	private async applyExternalSession(

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -42,7 +42,13 @@ export function createBrowserClient<DB extends Record<string, object> = LuxSchem
 	const usesDefaultCookieStorage = authOptions.storage === undefined;
 	const isBrowser = typeof globalThis !== 'undefined' && Boolean((globalThis as any).document);
 	const isSingleton = options.isSingleton ?? isBrowser;
-	if (isSingleton && browserClient) return browserClient as LuxProjectClient<DB>;
+	const storageKey = authOptions.storageKey ?? (
+		usesDefaultCookieStorage ? DEFAULT_SESSION_COOKIE : 'lux.auth.session'
+	);
+	if (isSingleton && browserClient) {
+		syncBrowserClient(browserClient);
+		return browserClient as LuxProjectClient<DB>;
+	}
 
 	const client = createClient<DB>(url, key, {
 		fetch: options.fetch,
@@ -51,14 +57,17 @@ export function createBrowserClient<DB extends Record<string, object> = LuxSchem
 			persistSession: true,
 			autoRefreshToken: true,
 			...authOptions,
-			storageKey: authOptions.storageKey ?? (
-				usesDefaultCookieStorage ? DEFAULT_SESSION_COOKIE : 'lux.auth.session'
-			),
+			storageKey,
 			storage: usesDefaultCookieStorage
 				? browserCookieStorage(resolvedCookieOptions, options.cookies)
 				: authOptions.storage,
 		},
 	});
+	syncBrowserClient(client);
 	if (isSingleton) browserClient = client;
 	return client;
+}
+
+function syncBrowserClient(client: LuxProjectClient<any>): void {
+	void client.auth.syncSessionFromStorage(undefined, { broadcast: true });
 }

--- a/sdk/src/project.ts
+++ b/sdk/src/project.ts
@@ -134,6 +134,11 @@ export class LuxProjectClient<DB extends Record<string, object> = LuxSchema> {
 			apiKey: this.key,
 			fetch: this.fetchImpl,
 		});
+		this.auth.onAuthStateChange((event) => {
+			if (event === 'INITIAL_SESSION') return;
+			if (event === 'SIGNED_OUT') this.closeLiveSocket();
+			else this.restartLiveSocket();
+		});
 		this.storage = new LuxStorageNamespace(this);
 	}
 
@@ -304,20 +309,42 @@ export class LuxProjectClient<DB extends Record<string, object> = LuxSchema> {
 		};
 
 		socket.onclose = () => {
-			if (this.liveSocket === socket) this.liveSocket = null;
-			if (this.liveSubscriptions.size > 0) {
-				for (const subscription of this.liveSubscriptions.values()) {
-					this.livePending.push(JSON.stringify({
-						type: 'live.subscribe',
-						id: subscription.id,
-						spec: subscription.spec,
-					}));
-				}
+			const isActiveSocket = this.liveSocket === socket;
+			if (isActiveSocket) this.liveSocket = null;
+			if (isActiveSocket && this.liveSubscriptions.size > 0) {
+				this.queueLiveResubscriptions();
 				setTimeout(() => {
 					void this.ensureLiveSocket();
 				}, 1000);
 			}
 		};
+	}
+
+	private restartLiveSocket(): void {
+		if (this.liveSubscriptions.size === 0) return;
+		const socket = this.liveSocket;
+		this.liveSocket = null;
+		this.livePending = [];
+		this.queueLiveResubscriptions();
+		socket?.close();
+		void this.ensureLiveSocket();
+	}
+
+	private closeLiveSocket(): void {
+		const socket = this.liveSocket;
+		this.liveSocket = null;
+		this.livePending = [];
+		socket?.close();
+	}
+
+	private queueLiveResubscriptions(): void {
+		for (const subscription of this.liveSubscriptions.values()) {
+			this.livePending.push(JSON.stringify({
+				type: 'live.subscribe',
+				id: subscription.id,
+				spec: subscription.spec,
+			}));
+		}
 	}
 
 	private sendLive(message: Record<string, unknown>): void {

--- a/sdk/tests/auth.test.ts
+++ b/sdk/tests/auth.test.ts
@@ -122,6 +122,72 @@ describe('LuxAuthClient session state', () => {
 		}
 	});
 
+	test('broadcast sign-in survives storage reconciliation in the receiving tab', async () => {
+		const originalDocument = (globalThis as any).document;
+		const originalBroadcastChannel = (globalThis as any).BroadcastChannel;
+		const channels = new Map<string, Set<FakeBroadcastChannel>>();
+		(globalThis as any).document = {
+			visibilityState: 'visible',
+			addEventListener() {},
+		};
+		(globalThis as any).BroadcastChannel = class extends FakeBroadcastChannel {
+			constructor(name: string) {
+				super(name, channels);
+			}
+		};
+
+		try {
+			const firstStorage = memoryStorage();
+			const secondBacking = new Map<string, string>();
+			const writes: string[] = [];
+			const secondStorage: LuxAuthStorage = {
+				getItem: (key) => secondBacking.get(key) ?? null,
+				setItem: (key, value) => {
+					writes.push(value);
+					secondBacking.set(key, value);
+				},
+				removeItem: (key) => {
+					secondBacking.delete(key);
+				},
+			};
+			const first = new LuxAuthClient({
+				persistSession: true,
+				autoRefreshToken: false,
+				storage: firstStorage,
+				storageKey: 'lux.broadcast.reconcile',
+			});
+			const second = new LuxAuthClient({
+				persistSession: true,
+				autoRefreshToken: false,
+				storage: secondStorage,
+				storageKey: 'lux.broadcast.reconcile',
+			});
+			const events: string[] = [];
+			let resolveInitial!: () => void;
+			const initial = new Promise<void>((resolve) => {
+				resolveInitial = resolve;
+			});
+			second.onAuthStateChange((event, nextSession) => {
+				events.push(`${event}:${nextSession?.access_token ?? 'none'}`);
+				if (event === 'INITIAL_SESSION') resolveInitial();
+			});
+			await initial;
+
+			await first.setSession(session({ access_token: 'broadcast-token' }));
+			await Promise.resolve();
+
+			expect(events).toContain('SESSION_UPDATED:broadcast-token');
+			expect(writes).toHaveLength(1);
+			expect((await second.getSession()).data?.session?.access_token)
+				.toBe('broadcast-token');
+		} finally {
+			if (originalDocument === undefined) delete (globalThis as any).document;
+			else (globalThis as any).document = originalDocument;
+			if (originalBroadcastChannel === undefined) delete (globalThis as any).BroadcastChannel;
+			else (globalThis as any).BroadcastChannel = originalBroadcastChannel;
+		}
+	});
+
 	test('signOut clears local state when remote logout fails', async () => {
 		const storage = memoryStorage();
 		const auth = new LuxAuthClient({

--- a/sdk/tests/browser-ssr.test.ts
+++ b/sdk/tests/browser-ssr.test.ts
@@ -314,6 +314,109 @@ describe('browser and SSR clients', () => {
 		}
 	});
 
+	test('browser auth broadcasts cookie changes from client load', async () => {
+		const originalDocument = (globalThis as any).document;
+		const originalBroadcastChannel = (globalThis as any).BroadcastChannel;
+		const browserCookies = new Map<string, string>();
+		const channels = new Map<string, Set<FakeBroadcastChannel>>();
+		const document = createCookieDocument(browserCookies);
+		(globalThis as any).document = document;
+		(globalThis as any).BroadcastChannel = class extends FakeBroadcastChannel {
+			constructor(name: string) {
+				super(name, channels);
+			}
+		};
+
+		try {
+			const receiver = createBrowserClient(
+				'http://localhost:3957/v1/project',
+				'lux_pub_test',
+				{ isSingleton: false, auth: { autoRefreshToken: false } },
+			);
+			const events: string[] = [];
+			const subscription = receiver.auth.onAuthStateChange((event, session) => {
+				events.push(`${event}:${session?.access_token ?? 'none'}`);
+			});
+
+			await waitFor(() => events.includes('INITIAL_SESSION:none'));
+
+			const value = encodeSessionCookie({
+				access_token: 'server-load-access-token',
+				refresh_token: 'server-load-refresh-token',
+				expires_in: 3600,
+				token_type: 'bearer',
+				user: { id: 'usr_server_load', email: 'server-load@example.com' },
+			});
+			browserCookies.set('lux-auth-session', value);
+			createBrowserClient(
+				'http://localhost:3957/v1/project',
+				'lux_pub_test',
+				{
+					isSingleton: false,
+					auth: { autoRefreshToken: false },
+				},
+			);
+
+			await waitFor(() => events.includes('SIGNED_IN:server-load-access-token'));
+			subscription.unsubscribe();
+		} finally {
+			if (originalDocument === undefined) {
+				delete (globalThis as any).document;
+			} else {
+				(globalThis as any).document = originalDocument;
+			}
+			if (originalBroadcastChannel === undefined) {
+				delete (globalThis as any).BroadcastChannel;
+			} else {
+				(globalThis as any).BroadcastChannel = originalBroadcastChannel;
+			}
+		}
+	});
+
+	test('browser singleton syncs cookie changes on repeated client load', async () => {
+		const originalDocument = (globalThis as any).document;
+		const browserCookies = new Map<string, string>();
+		const document = createCookieDocument(browserCookies);
+		(globalThis as any).document = document;
+
+		try {
+			const browser = createBrowserClient(
+				'http://localhost:3957/v1/project-singleton-sync',
+				'lux_pub_sync',
+				{ auth: { autoRefreshToken: false } },
+			);
+			const events: string[] = [];
+			const subscription = browser.auth.onAuthStateChange((event, session) => {
+				events.push(`${event}:${session?.access_token ?? 'none'}`);
+			});
+
+			await waitFor(() => events.includes('INITIAL_SESSION:none'));
+
+			browserCookies.set('lux-auth-session', encodeSessionCookie({
+				access_token: 'singleton-sync-access-token',
+				refresh_token: 'singleton-sync-refresh-token',
+				expires_in: 3600,
+				token_type: 'bearer',
+				user: { id: 'usr_singleton_sync', email: 'singleton-sync@example.com' },
+			}));
+			const sameBrowser = createBrowserClient(
+				'http://localhost:3957/v1/project-singleton-sync',
+				'lux_pub_sync',
+				{ auth: { autoRefreshToken: false } },
+			);
+
+			expect(sameBrowser).toBe(browser);
+			await waitFor(() => events.includes('SIGNED_IN:singleton-sync-access-token'));
+			subscription.unsubscribe();
+		} finally {
+			if (originalDocument === undefined) {
+				delete (globalThis as any).document;
+			} else {
+				(globalThis as any).document = originalDocument;
+			}
+		}
+	});
+
 	test('client sign out reconciles a session created by an SSR redirect', async () => {
 		const originalDocument = (globalThis as any).document;
 		const browserCookies = new Map<string, string>();
@@ -442,6 +545,30 @@ function createCookieDocument(cookies: Map<string, string>): {
 			for (const listener of listeners) listener();
 		},
 	};
+}
+
+class FakeBroadcastChannel {
+	private listeners = new Set<(event: { data?: unknown }) => void>();
+
+	constructor(
+		private name: string,
+		private channels: Map<string, Set<FakeBroadcastChannel>>,
+	) {
+		const peers = channels.get(name) ?? new Set();
+		peers.add(this);
+		channels.set(name, peers);
+	}
+
+	addEventListener(_type: string, listener: (event: { data?: unknown }) => void) {
+		this.listeners.add(listener);
+	}
+
+	postMessage(data: unknown) {
+		for (const peer of this.channels.get(this.name) ?? []) {
+			if (peer === this) continue;
+			for (const listener of peer.listeners) listener({ data });
+		}
+	}
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {

--- a/sdk/tests/project.test.ts
+++ b/sdk/tests/project.test.ts
@@ -577,6 +577,161 @@ describe('Lux project client', () => {
 		expect(JSON.parse(sockets[0].sent[1])).toEqual({ type: 'live.unsubscribe', id });
 	});
 
+	test('live subscriptions reconnect when auth signs in after subscribe', async () => {
+		const sockets: FakeWebSocket[] = [];
+		class FakeWebSocket {
+			static CONNECTING = 0;
+			static OPEN = 1;
+			static CLOSED = 3;
+			readonly url: string;
+			readyState = FakeWebSocket.CONNECTING;
+			onopen: (() => void) | null = null;
+			onmessage: ((event: { data: string }) => void) | null = null;
+			onerror: (() => void) | null = null;
+			onclose: (() => void) | null = null;
+			sent: string[] = [];
+
+			constructor(url: string) {
+				this.url = url;
+				sockets.push(this);
+			}
+
+			send(message: string) {
+				this.sent.push(message);
+			}
+
+			close() {
+				this.readyState = FakeWebSocket.CLOSED;
+				this.onclose?.();
+			}
+
+			open() {
+				this.readyState = FakeWebSocket.OPEN;
+				this.onopen?.();
+			}
+
+			emit(message: unknown) {
+				this.onmessage?.({ data: JSON.stringify(message) });
+			}
+		}
+
+		const client = createClient('http://localhost:3957/v1/project', 'lux_pub_test', {
+			websocket: FakeWebSocket as unknown as typeof WebSocket,
+			auth: { persistSession: false, autoRefreshToken: false },
+		});
+
+		const livePromise = client.table('messages').live();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(sockets).toHaveLength(1);
+		expect(sockets[0].url).toBe('ws://localhost:3957/v1/project/live?apikey=lux_pub_test');
+
+		sockets[0].open();
+		const firstSubscribe = JSON.parse(sockets[0].sent[0]);
+		sockets[0].emit({
+			type: 'live.event',
+			id: firstSubscribe.id,
+			event: { kind: 'snapshot', rows: [] },
+		});
+		const { live, error } = await livePromise;
+		expect(error).toBeNull();
+		expect(live).not.toBeNull();
+
+		await client.auth.setSession({
+			access_token: 'user-jwt',
+			refresh_token: 'refresh',
+			expires_in: 3600,
+			token_type: 'bearer',
+			user: { id: 'usr_1', email: 'user@example.com' },
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(sockets).toHaveLength(2);
+		expect(sockets[1].url).toBe(
+			'ws://localhost:3957/v1/project/live?apikey=lux_pub_test&access_token=user-jwt',
+		);
+		sockets[1].open();
+		expect(JSON.parse(sockets[1].sent[0])).toEqual(firstSubscribe);
+
+		await live!.unsubscribe();
+	});
+
+	test('live subscriptions close without anonymous reconnect on sign out', async () => {
+		const sockets: FakeWebSocket[] = [];
+		class FakeWebSocket {
+			static CONNECTING = 0;
+			static OPEN = 1;
+			static CLOSED = 3;
+			readonly url: string;
+			readyState = FakeWebSocket.CONNECTING;
+			onopen: (() => void) | null = null;
+			onmessage: ((event: { data: string }) => void) | null = null;
+			onerror: (() => void) | null = null;
+			onclose: (() => void) | null = null;
+			sent: string[] = [];
+
+			constructor(url: string) {
+				this.url = url;
+				sockets.push(this);
+			}
+
+			send(message: string) {
+				this.sent.push(message);
+			}
+
+			close() {
+				this.readyState = FakeWebSocket.CLOSED;
+				this.onclose?.();
+			}
+
+			open() {
+				this.readyState = FakeWebSocket.OPEN;
+				this.onopen?.();
+			}
+
+			emit(message: unknown) {
+				this.onmessage?.({ data: JSON.stringify(message) });
+			}
+		}
+
+		const client = createClient('http://localhost:3957/v1/project', 'lux_pub_test', {
+			websocket: FakeWebSocket as unknown as typeof WebSocket,
+			auth: { persistSession: false, autoRefreshToken: false },
+		});
+		await client.auth.setSession({
+			access_token: 'user-jwt',
+			refresh_token: 'refresh',
+			expires_in: 3600,
+			token_type: 'bearer',
+			user: { id: 'usr_1', email: 'user@example.com' },
+		});
+
+		const livePromise = client.table('messages').live();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(sockets).toHaveLength(1);
+		expect(sockets[0].url).toBe(
+			'ws://localhost:3957/v1/project/live?apikey=lux_pub_test&access_token=user-jwt',
+		);
+
+		sockets[0].open();
+		const firstSubscribe = JSON.parse(sockets[0].sent[0]);
+		sockets[0].emit({
+			type: 'live.event',
+			id: firstSubscribe.id,
+			event: { kind: 'snapshot', rows: [] },
+		});
+		const { live, error } = await livePromise;
+		expect(error).toBeNull();
+		expect(live).not.toBeNull();
+
+		await client.auth.clearSession();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(sockets).toHaveLength(1);
+		expect(sockets[0].readyState).toBe(FakeWebSocket.CLOSED);
+
+		await live!.unsubscribe();
+	});
+
 	test('live() surfaces a rejected subscription as { error }', async () => {
 		const sockets: any[] = [];
 		class FakeWebSocket {


### PR DESCRIPTION
**Summary**

Fixes browser auth sync across tabs and active live subscriptions.

- Sync browser auth from storage whenever `createBrowserClient()` runs, including singleton reuse.
- Broadcast synced cookie/session changes so tabs updated by SSR redirects can notify other tabs.
- Mirror received auth broadcasts into local storage before applying them, preventing later storage reconciliation from wiping the broadcast session.
- Reconnect active `.live()` subscriptions on sign-in/session refresh so they use the latest token.
- Close live sockets on sign-out without reconnecting anonymously.

**Why**

Server-side auth flows can update the browser-readable auth cookie without the active browser client directly calling `signInWithPassword()`. In SvelteKit-style redirects, the tab that receives the updated cookie should detect it on the next client load, update auth state, and broadcast that change to other tabs.

Previously, sign-out propagated more reliably than sign-in, and live subscriptions could reconnect anonymously during logout.

**Tests**

```bash
bun test sdk/tests/project.test.ts sdk/tests/auth.test.ts sdk/tests/browser-ssr.test.ts
bun run build
```

**Coverage Added**

- Broadcast sign-in survives storage reconciliation in receiving tabs.
- Browser client syncs cookie changes on repeated client load.
- Browser client broadcasts cookie changes from client load.
- Live subscriptions reconnect with a token after sign-in.
- Live subscriptions close without anonymous reconnect on sign-out.