### PR TITLE
feat(enc): encryption at rest with env-sourced seal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ harness-rules.toml
 .env.*
 **/.env
 **/.env.*
+
+# Encryption keyring runtime artifacts (never commit)
+lux.enc
+*.enc.seal
+*.enc.tmp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "reqwest",
+ "ring",
  "rmp",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ p256 = { version = "0.13", features = ["jwk"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
+ring = "0.17"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Lux Cloud is the fastest path when you want to build an app backend around Lux w
 ## Features
 
 - **200+ commands** -- strings, lists, hashes, sets, sorted sets, streams, vectors, geo, time series, tables, HyperLogLog, bitops, pub/sub, transactions
-- **Relational tables** -- TCREATE, TINSERT, TSELECT, TUPDATE (WHERE), TDELETE (WHERE), TALTER with typed fields (str, int, float, bool, timestamp, uuid, vector, json, array), unique constraints, foreign keys, joins, GROUP BY/HAVING, WHERE/ORDER BY/LIMIT, `IN`/`NOT IN`, JSON dot-path queries with `IS VALID`, array `CONTAINS`, declared JSON-path indexes, and vector-aware NEAR queries. Structured data without standing up a separate primary database
+- **Relational tables** -- TCREATE, TINSERT, TSELECT, TUPDATE (WHERE), TDELETE (WHERE), TALTER with typed fields (str, int, float, bool, timestamp, uuid, vector, json, array), unique constraints, foreign keys, encrypted columns, joins, GROUP BY/HAVING, WHERE/ORDER BY/LIMIT, `IN`/`NOT IN`, JSON dot-path queries with `IS VALID`, array `CONTAINS`, declared JSON-path indexes, and vector-aware NEAR queries. Structured data without standing up a separate primary database
 - **Realtime key subscriptions** -- KSUB/KUNSUB: subscribe to key patterns, receive events when matching keys are mutated. Zero overhead when unused. No global config flags, no separate services. Unlike Redis keyspace notifications which tax every write globally, KSUB is surgical and async
 - **Native time series** -- TSADD, TSGET, TSRANGE, TSMRANGE with aggregation (avg, sum, min, max, count, std), retention policies, and label-based filtering. No modules, no sidecars. TSGET 4x faster than Redis GET
 - **Native vector search** -- VSET, VGET, VSEARCH with cosine similarity and metadata filtering, plus `VECTOR(n)` table columns that compose with table filters and live queries. No extensions, no sidecars
@@ -295,6 +295,12 @@ redis-cli TSELECT '*' FROM events WHERE metadata.count IS VALID       # existenc
 redis-cli TSELECT '*' FROM events WHERE tags CONTAINS a               # array membership; tags.0 indexes an element
 redis-cli TINDEX events metadata.plan.tier STR                        # declare a JSON-path index
 
+# Encrypted columns keep values encrypted in WAL/snapshots/tiered storage.
+# Add SEARCHABLE when you need exact equality filters or UNIQUE. ENCRYPTED
+# columns do not support DEFAULT because defaults are stored in schema metadata.
+redis-cli TCREATE secrets id UUID PRIMARY KEY, token STR ENCRYPTED, email STR UNIQUE ENCRYPTED SEARCHABLE
+redis-cli TSELECT '*' FROM secrets WHERE email = alice@example.com
+
 # Alter tables
 redis-cli TALTER users ADD role STR
 redis-cli TALTER users DROP role
@@ -302,7 +308,7 @@ redis-cli TALTER users DROP role
 
 Field types: `STR`, `INT`, `FLOAT`, `BOOL`, `TIMESTAMP`, `UUID`, `VECTOR(n)`, `JSON`, `ARRAY`.
 WHERE operators: `= != < > <= >=`, `IN`/`NOT IN`, JSON `IS VALID`/`IS NOT VALID`, and `CONTAINS`.
-Use SQL-style constraints like `UNIQUE`, `PRIMARY KEY`, and `REFERENCES table(field)`.
+Use SQL-style constraints like `UNIQUE`, `PRIMARY KEY`, and `REFERENCES table(field)`. Self-hosted encrypted columns use native `ENC` state (`ENC INIT`, `ENC ROTATE`, `ENC LIST`); Lux Cloud auto-initializes hosted projects.
 
 ### CLI
 

--- a/TABLE_FEATURE_INTERACTION_MATRIX.md
+++ b/TABLE_FEATURE_INTERACTION_MATRIX.md
@@ -1,0 +1,91 @@
+# Table Feature Interaction Matrix
+
+This is the regression map for table features that share derived state. A table
+change is not done when the leaf feature works in isolation; it also has to keep
+these interactions correct across snapshots, WAL replay, tiered storage, indexes,
+constraints, and query planning.
+
+## How to Use This Matrix
+
+- Add a row when a table feature introduces stored or derived state.
+- Mark the invariant that must survive insert, update, delete, upsert, snapshot,
+  and WAL replay.
+- Add at least one regression test for every high-risk `Required` interaction.
+- If an interaction is intentionally unsupported, test the rejection path.
+- Prefer adversarial tests that compose features. Single-feature happy-path tests
+  do not catch index/WAL/TTL/order regressions.
+- Every row with `Status = Gap` is either unsupported behavior that needs an
+  explicit rejection test, or supported behavior that needs a regression test.
+
+## Derived State Surfaces
+
+Most table bugs come from writing one surface and forgetting another. Any feature
+that touches a user-visible value needs an answer for each surface below.
+
+| Surface | What can go stale or leak | Required check |
+| --- | --- | --- |
+| Row hash | canonical stored field bytes, hidden TTL field | insert/update/upsert/delete replace the right fields and do not leave hidden state behind |
+| Primary ordering set | default scan order for INT and non-INT primary keys | WAL replay and updates preserve original order unless the user asked for another order |
+| Scalar indexes | string/numeric/bool/timestamp lookup sets and sorted sets | update/delete/upsert remove old entries before adding new entries |
+| Unique indexes | value-to-primary-key holder map | stale holders are purged, expired rows do not block reuse, updates rekey correctly |
+| Path indexes | JSON/ARRAY extracted scalar values | values match full-scan semantics and never expose encrypted roots |
+| Vector indexes | vector bytes plus distance candidate planning | updates/deletes/replay keep `NEAR` candidates in sync with row hashes |
+| TTL index | global expiry sorted set plus per-row hidden deadline | TTL clear removes both surfaces; replay does not resurrect old deadlines |
+| WAL | command log for crash recovery | replay reproduces rows, derived indexes, order, TTL, and constraints without plaintext leaks |
+| Snapshots | compact persisted image | snapshot/load preserves encrypted bytes, derived state, expiry, and schema flags |
+| Query planner | index candidate selection, fallback scan, OR planning, joins | indexed and non-indexed paths return the same rows and reject unsupported encrypted access |
+| Live/change events | emitted row payloads and delete/update signals | events expose allowed plaintext only after normal table read rules |
+
+## Encryption Interactions
+
+| Feature | Interaction | Required invariant | Status | Coverage |
+| --- | --- | --- | --- | --- |
+| `ENCRYPTED` scalar | row storage | row hash, snapshots, tiered storage, and WAL never contain plaintext | Covered | `encrypted_field_stores_ciphertext_and_returns_plaintext`, `encrypted_snapshot_does_not_store_plaintext_and_loads`, `encrypted_wal_does_not_store_plaintext_and_replays_latest_update` |
+| `ENCRYPTED SEARCHABLE` | equality filter | `WHERE col = value` uses blind indexes and returns plaintext rows | Covered | `encrypted_field_stores_ciphertext_and_returns_plaintext` |
+| `ENCRYPTED` non-searchable | equality / range filters | equality requires `SEARCHABLE`; range and other operators reject | Covered | `encrypted_query_guards_reject_unsupported_filters_and_ordering` |
+| `ENCRYPTED` mutation predicates | update/delete `WHERE` filters | mutation scans use the same encrypted predicate rules as reads | Covered | `encrypted_mutation_guards_reject_unsupported_predicates_and_conflicts` |
+| `ENCRYPTED` | `ORDER BY` | encrypted columns cannot be ordered, including `json.path` ordering on encrypted roots | Covered | `encrypted_query_guards_reject_unsupported_filters_and_ordering` |
+| `ENCRYPTED UNIQUE SEARCHABLE` | insert/update unique index | uniqueness is enforced on plaintext semantics and stale blind-index entries are removed on update | Covered | `encrypted_searchable_unique_uses_plaintext_semantics`, `encrypted_searchable_unique_rekeys_on_update` |
+| `ENCRYPTED UNIQUE SEARCHABLE` | delete unique/index cleanup | deleting a row removes blind unique holders and searchable index members so values can be reused | Covered | `encrypted_searchable_unique_delete_cleans_blind_indexes_and_allows_reuse` |
+| `ENCRYPTED UNIQUE SEARCHABLE` | upsert conflict target | `TUPSERT ... ON CONFLICT encrypted_unique_col` finds and updates the matching row | Covered | `encrypted_upsert_on_searchable_unique_replays_with_ttl_clear` |
+| `ENCRYPTED` non-searchable | upsert conflict target | non-searchable encrypted columns cannot be used as conflict targets via full-table decrypting scans | Covered | `encrypted_mutation_guards_reject_unsupported_predicates_and_conflicts` |
+| `ENCRYPTED` | `RETURNING` | insert/update/delete returning paths emit plaintext rows while committed storage remains ciphertext | Covered | `encrypted_returning_paths_emit_plaintext_and_store_ciphertext` |
+| `ENCRYPTED` defaults | schema/WAL literals | encrypted columns reject `DEFAULT` so schema metadata and raw `TALTER` WAL never persist default plaintext | Covered | `encrypted_field_rejects_invalid_combinations`, `encrypted_add_column_rejects_default_and_keeps_existing_rows_readable` |
+| `ENCRYPTED` add column | nullable backfill | adding a nullable encrypted column leaves existing rows readable without storing undecryptable empty bytes | Covered | `encrypted_add_column_rejects_default_and_keeps_existing_rows_readable` |
+| `ENCRYPTED` | HTTP table routes | JSON table create/insert/query paths honor encrypted schema flags, return plaintext rows, and store ciphertext | Covered | `http_table_routes_round_trip_encrypted_columns_without_raw_plaintext`, `http_table_create_rejects_encrypted_default` |
+| `ENCRYPTED` + WAL | nonnumeric primary key ordering | replayed updates preserve original default scan order | Covered | `encrypted_wal_replay_preserves_uuid_row_order_after_update` |
+| `ENCRYPTED` + WAL | TTL clear | replay of `TTL 0` removes both TTL index and hidden row deadline | Covered | `encrypted_wal_replay_clears_hidden_ttl_field` |
+| `ENCRYPTED` + upsert + WAL | conflict update with TTL clear | replay preserves upserted row identity, updated plaintext, unique blind index, and cleared TTL state | Covered | `encrypted_upsert_on_searchable_unique_replays_with_ttl_clear` |
+| `ENCRYPTED JSON` | `TINDEX json.path` | path indexes are rejected so scalar path values are not stored in plaintext index keys | Covered | `tindex_rejects_encrypted_json_column` |
+| `ENCRYPTED JSON` | JSON path filters | dot-path filters on encrypted roots reject instead of decrypting every row or leaking planner behavior | Covered | `encrypted_query_guards_reject_unsupported_filters_and_ordering` |
+| `ENCRYPTED JSON/ARRAY` | searchable equality | `SEARCHABLE` is rejected for JSON/ARRAY until whole-document canonical search semantics are deliberately designed | Covered | `encrypted_json_and_array_cannot_be_searchable_and_paths_reject` |
+| `ENCRYPTED` | joins | join keys cannot be encrypted; reject instead of doing decrypted hash joins | Covered | `encrypted_join_keys_are_rejected` |
+| `ENCRYPTED` | live/change events | table streams emit normal plaintext row payloads; raw key subscriptions emit only key metadata and not encrypted values | Covered | `live_encrypted_table_streams_plaintext_rows_without_key_event_value_leak` |
+| `ENCRYPTED SEARCHABLE` | RLS grants | row-scoped grants over encrypted searchable columns resolve through blind indexes; non-searchable encrypted grant predicates reject | Covered | `read_grant_on_encrypted_searchable_column_filters_through_blind_index`, `grant_on_encrypted_non_searchable_column_is_rejected` |
+| encryption key rotation | mixed-key rows | old keys decrypt; only active key writes; snapshots and WAL replay preserve key ids across update and search | Covered | `encrypted_key_rotation_survives_wal_replay_update_and_search`, `encrypted_snapshot_does_not_store_plaintext_and_loads` |
+
+## Core Table Interaction Backlog
+
+These are the next high-value compatibility rows outside encryption. They should
+be filled in as regressions when touching the corresponding subsystem.
+
+| Feature | Interaction | Required invariant | Status |
+| --- | --- | --- | --- |
+| `SEQUENCE PARTITION BY` | concurrent insert/upsert | generated values are unique and monotonic within partition | Gap |
+| `SEQUENCE PARTITION BY` | WAL replay/snapshot | counters resume at or above the highest committed value per partition | Gap |
+| `SEQUENCE PARTITION BY` | delete/reinsert | deleted rows do not allow duplicate sequence reuse | Gap |
+| Foreign keys | non-INT references | FK checks use encoded logical value semantics for all supported key types | Gap |
+| Foreign keys | TTL expiry | expired parent rows cannot satisfy new child inserts; expiry cleanup removes dependent state according to declared behavior | Gap |
+| Foreign keys | delete/cascade | row hash, indexes, unique holders, TTL entries, and live events agree after cascade | Gap |
+| Vector fields | `NEAR` with `WHERE` | vector candidate planning and scalar filters produce the same rows as full filtering | Gap |
+| Vector fields | update/delete/replay | vector index entries are replaced or removed with no stale candidates | Gap |
+| JSON/ARRAY paths | index vs full scan | `TINDEX` results exactly match non-indexed dot-path filters for missing/null/type mismatch cases | Gap |
+| JSON/ARRAY paths | update/delete/replay | path index entries are removed on update/delete and rebuilt on WAL replay | Gap |
+| Row TTL | unique reuse | expired rows do not block unique values, and purging removes all index forms | Gap |
+| Row TTL | snapshot downtime | expired rows are not resurrected after load; future deadlines keep their remaining absolute deadline | Gap |
+| Row TTL | live events | automatic expiry emits the intended delete/update signal exactly once | Gap |
+| RLS grants | joins/subqueries | policy evaluation cannot be bypassed through joined predicates or aliased columns | Gap |
+| RLS grants | OR predicates | every branch is checked under the same access rules as simple predicates | Gap |
+| RLS grants | writes | update/delete policies and `WITH CHECK` observe generated/default/encrypted values consistently | Gap |
+| `RETURNING` | generated/default values | returned rows match committed rows after defaults, serials, UUIDs, TTL, and encryption transforms | Gap |
+| `RETURNING` | multi-row mutations | partial failures do not emit rows for uncommitted mutations | Gap |

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4336,6 +4336,7 @@ pub(crate) fn put_grant(
             }
             None => grant.predicate.clone(),
         };
+        validate_grant_predicate_for_schema(store, cache, &grant.table, &predicate, now)?;
         let predicate = crate::grants::predicate_to_string(&predicate);
         let _ =
             tables::table_delete_where(store, cache, GRANTS_TABLE, &["id", "=", id.as_str()], now);
@@ -4354,6 +4355,109 @@ pub(crate) fn put_grant(
         )?;
     }
     Ok(())
+}
+
+fn validate_grant_predicate_for_schema(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    table: &str,
+    predicate: &crate::grants::Predicate,
+    now: Instant,
+) -> Result<(), String> {
+    let Ok(schema) = tables::load_schema(store, cache, table, now) else {
+        return Ok(());
+    };
+    validate_grant_predicate_columns(store, cache, table, &schema, predicate, now)
+}
+
+fn validate_grant_predicate_columns(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    table: &str,
+    schema: &[tables::FieldDef],
+    predicate: &crate::grants::Predicate,
+    now: Instant,
+) -> Result<(), String> {
+    for clause in predicate.clauses() {
+        for condition in clause {
+            validate_grant_condition_columns(store, cache, table, schema, condition, now)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_grant_condition_columns(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    table: &str,
+    schema: &[tables::FieldDef],
+    condition: &crate::grants::Condition,
+    now: Instant,
+) -> Result<(), String> {
+    match condition {
+        crate::grants::Condition::Cmp { column, op, .. } => {
+            validate_grant_column_filter(table, schema, column, op)
+        }
+        crate::grants::Condition::InSubquery {
+            column,
+            negated,
+            subquery,
+        } => {
+            validate_grant_column_filter(
+                table,
+                schema,
+                column,
+                if *negated { "NOT IN" } else { "IN" },
+            )?;
+            if let Ok(inner_schema) = tables::load_schema(store, cache, &subquery.table, now) {
+                validate_grant_predicate_columns(
+                    store,
+                    cache,
+                    &subquery.table,
+                    &inner_schema,
+                    &subquery.inner,
+                    now,
+                )?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn validate_grant_column_filter(
+    table: &str,
+    schema: &[tables::FieldDef],
+    column: &str,
+    op: &str,
+) -> Result<(), String> {
+    if let Some((root, rest)) = column.split_once('.') {
+        if !rest.is_empty() && schema.iter().any(|f| f.name == root && f.encrypted) {
+            return Err(format!(
+                "ERR encrypted column '{}' in grant on '{}' does not support JSON path filters",
+                root, table
+            ));
+        }
+    }
+    let bare = column.split('.').next().unwrap_or(column);
+    let Some(field) = schema.iter().find(|f| f.name == bare) else {
+        return Ok(());
+    };
+    if !field.encrypted {
+        return Ok(());
+    }
+    if op == "=" && field.searchable {
+        return Ok(());
+    }
+    if op == "=" {
+        return Err(format!(
+            "ERR encrypted column '{}' in grant on '{}' must be SEARCHABLE for equality filters",
+            field.name, table
+        ));
+    }
+    Err(format!(
+        "ERR encrypted column '{}' in grant on '{}' only supports equality filters when SEARCHABLE",
+        field.name, table
+    ))
 }
 
 /// Remove a grant for (table, scope). Returns true if one existed.
@@ -5586,6 +5690,141 @@ mod tests {
         let p = principal("u1");
         let filter = read_filter(&store, &cache, &p, "audit", now).unwrap();
         assert_eq!(filter, "owner = u@x.dev");
+    }
+
+    fn encrypted_test_store() -> Store {
+        Store::new_with_config(Arc::new(crate::ServerConfig {
+            encryption: crate::EncryptionConfig {
+                active_key_id: Some("k1".to_string()),
+                keys: vec![crate::EncryptionKeyConfig {
+                    id: "k1".to_string(),
+                    secret: b"grant-encryption-secret".to_vec(),
+                    decrypt_only: false,
+                }],
+                ..Default::default()
+            },
+            ..crate::ServerConfig::default()
+        }))
+    }
+
+    fn selected_rows(result: crate::tables::SelectResult) -> Vec<Vec<(String, String)>> {
+        match result {
+            crate::tables::SelectResult::Rows(rows) => rows,
+            crate::tables::SelectResult::Aggregate(_) => panic!("expected row result"),
+        }
+    }
+
+    #[test]
+    fn read_grant_on_encrypted_searchable_column_filters_through_blind_index() {
+        let store = encrypted_test_store();
+        let cache = Arc::new(RwLock::new(SchemaCache::new()));
+        let now = Instant::now();
+        crate::tables::table_create(
+            &store,
+            &cache,
+            "messages",
+            &[
+                "id",
+                "STR",
+                "PRIMARY",
+                "KEY,",
+                "owner_email",
+                "STR",
+                "ENCRYPTED",
+                "SEARCHABLE,",
+                "body",
+                "STR",
+            ],
+            now,
+        )
+        .unwrap();
+        crate::tables::table_insert(
+            &store,
+            &cache,
+            "messages",
+            &[
+                ("id", "m1"),
+                ("owner_email", "u@x.dev"),
+                ("body", "allowed"),
+            ],
+            now,
+        )
+        .unwrap();
+        crate::tables::table_insert(
+            &store,
+            &cache,
+            "messages",
+            &[
+                ("id", "m2"),
+                ("owner_email", "other@x.dev"),
+                ("body", "blocked"),
+            ],
+            now,
+        )
+        .unwrap();
+        grant(
+            &store,
+            &cache,
+            &[
+                "read",
+                "ON",
+                "messages",
+                "WHERE",
+                "owner_email",
+                "=",
+                "auth.email",
+            ],
+            now,
+        );
+
+        let p = principal("u1");
+        let filter = read_filter(&store, &cache, &p, "messages", now).unwrap();
+        assert_eq!(filter, "owner_email = u@x.dev");
+        let mut tokens = vec!["*", "FROM", "messages", "WHERE"];
+        tokens.extend(filter.split_whitespace());
+        let plan = crate::tables::parse_select(&tokens).unwrap();
+        let rows = selected_rows(crate::tables::table_select(&store, &cache, &plan, now).unwrap());
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].iter().any(|(k, v)| k == "body" && v == "allowed"));
+        assert!(rows[0]
+            .iter()
+            .any(|(k, v)| k == "owner_email" && v == "u@x.dev"));
+    }
+
+    #[test]
+    fn grant_on_encrypted_non_searchable_column_is_rejected() {
+        let store = encrypted_test_store();
+        let cache = Arc::new(RwLock::new(SchemaCache::new()));
+        let now = Instant::now();
+        crate::tables::table_create(
+            &store,
+            &cache,
+            "messages",
+            &[
+                "id",
+                "UUID",
+                "PRIMARY",
+                "KEY,",
+                "secret",
+                "STR",
+                "ENCRYPTED",
+            ],
+            now,
+        )
+        .unwrap();
+        let grant = crate::grants::parse_grant(&[
+            "read",
+            "ON",
+            "messages",
+            "WHERE",
+            "secret",
+            "=",
+            "auth.email",
+        ])
+        .unwrap();
+
+        let err = put_grant(&store, &cache, &grant, now).unwrap_err();
+        assert!(err.contains("must be SEARCHABLE"), "{err}");
     }
 
     #[test]

--- a/src/cmd/encryption.rs
+++ b/src/cmd/encryption.rs
@@ -1,0 +1,160 @@
+use bytes::BytesMut;
+use std::time::{Duration, Instant};
+
+use crate::resp;
+use crate::store::Store;
+
+use super::{cmd_eq, parse_u64, CmdResult};
+
+pub fn cmd_enc(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() < 2 {
+        resp::write_error(
+            out,
+            "ERR usage: ENC <STATUS|INIT|LIST|ROTATE|REWRAP|RETIRE>",
+        );
+        return CmdResult::Written;
+    }
+    if cmd_eq(args[1], b"STATUS") {
+        let status = store.encryption().status();
+        resp::write_array_header(out, 8);
+        resp::write_bulk(out, "initialized");
+        resp::write_integer(out, if status.initialized { 1 } else { 0 });
+        resp::write_bulk(out, "active_key_id");
+        match status.active_key_id {
+            Some(id) => resp::write_bulk(out, &id),
+            None => resp::write_null(out),
+        }
+        resp::write_bulk(out, "key_count");
+        resp::write_integer(out, status.key_count as i64);
+        resp::write_bulk(out, "persisted");
+        resp::write_integer(out, if status.persisted { 1 } else { 0 });
+        return CmdResult::Written;
+    }
+    if cmd_eq(args[1], b"LIST") {
+        let keys = store.encryption().list();
+        resp::write_array_header(out, keys.len());
+        for key in keys {
+            resp::write_array_header(out, 4);
+            resp::write_bulk(out, "id");
+            resp::write_bulk(out, &key.id);
+            resp::write_bulk(out, "status");
+            resp::write_bulk(out, key.status);
+        }
+        return CmdResult::Written;
+    }
+    if cmd_eq(args[1], b"INIT") {
+        let key_id = parse_keyid(args, 2, out);
+        let Some(key_id) = key_id else {
+            return CmdResult::Written;
+        };
+        match store.encryption().init(key_id) {
+            Ok(id) => resp::write_bulk(out, &id),
+            Err(err) => resp::write_error(out, &err),
+        }
+        return CmdResult::Written;
+    }
+    if cmd_eq(args[1], b"ROTATE") {
+        let key_id = parse_keyid(args, 2, out);
+        let Some(key_id) = key_id else {
+            return CmdResult::Written;
+        };
+        match store.encryption().rotate(key_id) {
+            Ok(id) => resp::write_bulk(out, &id),
+            Err(err) => resp::write_error(out, &err),
+        }
+        return CmdResult::Written;
+    }
+    if cmd_eq(args[1], b"REWRAP") {
+        match store.enc_rewrap_all() {
+            Ok(count) => resp::write_integer(out, count as i64),
+            Err(err) => resp::write_error(out, &err),
+        }
+        return CmdResult::Written;
+    }
+    if cmd_eq(args[1], b"RETIRE") {
+        if args.len() != 3 {
+            resp::write_error(out, "ERR usage: ENC RETIRE <key_id>");
+            return CmdResult::Written;
+        }
+        match store.enc_retire_key(std::str::from_utf8(args[2]).unwrap_or("")) {
+            Ok(()) => resp::write_ok(out),
+            Err(err) => resp::write_error(out, &err),
+        }
+        return CmdResult::Written;
+    }
+    if cmd_eq(args[1], b"RAWSET") {
+        return cmd_rawset(args, store, out, now);
+    }
+    if cmd_eq(args[1], b"RAWHSET") {
+        return cmd_rawhset(args, store, out, now);
+    }
+    resp::write_error(out, "ERR unknown ENC subcommand");
+    CmdResult::Written
+}
+
+fn parse_keyid<'a>(args: &[&'a [u8]], start: usize, out: &mut BytesMut) -> Option<Option<&'a str>> {
+    if args.len() == start {
+        return Some(None);
+    }
+    if args.len() == start + 2 && cmd_eq(args[start], b"KEYID") {
+        return Some(Some(std::str::from_utf8(args[start + 1]).unwrap_or("")));
+    }
+    resp::write_error(out, "ERR usage: ENC INIT|ROTATE [KEYID <id>]");
+    None
+}
+
+fn cmd_rawset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() < 4 {
+        resp::write_error(
+            out,
+            "ERR usage: ENC RAWSET <key> <ciphertext> [SET options]",
+        );
+        return CmdResult::Written;
+    }
+    let mut ttl = None;
+    let mut i = 4;
+    while i < args.len() {
+        if cmd_eq(args[i], b"EX") && i + 1 < args.len() {
+            let Ok(secs) = parse_u64(args[i + 1]) else {
+                resp::write_error(out, "ERR value is not an integer or out of range");
+                return CmdResult::Written;
+            };
+            ttl = Some(Duration::from_secs(secs));
+            i += 2;
+        } else if cmd_eq(args[i], b"PX") && i + 1 < args.len() {
+            let Ok(ms) = parse_u64(args[i + 1]) else {
+                resp::write_error(out, "ERR value is not an integer or out of range");
+                return CmdResult::Written;
+            };
+            ttl = Some(Duration::from_millis(ms));
+            i += 2;
+        } else if cmd_eq(args[i], b"NX")
+            || cmd_eq(args[i], b"XX")
+            || cmd_eq(args[i], b"KEEPTTL")
+            || cmd_eq(args[i], b"GET")
+        {
+            i += 1;
+        } else if cmd_eq(args[i], b"IFEQ") && i + 1 < args.len() {
+            i += 2;
+        } else {
+            resp::write_error(out, "ERR syntax error");
+            return CmdResult::Written;
+        }
+    }
+    store.set(args[2], args[3], ttl, now);
+    resp::write_ok(out);
+    CmdResult::Written
+}
+
+fn cmd_rawhset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() < 5 || !(args.len() - 3).is_multiple_of(2) {
+        resp::write_error(out, "ERR usage: ENC RAWHSET <key> <field> <ciphertext> ...");
+        return CmdResult::Written;
+    }
+    let pairs: Vec<(&[u8], &[u8])> = args[3..].chunks(2).map(|c| (c[0], c[1])).collect();
+    match store.hset(args[2], &pairs, now) {
+        Ok(_) => resp::write_ok(out),
+        Err(err) => resp::write_error(out, &err),
+    }
+    CmdResult::Written
+}

--- a/src/cmd/hashes.rs
+++ b/src/cmd/hashes.rs
@@ -20,7 +20,13 @@ fn parse_usize_arg(arg: &[u8], out: &mut BytesMut) -> Option<usize> {
 
 pub fn cmd_hset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     let is_hmset = cmd_eq(args[0], b"HMSET");
-    if args.len() < 4 || !(args.len() - 2).is_multiple_of(2) {
+    let encrypted = args.last().is_some_and(|arg| cmd_eq(arg, b"ENCRYPTED"));
+    let end = if encrypted {
+        args.len() - 1
+    } else {
+        args.len()
+    };
+    if end < 4 || !(end - 2).is_multiple_of(2) {
         let cmd_name = if is_hmset { "hmset" } else { "hset" };
         resp::write_error(
             out,
@@ -28,15 +34,35 @@ pub fn cmd_hset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
         );
         return CmdResult::Written;
     }
-    let result = if args.len() == 4 {
-        let pair = [(args[2], args[3])];
-        store.hset(args[1], &pair, now)
+    let pairs: Vec<(&[u8], &[u8])> = args[2..end].chunks(2).map(|c| (c[0], c[1])).collect();
+    let fields: Vec<&[u8]> = pairs.iter().map(|(field, _)| *field).collect();
+    let should_self_log = encrypted || store.hash_fields_need_encryption(args[1], &fields, now);
+    let result = if should_self_log {
+        store
+            .hset_kv(args[1], &pairs, encrypted, now)
+            .map(|(added, stored_pairs)| (added, Some(stored_pairs)))
     } else {
-        let pairs: Vec<(&[u8], &[u8])> = args[2..].chunks(2).map(|c| (c[0], c[1])).collect();
-        store.hset(args[1], &pairs, now)
+        store.hset(args[1], &pairs, now).map(|added| (added, None))
     };
     match result {
-        Ok(n) => {
+        Ok((n, stored_pairs)) => {
+            if should_self_log && store.wal_enabled() {
+                if let Some(stored_pairs) = stored_pairs {
+                    let mut owned: Vec<Vec<u8>> = Vec::with_capacity(3 + stored_pairs.len() * 2);
+                    owned.push(b"ENC".to_vec());
+                    owned.push(b"RAWHSET".to_vec());
+                    owned.push(args[1].to_vec());
+                    for (field, value) in stored_pairs {
+                        owned.push(field);
+                        owned.push(value);
+                    }
+                    let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+                    if let Err(e) = store.wal_log_command(&refs) {
+                        resp::write_error(out, &format!("ERR WAL append failed: {e}"));
+                        return CmdResult::Written;
+                    }
+                }
+            }
             if is_hmset {
                 resp::write_ok(out);
             } else {
@@ -382,7 +408,13 @@ pub fn cmd_hscan(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
                         resp::write_array_header(out, filtered.len() * 2);
                         for (k, v) in &filtered {
                             resp::write_bulk(out, k);
-                            resp::write_bulk_raw(out, v);
+                            match store.decrypt_hash_field_value(ks, k.as_bytes(), (*v).clone()) {
+                                Ok(value) => resp::write_bulk_raw(out, &value),
+                                Err(err) => {
+                                    resp::write_error(out, &err);
+                                    return CmdResult::Written;
+                                }
+                            }
                         }
                     }
                 } else {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 mod bitops;
+mod encryption;
 mod geo;
 mod hashes;
 mod hll;
@@ -848,6 +849,10 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         min_arity: 3,
     },
     CommandSpec {
+        name: b"ENC",
+        min_arity: 2,
+    },
+    CommandSpec {
         name: b"SCRIPT",
         min_arity: 2,
     },
@@ -1613,6 +1618,9 @@ pub fn execute(
             if cmd_eq(cmd, b"EVALSHA") {
                 return scripting::cmd_evalsha(args, store, out, now);
             }
+            if cmd_eq(cmd, b"ENC") {
+                return encryption::cmd_enc(args, store, out, now);
+            }
             if cmd_eq(cmd, b"EXEC") {
                 resp::write_error(out, &format!("ERR unknown command '{}'", arg_str(cmd)));
                 return CmdResult::Written;
@@ -2028,6 +2036,9 @@ pub fn execute(
             if cmd_eq(cmd, b"TINSERT") {
                 return tables::cmd_tinsert(args, store, cache, out, now);
             }
+            if cmd_eq(cmd, b"TROWSET") {
+                return tables::cmd_trowset(args, store, cache, out, now);
+            }
             if cmd_eq(cmd, b"TUPSERT") {
                 return tables::cmd_tupsert(args, store, cache, out, now);
             }
@@ -2246,7 +2257,7 @@ pub fn execute_with_wal(
         // layer (for crash determinism + so HTTP table writes, which never reach
         // this function, are durable). Raw-logging them here too would apply the
         // row twice on replay, so skip them.
-        if !command_self_logs_wal(args[0]) {
+        if !command_self_logs_wal_args(args, store, now) {
             if let Err(e) = store.wal_log_command(args) {
                 resp::write_error(out, &format!("ERR WAL append failed: {e}"));
                 return CmdResult::Written;
@@ -2269,8 +2280,42 @@ fn command_self_logs_wal(cmd: &[u8]) -> bool {
     let c = &up[..cmd.len()];
     matches!(
         c,
-        b"TINSERT" | b"TUPSERT" | b"TUPDATE" | b"TDELETE" | b"TCREATE" | b"TDROP" | b"XADD"
+        b"TINSERT"
+            | b"TROWSET"
+            | b"TUPSERT"
+            | b"TUPDATE"
+            | b"TDELETE"
+            | b"TCREATE"
+            | b"TDROP"
+            | b"XADD"
     )
+}
+
+fn command_self_logs_wal_args(args: &[&[u8]], store: &Store, now: Instant) -> bool {
+    if args.is_empty() {
+        return false;
+    }
+    let cmd = args[0];
+    if command_self_logs_wal(cmd) {
+        return true;
+    }
+    if cmd_eq(cmd, b"SET") && args.len() >= 3 {
+        return args[3..].iter().any(|arg| cmd_eq(arg, b"ENCRYPTED"))
+            || store.kv_string_is_encrypted(args[1], now);
+    }
+    if (cmd_eq(cmd, b"HSET") || cmd_eq(cmd, b"HMSET")) && args.len() >= 4 {
+        let encrypted = args.last().is_some_and(|arg| cmd_eq(arg, b"ENCRYPTED"));
+        let end = if encrypted {
+            args.len() - 1
+        } else {
+            args.len()
+        };
+        if end > 2 && (end - 2).is_multiple_of(2) {
+            let fields: Vec<&[u8]> = args[2..end].chunks(2).map(|chunk| chunk[0]).collect();
+            return encrypted || store.hash_fields_need_encryption(args[1], &fields, now);
+        }
+    }
+    false
 }
 
 #[allow(dead_code)]
@@ -3566,6 +3611,8 @@ mod tests {
     use super::*;
     use crate::pubsub::Broker;
     use crate::store::Store;
+    use crate::{ServerConfig, StorageConfig, StorageMode};
+    use std::sync::Arc;
     use std::time::Instant;
 
     fn exec(store: &Store, args: &[&[u8]]) -> BytesMut {
@@ -3580,6 +3627,177 @@ mod tests {
 
     fn exec_str(store: &Store, args: &[&[u8]]) -> String {
         String::from_utf8_lossy(&exec(store, args)).to_string()
+    }
+
+    fn exec_wal(store: &Store, args: &[&[u8]]) -> BytesMut {
+        let broker = Broker::new();
+        let cache =
+            std::sync::Arc::new(parking_lot::RwLock::new(crate::tables::SchemaCache::new()));
+        let mut out = BytesMut::new();
+        execute_with_wal(store, &cache, &broker, args, &mut out, Instant::now());
+        out
+    }
+
+    fn read_wal_bytes(dir: &std::path::Path) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for entry in std::fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path().join("wal.lux");
+            if path.exists() {
+                bytes.extend(std::fs::read(path).unwrap());
+            }
+        }
+        bytes
+    }
+
+    #[test]
+    fn enc_init_persists_sealed_state_and_rotate_lists_statuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+
+        let status = exec_str(&store, &[b"ENC", b"STATUS"]);
+        assert!(status.contains("initialized"), "{status}");
+        let out = exec_str(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        assert!(out.contains("k1"), "{out}");
+        assert!(dir.path().join("lux.enc").exists());
+        assert!(dir.path().join("lux.enc.seal").exists());
+        let sealed = std::fs::read(dir.path().join("lux.enc")).unwrap();
+        assert!(!sealed.windows(b"secret".len()).any(|w| w == b"secret"));
+
+        let restored = Store::new_with_config(config);
+        let list = exec_str(&restored, &[b"ENC", b"LIST"]);
+        assert!(list.contains("k1"), "{list}");
+        assert!(list.contains("active"), "{list}");
+        let out = exec_str(&restored, &[b"ENC", b"ROTATE", b"KEYID", b"k2"]);
+        assert!(out.contains("k2"), "{out}");
+        let list = exec_str(&restored, &[b"ENC", b"LIST"]);
+        assert!(list.contains("k1"), "{list}");
+        assert!(list.contains("decrypt-only"), "{list}");
+        assert!(list.contains("k2"), "{list}");
+        assert!(list.contains("active"), "{list}");
+    }
+
+    #[test]
+    fn encrypted_set_self_logs_ciphertext_and_replays() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        let out = String::from_utf8_lossy(&exec_wal(
+            &store,
+            &[b"SET", b"api-token", b"wal-secret-value", b"ENCRYPTED"],
+        ))
+        .to_string();
+        assert!(out.contains("OK"), "{out}");
+        store.fsync_wal();
+        let wal = read_wal_bytes(dir.path());
+        assert!(!wal
+            .windows(b"wal-secret-value".len())
+            .any(|w| w == b"wal-secret-value"));
+        assert!(wal.windows(b"RAWSET".len()).any(|w| w == b"RAWSET"));
+
+        let restored = Store::new_with_config(config);
+        restored.replay_wal(&Broker::new());
+        let got = exec_str(&restored, &[b"GET", b"api-token"]);
+        assert!(got.contains("wal-secret-value"), "{got}");
+    }
+
+    #[test]
+    fn encrypted_hset_self_logs_ciphertext_and_replays() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        let out = String::from_utf8_lossy(&exec_wal(
+            &store,
+            &[
+                b"HSET",
+                b"profile:1",
+                b"token",
+                b"hash-secret-value",
+                b"ENCRYPTED",
+            ],
+        ))
+        .to_string();
+        assert!(out.contains(":1"), "{out}");
+        store.fsync_wal();
+        let wal = read_wal_bytes(dir.path());
+        assert!(!wal
+            .windows(b"hash-secret-value".len())
+            .any(|w| w == b"hash-secret-value"));
+        assert!(wal.windows(b"RAWHSET".len()).any(|w| w == b"RAWHSET"));
+
+        let restored = Store::new_with_config(config);
+        restored.replay_wal(&Broker::new());
+        let got = exec_str(&restored, &[b"HGET", b"profile:1", b"token"]);
+        assert!(got.contains("hash-secret-value"), "{got}");
+        let scan = exec_str(&restored, &[b"HSCAN", b"profile:1", b"0"]);
+        assert!(scan.contains("hash-secret-value"), "{scan}");
+    }
+
+    #[test]
+    fn enc_rotate_rewrap_then_retire_preserves_existing_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config);
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(&store, &[b"SET", b"token", b"rotate-secret", b"ENCRYPTED"]);
+
+        let out = exec_str(&store, &[b"ENC", b"ROTATE", b"KEYID", b"k2"]);
+        assert!(out.contains("k2"), "{out}");
+        let got = exec_str(&store, &[b"GET", b"token"]);
+        assert!(got.contains("rotate-secret"), "{got}");
+        let retire = exec_str(&store, &[b"ENC", b"RETIRE", b"k1"]);
+        assert!(retire.contains("still required"), "{retire}");
+
+        let rewrap = exec_str(&store, &[b"ENC", b"REWRAP"]);
+        assert!(rewrap.contains(":1"), "{rewrap}");
+        let retire = exec_str(&store, &[b"ENC", b"RETIRE", b"k1"]);
+        assert!(retire.contains("OK"), "{retire}");
+        let got = exec_str(&store, &[b"GET", b"token"]);
+        assert!(got.contains("rotate-secret"), "{got}");
+    }
+
+    #[test]
+    fn encrypted_string_side_commands_use_plaintext_or_reject_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::new_with_config(Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        }));
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(&store, &[b"SET", b"secret", b"abcdef", b"ENCRYPTED"]);
+
+        let get = exec(&store, &[b"GET", b"secret"]);
+        assert_eq!(&get[..], b"$6\r\nabcdef\r\n");
+        let strlen = exec_str(&store, &[b"STRLEN", b"secret"]);
+        assert!(strlen.contains(":6"), "{strlen}");
+        let range = exec_str(&store, &[b"GETRANGE", b"secret", b"1", b"3"]);
+        assert!(range.contains("bcd"), "{range}");
+        let append = exec_str(&store, &[b"APPEND", b"secret", b"x"]);
+        assert!(append.contains("encrypted string"), "{append}");
+        let incr = exec_str(&store, &[b"INCR", b"secret"]);
+        assert!(incr.contains("encrypted string"), "{incr}");
     }
 
     #[test]

--- a/src/cmd/strings.rs
+++ b/src/cmd/strings.rs
@@ -8,6 +8,7 @@ use super::{arg_str, cmd_eq, parse_i64, parse_u64, CmdResult};
 
 const INTEGER_ERR: &str = "ERR value is not an integer or out of range";
 const VALUE_TOO_LARGE_ERR: &str = "ERR string exceeds maximum allowed size";
+const ENCRYPTED_MUTATION_ERR: &str = "ERR encrypted string does not support this mutation command";
 
 fn parse_i64_arg(arg: &[u8], out: &mut BytesMut) -> Option<i64> {
     match parse_i64(arg) {
@@ -46,6 +47,28 @@ fn parse_positive_ttl(arg: &[u8], command: &str, out: &mut BytesMut) -> Option<u
     }
 }
 
+fn reject_encrypted_string_mutation(
+    store: &Store,
+    key: &[u8],
+    now: Instant,
+    out: &mut BytesMut,
+) -> bool {
+    if store.kv_string_is_encrypted(key, now) {
+        resp::write_error(out, ENCRYPTED_MUTATION_ERR);
+        true
+    } else {
+        false
+    }
+}
+
+fn full_string_value(store: &Store, key: &[u8], now: Instant) -> Result<Bytes, String> {
+    if store.kv_string_is_encrypted(key, now) {
+        Ok(store.get_kv_string(key, now)?.unwrap_or_default())
+    } else {
+        store.getrange(key, 0, -1, now)
+    }
+}
+
 pub fn cmd_set(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     if args.len() < 3 {
         resp::write_error(out, "ERR wrong number of arguments for 'set' command");
@@ -57,6 +80,7 @@ pub fn cmd_set(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
     let mut xx = false;
     let mut get = false;
     let mut ifeq = None;
+    let mut encrypted = false;
     let mut i = 3;
     while i < args.len() {
         if cmd_eq(args[i], b"EX") {
@@ -146,6 +170,9 @@ pub fn cmd_set(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
             }
             keep_ttl = true;
             i += 1;
+        } else if cmd_eq(args[i], b"ENCRYPTED") {
+            encrypted = true;
+            i += 1;
         } else {
             resp::write_error(out, "ERR syntax error");
             return CmdResult::Written;
@@ -162,9 +189,30 @@ pub fn cmd_set(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
         xx,
         ifeq,
         get,
+        encrypted,
     };
+    let should_self_log = encrypted || store.kv_string_is_encrypted(args[1], now);
     match store.set_conditional(args[1], args[2], options, now) {
         Ok((set, old)) => {
+            if set && should_self_log && store.wal_enabled() {
+                if let Some(raw) = store.get_raw_string(args[1], now) {
+                    let mut owned: Vec<Vec<u8>> = Vec::with_capacity(args.len());
+                    owned.push(b"ENC".to_vec());
+                    owned.push(b"RAWSET".to_vec());
+                    owned.push(args[1].to_vec());
+                    owned.push(raw.to_vec());
+                    for arg in &args[3..] {
+                        if !cmd_eq(arg, b"ENCRYPTED") {
+                            owned.push(arg.to_vec());
+                        }
+                    }
+                    let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+                    if let Err(e) = store.wal_log_command(&refs) {
+                        resp::write_error(out, &format!("ERR WAL append failed: {e}"));
+                        return CmdResult::Written;
+                    }
+                }
+            }
             if get {
                 resp::write_optional_bulk_raw(out, &old);
             } else if set {
@@ -183,6 +231,9 @@ pub fn cmd_setnx(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         resp::write_error(out, "ERR wrong number of arguments for 'setnx' command");
         return CmdResult::Written;
     }
+    if reject_encrypted_string_mutation(store, args[1], now, out) {
+        return CmdResult::Written;
+    }
     resp::write_integer(
         out,
         if store.set_nx(args[1], args[2], now) {
@@ -197,6 +248,9 @@ pub fn cmd_setnx(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
 pub fn cmd_setex(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     if args.len() < 4 {
         resp::write_error(out, "ERR wrong number of arguments for 'setex' command");
+        return CmdResult::Written;
+    }
+    if reject_encrypted_string_mutation(store, args[1], now, out) {
         return CmdResult::Written;
     }
     match parse_i64(args[2]) {
@@ -222,6 +276,9 @@ pub fn cmd_psetex(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, "ERR wrong number of arguments for 'psetex' command");
         return CmdResult::Written;
     }
+    if reject_encrypted_string_mutation(store, args[1], now, out) {
+        return CmdResult::Written;
+    }
     let ms = match parse_positive_ttl(args[2], "psetex", out) {
         Some(ms) => ms,
         None => return CmdResult::Written,
@@ -236,13 +293,19 @@ pub fn cmd_get(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
         resp::write_error(out, "ERR wrong number of arguments for 'get' command");
         return CmdResult::Written;
     }
-    resp::write_optional_bulk_raw(out, &store.get(args[1], now));
+    match store.get_kv_string(args[1], now) {
+        Ok(value) => resp::write_optional_bulk_raw(out, &value),
+        Err(err) => resp::write_error(out, &err),
+    }
     CmdResult::Written
 }
 
 pub fn cmd_getset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     if args.len() < 3 {
         resp::write_error(out, "ERR wrong number of arguments for 'getset' command");
+        return CmdResult::Written;
+    }
+    if reject_encrypted_string_mutation(store, args[1], now, out) {
         return CmdResult::Written;
     }
     resp::write_optional_bulk_raw(out, &store.get_set(args[1], args[2], now));
@@ -254,7 +317,14 @@ pub fn cmd_getdel(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, "ERR wrong number of arguments for 'getdel' command");
         return CmdResult::Written;
     }
-    resp::write_optional_bulk_raw(out, &store.getdel(args[1], now));
+    let old = store.getdel(args[1], now);
+    match old
+        .map(|value| store.decrypt_kv_string_value(args[1], value))
+        .transpose()
+    {
+        Ok(value) => resp::write_optional_bulk_raw(out, &value),
+        Err(err) => resp::write_error(out, &err),
+    }
     CmdResult::Written
 }
 
@@ -349,7 +419,14 @@ pub fn cmd_getex(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
             return CmdResult::Written;
         }
     }
-    resp::write_optional_bulk_raw(out, &store.getex(args[1], ttl, persist, now));
+    let value = store.getex(args[1], ttl, persist, now);
+    match value
+        .map(|value| store.decrypt_kv_string_value(args[1], value))
+        .transpose()
+    {
+        Ok(value) => resp::write_optional_bulk_raw(out, &value),
+        Err(err) => resp::write_error(out, &err),
+    }
     CmdResult::Written
 }
 
@@ -366,6 +443,36 @@ pub fn cmd_getrange(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Inst
         Some(n) => n,
         None => return CmdResult::Written,
     };
+    if store.kv_string_is_encrypted(args[1], now) {
+        match store.get_kv_string(args[1], now) {
+            Ok(Some(value)) => {
+                if value.is_empty() {
+                    resp::write_bulk_raw(out, b"");
+                    return CmdResult::Written;
+                }
+                let len = value.len() as i64;
+                let s = if start < 0 {
+                    (len + start).max(0)
+                } else {
+                    start
+                } as usize;
+                let e_raw = if end < 0 { len + end } else { end };
+                if e_raw < 0 {
+                    resp::write_bulk_raw(out, b"");
+                    return CmdResult::Written;
+                }
+                let e = e_raw.min(len - 1) as usize;
+                if s > e || s >= value.len() {
+                    resp::write_bulk_raw(out, b"");
+                } else {
+                    resp::write_bulk_raw(out, &value[s..=e]);
+                }
+            }
+            Ok(None) => resp::write_bulk_raw(out, b""),
+            Err(err) => resp::write_error(out, &err),
+        }
+        return CmdResult::Written;
+    }
     match store.getrange(args[1], start, end, now) {
         Ok(val) => resp::write_bulk_raw(out, &val),
         Err(err) => resp::write_error(out, &err),
@@ -382,6 +489,9 @@ pub fn cmd_setrange(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Inst
         Some(n) => n,
         None => return CmdResult::Written,
     };
+    if reject_encrypted_string_mutation(store, args[1], now, out) {
+        return CmdResult::Written;
+    }
     let offset = match usize::try_from(offset_u64) {
         Ok(offset) => offset,
         Err(_) => {
@@ -416,7 +526,10 @@ pub fn cmd_mget(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
     }
     resp::write_array_header(out, args.len() - 1);
     for key in &args[1..] {
-        resp::write_optional_bulk_raw(out, &store.get(key, now));
+        match store.get_kv_string(key, now) {
+            Ok(value) => resp::write_optional_bulk_raw(out, &value),
+            Err(_) => resp::write_null(out),
+        }
     }
     CmdResult::Written
 }
@@ -428,6 +541,9 @@ pub fn cmd_mset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
     }
     let mut i = 1;
     while i < args.len() {
+        if reject_encrypted_string_mutation(store, args[i], now, out) {
+            return CmdResult::Written;
+        }
         store.set(args[i], args[i + 1], None, now);
         i += 2;
     }
@@ -441,6 +557,13 @@ pub fn cmd_msetnx(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         return CmdResult::Written;
     }
     let pairs: Vec<(&[u8], &[u8])> = args[1..].chunks(2).map(|c| (c[0], c[1])).collect();
+    if pairs
+        .iter()
+        .any(|(key, _)| store.kv_string_is_encrypted(key, now))
+    {
+        resp::write_error(out, ENCRYPTED_MUTATION_ERR);
+        return CmdResult::Written;
+    }
     resp::write_integer(out, if store.msetnx(&pairs, now) { 1 } else { 0 });
     CmdResult::Written
 }
@@ -450,7 +573,15 @@ pub fn cmd_strlen(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, "ERR wrong number of arguments for 'strlen' command");
         return CmdResult::Written;
     }
-    resp::write_integer(out, store.strlen(args[1], now));
+    if store.kv_string_is_encrypted(args[1], now) {
+        match store.get_kv_string(args[1], now) {
+            Ok(Some(value)) => resp::write_integer(out, value.len() as i64),
+            Ok(None) => resp::write_integer(out, 0),
+            Err(err) => resp::write_error(out, &err),
+        }
+    } else {
+        resp::write_integer(out, store.strlen(args[1], now));
+    }
     CmdResult::Written
 }
 
@@ -500,14 +631,14 @@ pub fn cmd_lcs(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
         return CmdResult::Written;
     }
 
-    let left = match store.getrange(args[1], 0, -1, now) {
+    let left = match full_string_value(store, args[1], now) {
         Ok(value) => value,
         Err(err) => {
             resp::write_error(out, &err);
             return CmdResult::Written;
         }
     };
-    let right = match store.getrange(args[2], 0, -1, now) {
+    let right = match full_string_value(store, args[2], now) {
         Ok(value) => value,
         Err(err) => {
             resp::write_error(out, &err);
@@ -614,6 +745,9 @@ pub fn cmd_append(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, "ERR wrong number of arguments for 'append' command");
         return CmdResult::Written;
     }
+    if reject_encrypted_string_mutation(store, args[1], now, out) {
+        return CmdResult::Written;
+    }
     // Cap repeated APPENDs so a value can't be grown without bound past the
     // configured request ceiling (each call is RESP-bounded, the running total is not).
     let projected = (store.strlen(args[1], now) as usize).saturating_add(args[2].len());
@@ -630,6 +764,9 @@ pub fn cmd_incr(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
         resp::write_error(out, "ERR wrong number of arguments for 'incr' command");
         return CmdResult::Written;
     }
+    if reject_encrypted_string_mutation(store, args[1], now, out) {
+        return CmdResult::Written;
+    }
     match store.incr(args[1], 1, now) {
         Ok(n) => resp::write_integer(out, n),
         Err(e) => resp::write_error(out, &e),
@@ -642,6 +779,9 @@ pub fn cmd_decr(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
         resp::write_error(out, "ERR wrong number of arguments for 'decr' command");
         return CmdResult::Written;
     }
+    if reject_encrypted_string_mutation(store, args[1], now, out) {
+        return CmdResult::Written;
+    }
     match store.incr(args[1], -1, now) {
         Ok(n) => resp::write_integer(out, n),
         Err(e) => resp::write_error(out, &e),
@@ -652,6 +792,9 @@ pub fn cmd_decr(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
 pub fn cmd_incrby(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     if args.len() < 3 {
         resp::write_error(out, "ERR wrong number of arguments for 'incrby' command");
+        return CmdResult::Written;
+    }
+    if reject_encrypted_string_mutation(store, args[1], now, out) {
         return CmdResult::Written;
     }
     match parse_i64(args[2]) {
@@ -667,6 +810,9 @@ pub fn cmd_incrby(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
 pub fn cmd_decrby(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     if args.len() < 3 {
         resp::write_error(out, "ERR wrong number of arguments for 'decrby' command");
+        return CmdResult::Written;
+    }
+    if reject_encrypted_string_mutation(store, args[1], now, out) {
         return CmdResult::Written;
     }
     match parse_i64(args[2]) {
@@ -690,6 +836,9 @@ pub fn cmd_incrbyfloat(
             out,
             "ERR wrong number of arguments for 'incrbyfloat' command",
         );
+        return CmdResult::Written;
+    }
+    if reject_encrypted_string_mutation(store, args[1], now, out) {
         return CmdResult::Written;
     }
     let delta_str = arg_str(args[2]);

--- a/src/cmd/tables.rs
+++ b/src/cmd/tables.rs
@@ -163,6 +163,39 @@ pub fn cmd_tinsert(
     CmdResult::Written
 }
 
+pub fn cmd_trowset(
+    args: &[&[u8]],
+    store: &Store,
+    cache: &SharedSchemaCache,
+    out: &mut BytesMut,
+    now: Instant,
+) -> CmdResult {
+    if !store
+        .wal_suppress
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        resp::write_error(out, "ERR TROWSET is internal to WAL replay");
+        return CmdResult::Written;
+    }
+    if args.len() < 3 || !(args.len() - 3).is_multiple_of(2) {
+        resp::write_error(out, "ERR usage: TROWSET <table> <pk> <field> <raw> ...");
+        return CmdResult::Written;
+    }
+    let table = arg_str(args[1]);
+    let pk = arg_str(args[2]);
+    let mut raw_pairs = Vec::new();
+    let mut i = 3;
+    while i + 1 < args.len() {
+        raw_pairs.push((args[i], args[i + 1]));
+        i += 2;
+    }
+    match tables::table_apply_wal_row(store, cache, table, pk, &raw_pairs, now) {
+        Ok(()) => resp::write_ok(out),
+        Err(e) => resp::write_error(out, &e),
+    }
+    CmdResult::Written
+}
+
 pub fn cmd_tupsert(
     args: &[&[u8]],
     store: &Store,

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -1,0 +1,1279 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use parking_lot::RwLock;
+use rand_core::{OsRng, RngCore};
+use ring::{aead, hmac};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const ENVELOPE_MAGIC: &[u8] = b"LUXENC2";
+const STATE_MAGIC: &[u8] = b"LUXENCSTATE1";
+const NONCE_LEN: usize = 12;
+const DATA_KEY_LEN: usize = 32;
+const WRAPPED_DATA_KEY_LEN: usize = DATA_KEY_LEN + 16;
+
+#[derive(Clone, Default)]
+pub struct EncryptionConfig {
+    /// Legacy/bootstrap active key id. Native deployments should use ENC INIT /
+    /// ENC ROTATE and persisted encryption state instead.
+    pub active_key_id: Option<String>,
+    /// Legacy/bootstrap key list. Used when no persisted ENC state exists.
+    pub keys: Vec<EncryptionKeyConfig>,
+    /// Optional sealed ENC state path. Defaults to `<data_dir>/lux.enc`.
+    pub state_path: Option<String>,
+    /// Optional local seal secret path. Defaults to `<data_dir>/lux.enc.seal`.
+    pub seal_path: Option<String>,
+    /// Generate persisted ENC state automatically when no state exists.
+    pub auto_init: bool,
+    /// Seal key sourced from outside the data volume (e.g. an injected env var).
+    /// When set, the keyring is sealed/unsealed with this instead of the on-disk
+    /// seal file, so a stolen data volume does not also carry the key.
+    pub seal_secret: Option<[u8; 32]>,
+    /// Prior seal keys accepted for *unsealing* only (seal rotation). On open the
+    /// keyring is re-sealed under `seal_secret`; these let a rotated deployment
+    /// still read state sealed by the previous key.
+    pub previous_seal_secrets: Vec<[u8; 32]>,
+}
+
+impl std::fmt::Debug for EncryptionConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncryptionConfig")
+            .field("active_key_id", &self.active_key_id)
+            .field("keys", &self.keys.iter().map(|k| &k.id).collect::<Vec<_>>())
+            .field("state_path", &self.state_path)
+            .field("seal_path", &self.seal_path)
+            .field("auto_init", &self.auto_init)
+            .field("seal_secret", &self.seal_secret.map(|_| "<redacted>"))
+            .field("previous_seal_secrets", &self.previous_seal_secrets.len())
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+pub struct EncryptionKeyConfig {
+    pub id: String,
+    pub secret: Vec<u8>,
+    pub decrypt_only: bool,
+}
+
+impl std::fmt::Debug for EncryptionKeyConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncryptionKeyConfig")
+            .field("id", &self.id)
+            .field("secret", &"<redacted>")
+            .field("decrypt_only", &self.decrypt_only)
+            .finish()
+    }
+}
+
+pub(crate) struct EncryptionKeyring {
+    inner: RwLock<EncryptionState>,
+    state_path: Option<PathBuf>,
+    seal_path: Option<PathBuf>,
+    /// Env-sourced seal used to seal/unseal persisted state. When `None`, the
+    /// on-disk `seal_path` file is the seal source (local-dev behavior). Previous
+    /// seals (rotation / file-to-env migration) are only needed while unsealing at
+    /// `open`, so they are not retained on the keyring.
+    seal_secret: Option<[u8; 32]>,
+}
+
+struct EncryptionState {
+    active_key_id: Option<String>,
+    keys: HashMap<String, NetworkKey>,
+}
+
+struct NetworkKey {
+    secret: Vec<u8>,
+    wrap_key: aead::LessSafeKey,
+    search_key: hmac::Key,
+    decrypt_only: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct EncryptionStatus {
+    pub initialized: bool,
+    pub active_key_id: Option<String>,
+    pub key_count: usize,
+    pub persisted: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct EncryptionKeyInfo {
+    pub id: String,
+    pub status: &'static str,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PlainState {
+    version: u8,
+    active_key_id: Option<String>,
+    keys: Vec<PlainKey>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PlainKey {
+    id: String,
+    secret: String,
+    decrypt_only: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SealedState {
+    version: u8,
+    nonce: String,
+    ciphertext: String,
+}
+
+impl EncryptionKeyring {
+    pub(crate) fn open(config: &EncryptionConfig, data_dir: &str) -> Result<Self, String> {
+        let state_path = resolve_path(config.state_path.as_deref(), data_dir, "lux.enc");
+        let seal_path = resolve_path(config.seal_path.as_deref(), data_dir, "lux.enc.seal");
+        let seal_secret = config.seal_secret;
+        let previous_seal_secrets = config.previous_seal_secrets.clone();
+
+        // Unseal existing state by trying every candidate seal (current env seal,
+        // rotated-out previous seals, then the on-disk file seal). Track whether
+        // the seal that actually opened it matches the current sealing seal; if
+        // not, we re-seal below so the state converges onto the current seal.
+        let mut needs_reseal = false;
+        let state = if state_path.as_ref().is_some_and(|p| p.exists()) {
+            let candidates =
+                collect_candidate_seals(seal_secret, &previous_seal_secrets, seal_path.as_deref())?;
+            let (state, used_seal) = Self::load_state(
+                state_path.as_ref().expect("state path checked").as_path(),
+                &candidates,
+            )?;
+            let current = current_seal(seal_secret, seal_path.as_deref())?;
+            needs_reseal = used_seal != current;
+            state
+        } else {
+            Self::state_from_config(config)?
+        };
+
+        let keyring = Self {
+            inner: RwLock::new(state),
+            state_path,
+            seal_path,
+            seal_secret,
+        };
+        keyring.validate()?;
+
+        // Migration / rotation: re-seal persisted state under the current seal
+        // when it was opened with a previous or on-disk seal.
+        if needs_reseal {
+            let inner = keyring.inner.read();
+            keyring.persist_state(&inner)?;
+        }
+
+        if config.auto_init && !keyring.has_active_key() {
+            keyring.init(None)?;
+        }
+
+        // When the seal is sourced from the env, the on-disk seal file is now
+        // obsolete (state is sealed under the env seal). Remove it so a stolen
+        // data volume no longer carries the key that opens it.
+        if keyring.seal_secret.is_some() {
+            if let Some(path) = &keyring.seal_path {
+                if path.exists() {
+                    let _ = fs::remove_file(path);
+                }
+            }
+        }
+
+        Ok(keyring)
+    }
+
+    fn state_from_config(config: &EncryptionConfig) -> Result<EncryptionState, String> {
+        let keys = build_network_keys(&config.keys)?;
+        validate_active_key(config.active_key_id.as_deref(), &keys)?;
+        Ok(EncryptionState {
+            active_key_id: config.active_key_id.clone(),
+            keys,
+        })
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        let inner = self.inner.read();
+        validate_active_key(inner.active_key_id.as_deref(), &inner.keys)
+    }
+
+    pub(crate) fn status(&self) -> EncryptionStatus {
+        let inner = self.inner.read();
+        EncryptionStatus {
+            initialized: inner.active_key_id.is_some(),
+            active_key_id: inner.active_key_id.clone(),
+            key_count: inner.keys.len(),
+            persisted: self.state_path.as_ref().is_some_and(|p| p.exists()),
+        }
+    }
+
+    pub(crate) fn list(&self) -> Vec<EncryptionKeyInfo> {
+        let inner = self.inner.read();
+        let mut keys: Vec<EncryptionKeyInfo> = inner
+            .keys
+            .iter()
+            .map(|(id, key)| EncryptionKeyInfo {
+                id: id.clone(),
+                status: if inner.active_key_id.as_deref() == Some(id.as_str()) {
+                    "active"
+                } else if key.decrypt_only {
+                    "decrypt-only"
+                } else {
+                    "available"
+                },
+            })
+            .collect();
+        keys.sort_by(|a, b| a.id.cmp(&b.id));
+        keys
+    }
+
+    pub(crate) fn init(&self, requested_id: Option<&str>) -> Result<String, String> {
+        let mut inner = self.inner.write();
+        if let Some(active) = inner.active_key_id.clone() {
+            return Ok(active);
+        }
+        let id = requested_id
+            .map(str::to_string)
+            .unwrap_or_else(generate_key_id);
+        validate_key_id(&id)?;
+        let key = EncryptionKeyConfig {
+            id: id.clone(),
+            secret: generate_secret(),
+            decrypt_only: false,
+        };
+        inner.keys = build_network_keys(&[key])?;
+        inner.active_key_id = Some(id.clone());
+        self.persist_state(&inner)?;
+        Ok(id)
+    }
+
+    pub(crate) fn rotate(&self, requested_id: Option<&str>) -> Result<String, String> {
+        let mut inner = self.inner.write();
+        if inner.keys.is_empty() {
+            drop(inner);
+            return self.init(requested_id);
+        }
+        let id = requested_id
+            .map(str::to_string)
+            .unwrap_or_else(generate_key_id);
+        validate_key_id(&id)?;
+        if inner.keys.contains_key(&id) {
+            return Err(format!("ERR ENC key '{}' already exists", id));
+        }
+        for key in inner.keys.values_mut() {
+            key.decrypt_only = true;
+        }
+        let config = EncryptionKeyConfig {
+            id: id.clone(),
+            secret: generate_secret(),
+            decrypt_only: false,
+        };
+        let mut new_keys = build_network_keys(&[config])?;
+        inner
+            .keys
+            .insert(id.clone(), new_keys.remove(&id).expect("new key exists"));
+        inner.active_key_id = Some(id.clone());
+        self.persist_state(&inner)?;
+        Ok(id)
+    }
+
+    pub(crate) fn retire(&self, key_id: &str) -> Result<(), String> {
+        let mut inner = self.inner.write();
+        if inner.active_key_id.as_deref() == Some(key_id) {
+            return Err("ERR ENC cannot retire the active key".to_string());
+        }
+        if inner.keys.remove(key_id).is_none() {
+            return Err(format!("ERR ENC key '{}' does not exist", key_id));
+        }
+        self.persist_state(&inner)
+    }
+
+    pub(crate) fn remaining_key_ids_without(&self, key_id: &str) -> HashSet<String> {
+        self.inner
+            .read()
+            .keys
+            .keys()
+            .filter(|id| id.as_str() != key_id)
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) fn is_encrypted_value(raw: &[u8]) -> bool {
+        raw.starts_with(ENVELOPE_MAGIC)
+    }
+
+    pub(crate) fn envelope_decryptable_by_any(envelope: &[u8], key_ids: &HashSet<String>) -> bool {
+        parse_envelope(envelope).is_ok_and(|parsed| {
+            parsed
+                .wraps
+                .iter()
+                .any(|wrap| key_ids.contains(wrap.key_id))
+        })
+    }
+
+    pub(crate) fn reencrypt(
+        &self,
+        table: &str,
+        field: &str,
+        pk: &str,
+        envelope: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        let plaintext = self.decrypt(table, field, pk, envelope)?;
+        self.encrypt(table, field, pk, &plaintext)
+    }
+
+    pub(crate) fn has_active_key(&self) -> bool {
+        self.inner.read().active_key_id.is_some()
+    }
+
+    pub(crate) fn encrypt(
+        &self,
+        table: &str,
+        field: &str,
+        pk: &str,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        let inner = self.inner.read();
+        let active_key_id = inner
+            .active_key_id
+            .as_deref()
+            .ok_or_else(|| "ERR encrypted values require an active encryption key".to_string())?;
+        if inner.keys.is_empty() {
+            return Err("ERR encrypted values require at least one encryption key".to_string());
+        }
+
+        let mut data_key = [0u8; DATA_KEY_LEN];
+        OsRng.fill_bytes(&mut data_key);
+
+        let value_key = data_value_key(&data_key)?;
+        let mut value_nonce = [0u8; NONCE_LEN];
+        OsRng.fill_bytes(&mut value_nonce);
+        let aad = value_aad(table, field, pk, active_key_id);
+        let mut ciphertext = plaintext.to_vec();
+        value_key
+            .seal_in_place_append_tag(
+                aead::Nonce::assume_unique_for_key(value_nonce),
+                aead::Aad::from(aad.as_slice()),
+                &mut ciphertext,
+            )
+            .map_err(|_| "ERR encryption failed".to_string())?;
+
+        let mut key_ids: Vec<&String> = inner.keys.keys().collect();
+        key_ids.sort();
+        let wrap_aad = wrap_aad(table, field, pk, active_key_id);
+        let mut wraps = Vec::with_capacity(key_ids.len());
+        for key_id in key_ids {
+            let Some(key) = inner.keys.get(key_id) else {
+                continue;
+            };
+            let mut wrap_nonce = [0u8; NONCE_LEN];
+            OsRng.fill_bytes(&mut wrap_nonce);
+            let mut wrapped = data_key.to_vec();
+            key.wrap_key
+                .seal_in_place_append_tag(
+                    aead::Nonce::assume_unique_for_key(wrap_nonce),
+                    aead::Aad::from(wrap_aad.as_slice()),
+                    &mut wrapped,
+                )
+                .map_err(|_| "ERR encryption key wrap failed".to_string())?;
+            wraps.push((key_id.as_str(), wrap_nonce, wrapped));
+        }
+        if wraps.len() > u8::MAX as usize {
+            return Err("ERR too many encryption keys for one encrypted value".to_string());
+        }
+
+        let mut envelope = Vec::new();
+        envelope.extend_from_slice(ENVELOPE_MAGIC);
+        envelope.push(active_key_id.len() as u8);
+        envelope.extend_from_slice(active_key_id.as_bytes());
+        envelope.push(wraps.len() as u8);
+        for (key_id, nonce, wrapped) in wraps {
+            envelope.push(key_id.len() as u8);
+            envelope.extend_from_slice(key_id.as_bytes());
+            envelope.extend_from_slice(&nonce);
+            envelope.extend_from_slice(&wrapped);
+        }
+        envelope.extend_from_slice(&value_nonce);
+        envelope.extend_from_slice(&ciphertext);
+        Ok(envelope)
+    }
+
+    pub(crate) fn decrypt(
+        &self,
+        table: &str,
+        field: &str,
+        pk: &str,
+        envelope: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        let inner = self.inner.read();
+        let parsed = parse_envelope(envelope)?;
+        let wrap_aad = wrap_aad(table, field, pk, parsed.writer_key_id);
+        let mut data_key = None;
+        for wrap in parsed.wraps {
+            let Some(key) = inner.keys.get(wrap.key_id) else {
+                continue;
+            };
+            let mut in_out = wrap.wrapped_data_key.to_vec();
+            if let Ok(opened) = key.wrap_key.open_in_place(
+                aead::Nonce::assume_unique_for_key(*wrap.nonce),
+                aead::Aad::from(wrap_aad.as_slice()),
+                &mut in_out,
+            ) {
+                if opened.len() == DATA_KEY_LEN {
+                    let mut key_bytes = [0u8; DATA_KEY_LEN];
+                    key_bytes.copy_from_slice(opened);
+                    data_key = Some(key_bytes);
+                    break;
+                }
+            }
+        }
+        let data_key = data_key.ok_or_else(|| {
+            "ERR encrypted value cannot be decrypted by configured keys".to_string()
+        })?;
+        let value_key = data_value_key(&data_key)?;
+        let aad = value_aad(table, field, pk, parsed.writer_key_id);
+        let mut in_out = parsed.ciphertext.to_vec();
+        let plaintext = value_key
+            .open_in_place(
+                aead::Nonce::assume_unique_for_key(*parsed.value_nonce),
+                aead::Aad::from(aad.as_slice()),
+                &mut in_out,
+            )
+            .map_err(|_| "ERR encrypted value could not be decrypted".to_string())?;
+        Ok(plaintext.to_vec())
+    }
+
+    pub(crate) fn blind_indexes(
+        &self,
+        table: &str,
+        field: &str,
+        encoded_value: &[u8],
+    ) -> Result<Vec<String>, String> {
+        let inner = self.inner.read();
+        if inner.keys.is_empty() {
+            return Err(
+                "ERR searchable encrypted columns require configured encryption keys".to_string(),
+            );
+        }
+        let mut key_ids: Vec<&String> = inner.keys.keys().collect();
+        key_ids.sort();
+        let mut indexes = Vec::with_capacity(key_ids.len());
+        for key_id in key_ids {
+            let key = inner.keys.get(key_id).unwrap();
+            let mut msg = Vec::with_capacity(table.len() + field.len() + encoded_value.len() + 2);
+            msg.extend_from_slice(table.as_bytes());
+            msg.push(0);
+            msg.extend_from_slice(field.as_bytes());
+            msg.push(0);
+            msg.extend_from_slice(encoded_value);
+            let tag = hmac::sign(&key.search_key, &msg);
+            indexes.push(hex(tag.as_ref()));
+        }
+        Ok(indexes)
+    }
+
+    /// Unseal persisted state by trying each candidate seal in order. Returns the
+    /// decoded state together with the seal that successfully opened it, so the
+    /// caller can decide whether to re-seal under a newer key.
+    fn load_state(
+        state_path: &Path,
+        candidates: &[[u8; 32]],
+    ) -> Result<(EncryptionState, [u8; 32]), String> {
+        let raw = fs::read(state_path).map_err(|e| format!("ERR ENC state read failed: {e}"))?;
+        let sealed: SealedState =
+            serde_json::from_slice(&raw).map_err(|e| format!("ERR ENC state is invalid: {e}"))?;
+        if sealed.version != 1 {
+            return Err("ERR ENC state version is unsupported".to_string());
+        }
+        let nonce = base64::engine::general_purpose::STANDARD
+            .decode(sealed.nonce)
+            .map_err(|_| "ERR ENC state nonce is invalid".to_string())?;
+        let nonce: [u8; NONCE_LEN] = nonce
+            .try_into()
+            .map_err(|_| "ERR ENC state nonce is invalid".to_string())?;
+        let ciphertext = base64::engine::general_purpose::STANDARD
+            .decode(sealed.ciphertext)
+            .map_err(|_| "ERR ENC state ciphertext is invalid".to_string())?;
+
+        for seal in candidates {
+            let key = seal_state_key(seal)?;
+            let mut buf = ciphertext.clone();
+            let Ok(plain) = key.open_in_place(
+                aead::Nonce::assume_unique_for_key(nonce),
+                aead::Aad::from(STATE_MAGIC),
+                &mut buf,
+            ) else {
+                continue;
+            };
+            let plain: PlainState = serde_json::from_slice(plain)
+                .map_err(|e| format!("ERR ENC state is invalid: {e}"))?;
+            if plain.version != 1 {
+                return Err("ERR ENC state version is unsupported".to_string());
+            }
+            let configs = plain
+                .keys
+                .into_iter()
+                .map(|key| {
+                    let secret = base64::engine::general_purpose::STANDARD
+                        .decode(key.secret)
+                        .map_err(|_| "ERR ENC state key secret is invalid".to_string())?;
+                    Ok(EncryptionKeyConfig {
+                        id: key.id,
+                        secret,
+                        decrypt_only: key.decrypt_only,
+                    })
+                })
+                .collect::<Result<Vec<_>, String>>()?;
+            let keys = build_network_keys(&configs)?;
+            validate_active_key(plain.active_key_id.as_deref(), &keys)?;
+            return Ok((
+                EncryptionState {
+                    active_key_id: plain.active_key_id,
+                    keys,
+                },
+                *seal,
+            ));
+        }
+        Err("ERR ENC state could not be unsealed".to_string())
+    }
+
+    fn persist_state(&self, inner: &EncryptionState) -> Result<(), String> {
+        let state_path = self
+            .state_path
+            .as_ref()
+            .ok_or_else(|| "ERR ENC state path is not configured".to_string())?;
+        let seal = current_seal(self.seal_secret, self.seal_path.as_deref())?;
+        let mut key_ids: Vec<&String> = inner.keys.keys().collect();
+        key_ids.sort();
+        let plain = PlainState {
+            version: 1,
+            active_key_id: inner.active_key_id.clone(),
+            keys: key_ids
+                .into_iter()
+                .map(|id| {
+                    let key = inner.keys.get(id).expect("key id from map");
+                    PlainKey {
+                        id: id.clone(),
+                        secret: base64::engine::general_purpose::STANDARD.encode(&key.secret),
+                        decrypt_only: key.decrypt_only,
+                    }
+                })
+                .collect(),
+        };
+        let mut plaintext = serde_json::to_vec(&plain)
+            .map_err(|e| format!("ERR ENC state serialize failed: {e}"))?;
+        let mut nonce = [0u8; NONCE_LEN];
+        OsRng.fill_bytes(&mut nonce);
+        let key = seal_state_key(&seal)?;
+        key.seal_in_place_append_tag(
+            aead::Nonce::assume_unique_for_key(nonce),
+            aead::Aad::from(STATE_MAGIC),
+            &mut plaintext,
+        )
+        .map_err(|_| "ERR ENC state seal failed".to_string())?;
+        let sealed = SealedState {
+            version: 1,
+            nonce: base64::engine::general_purpose::STANDARD.encode(nonce),
+            ciphertext: base64::engine::general_purpose::STANDARD.encode(plaintext),
+        };
+        let raw = serde_json::to_vec_pretty(&sealed)
+            .map_err(|e| format!("ERR ENC state serialize failed: {e}"))?;
+        if let Some(parent) = state_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| format!("ERR ENC state mkdir failed: {e}"))?;
+        }
+        let tmp = state_path.with_extension("enc.tmp");
+        {
+            use std::io::Write;
+            let mut file =
+                fs::File::create(&tmp).map_err(|e| format!("ERR ENC state write failed: {e}"))?;
+            file.write_all(&raw)
+                .map_err(|e| format!("ERR ENC state write failed: {e}"))?;
+            file.sync_all()
+                .map_err(|e| format!("ERR ENC state sync failed: {e}"))?;
+        }
+        fs::rename(&tmp, state_path).map_err(|e| format!("ERR ENC state replace failed: {e}"))?;
+        // fsync the directory so the rename itself is durable across a crash.
+        if let Some(parent) = state_path.parent() {
+            if let Ok(dir) = fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The seal used to *seal* state: the env-sourced secret when present, otherwise
+/// the on-disk seal file (created on first use, matching local-dev behavior).
+fn current_seal(
+    seal_secret: Option<[u8; 32]>,
+    seal_path: Option<&Path>,
+) -> Result<[u8; 32], String> {
+    if let Some(secret) = seal_secret {
+        return Ok(secret);
+    }
+    let path = seal_path.ok_or_else(|| "ERR ENC seal key is not configured".to_string())?;
+    read_seal_key(path, true)
+}
+
+/// Seals accepted for *unsealing*, in priority order: the current env seal, then
+/// rotated-out previous env seals, then the on-disk seal file if it exists.
+/// Errors only when no source is configured at all.
+fn collect_candidate_seals(
+    seal_secret: Option<[u8; 32]>,
+    previous: &[[u8; 32]],
+    seal_path: Option<&Path>,
+) -> Result<Vec<[u8; 32]>, String> {
+    let mut out: Vec<[u8; 32]> = Vec::new();
+    if let Some(secret) = seal_secret {
+        out.push(secret);
+    }
+    for seal in previous {
+        if !out.contains(seal) {
+            out.push(*seal);
+        }
+    }
+    if let Some(path) = seal_path {
+        if path.exists() {
+            let file_seal = read_seal_key(path, false)?;
+            if !out.contains(&file_seal) {
+                out.push(file_seal);
+            }
+        }
+    }
+    if out.is_empty() {
+        return Err("ERR ENC no seal key configured".to_string());
+    }
+    Ok(out)
+}
+
+struct ParsedEnvelope<'a> {
+    writer_key_id: &'a str,
+    wraps: Vec<KeyWrap<'a>>,
+    value_nonce: &'a [u8; NONCE_LEN],
+    ciphertext: &'a [u8],
+}
+
+struct KeyWrap<'a> {
+    key_id: &'a str,
+    nonce: &'a [u8; NONCE_LEN],
+    wrapped_data_key: &'a [u8],
+}
+
+fn parse_envelope(envelope: &[u8]) -> Result<ParsedEnvelope<'_>, String> {
+    if !envelope.starts_with(ENVELOPE_MAGIC) {
+        return Err("ERR stored value is not encrypted".to_string());
+    }
+    let mut pos = ENVELOPE_MAGIC.len();
+    let writer_len = *envelope
+        .get(pos)
+        .ok_or_else(|| "ERR encrypted value is truncated".to_string())?
+        as usize;
+    pos += 1;
+    let writer_end = pos + writer_len;
+    if envelope.len() < writer_end + 1 {
+        return Err("ERR encrypted value is truncated".to_string());
+    }
+    let writer_key_id = std::str::from_utf8(&envelope[pos..writer_end])
+        .map_err(|_| "ERR encrypted value has invalid writer key id".to_string())?;
+    pos = writer_end;
+    let wrap_count = envelope[pos] as usize;
+    pos += 1;
+    let mut wraps = Vec::with_capacity(wrap_count);
+    for _ in 0..wrap_count {
+        let id_len = *envelope
+            .get(pos)
+            .ok_or_else(|| "ERR encrypted value is truncated".to_string())?
+            as usize;
+        pos += 1;
+        let id_end = pos + id_len;
+        let wrap_end = id_end + NONCE_LEN + WRAPPED_DATA_KEY_LEN;
+        if envelope.len() < wrap_end {
+            return Err("ERR encrypted value is truncated".to_string());
+        }
+        let key_id = std::str::from_utf8(&envelope[pos..id_end])
+            .map_err(|_| "ERR encrypted value has invalid key id".to_string())?;
+        pos = id_end;
+        let nonce: &[u8; NONCE_LEN] = envelope[pos..pos + NONCE_LEN]
+            .try_into()
+            .map_err(|_| "ERR encrypted value has invalid key nonce".to_string())?;
+        pos += NONCE_LEN;
+        let wrapped_data_key = &envelope[pos..pos + WRAPPED_DATA_KEY_LEN];
+        pos += WRAPPED_DATA_KEY_LEN;
+        wraps.push(KeyWrap {
+            key_id,
+            nonce,
+            wrapped_data_key,
+        });
+    }
+    if envelope.len() < pos + NONCE_LEN {
+        return Err("ERR encrypted value is truncated".to_string());
+    }
+    let value_nonce: &[u8; NONCE_LEN] = envelope[pos..pos + NONCE_LEN]
+        .try_into()
+        .map_err(|_| "ERR encrypted value has invalid value nonce".to_string())?;
+    pos += NONCE_LEN;
+    Ok(ParsedEnvelope {
+        writer_key_id,
+        wraps,
+        value_nonce,
+        ciphertext: &envelope[pos..],
+    })
+}
+
+fn build_network_keys(
+    configs: &[EncryptionKeyConfig],
+) -> Result<HashMap<String, NetworkKey>, String> {
+    let mut keys = HashMap::new();
+    for key in configs {
+        validate_key_id(&key.id)?;
+        if keys.contains_key(&key.id) {
+            return Err(format!("ERR duplicate ENC key '{}'", key.id));
+        }
+        let wrap_key = derive_key(&key.secret, b"lux-dek-wrap-v1");
+        let search_key = derive_key(&key.secret, b"lux-table-search-v1");
+        let unbound = aead::UnboundKey::new(&aead::CHACHA20_POLY1305, &wrap_key)
+            .map_err(|_| "ERR invalid encryption key".to_string())?;
+        keys.insert(
+            key.id.clone(),
+            NetworkKey {
+                secret: key.secret.clone(),
+                wrap_key: aead::LessSafeKey::new(unbound),
+                search_key: hmac::Key::new(hmac::HMAC_SHA256, &search_key),
+                decrypt_only: key.decrypt_only,
+            },
+        );
+    }
+    Ok(keys)
+}
+
+fn validate_key_id(id: &str) -> Result<(), String> {
+    if id.is_empty() {
+        return Err("ERR encryption key id cannot be empty".to_string());
+    }
+    if id.len() > u8::MAX as usize {
+        return Err("ERR encryption key id is too long".to_string());
+    }
+    if !id
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+    {
+        return Err(
+            "ERR encryption key id must contain only letters, numbers, '_' or '-'".to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn validate_active_key(
+    active_key_id: Option<&str>,
+    keys: &HashMap<String, NetworkKey>,
+) -> Result<(), String> {
+    if let Some(active) = active_key_id {
+        let key = keys
+            .get(active)
+            .ok_or_else(|| format!("ERR active encryption key '{}' is not configured", active))?;
+        if key.decrypt_only {
+            return Err(format!(
+                "ERR active encryption key '{}' is marked decrypt-only",
+                active
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn resolve_path(configured: Option<&str>, data_dir: &str, default_name: &str) -> Option<PathBuf> {
+    if configured == Some("") {
+        return None;
+    }
+    Some(
+        configured
+            .map(PathBuf::from)
+            .unwrap_or_else(|| Path::new(data_dir).join(default_name)),
+    )
+}
+
+fn generate_key_id() -> String {
+    let mut bytes = [0u8; 8];
+    OsRng.fill_bytes(&mut bytes);
+    format!("k{}", hex(&bytes))
+}
+
+fn generate_secret() -> Vec<u8> {
+    let mut secret = vec![0u8; 32];
+    OsRng.fill_bytes(&mut secret);
+    secret
+}
+
+fn read_seal_key(path: &Path, create: bool) -> Result<[u8; 32], String> {
+    match fs::read(path) {
+        Ok(raw) => {
+            let text = String::from_utf8(raw)
+                .map_err(|_| "ERR ENC seal file is not valid UTF-8".to_string())?;
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(text.trim())
+                .map_err(|_| "ERR ENC seal file is invalid".to_string())?;
+            decoded
+                .try_into()
+                .map_err(|_| "ERR ENC seal file has invalid length".to_string())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound && create => {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|e| format!("ERR ENC seal mkdir failed: {e}"))?;
+            }
+            let mut seal = [0u8; 32];
+            OsRng.fill_bytes(&mut seal);
+            let encoded = base64::engine::general_purpose::STANDARD.encode(seal);
+            write_new_seal_file(path, encoded.as_bytes())?;
+            Ok(seal)
+        }
+        Err(e) => Err(format!("ERR ENC seal read failed: {e}")),
+    }
+}
+
+fn write_new_seal_file(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|e| format!("ERR ENC seal create failed: {e}"))?;
+        file.write_all(bytes)
+            .map_err(|e| format!("ERR ENC seal write failed: {e}"))?;
+        file.write_all(b"\n")
+            .map_err(|e| format!("ERR ENC seal write failed: {e}"))?;
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        fs::write(path, [bytes, b"\n"].concat())
+            .map_err(|e| format!("ERR ENC seal write failed: {e}"))
+    }
+}
+
+fn seal_state_key(secret: &[u8; 32]) -> Result<aead::LessSafeKey, String> {
+    let key = derive_key(secret, b"lux-enc-state-seal-v1");
+    let unbound = aead::UnboundKey::new(&aead::CHACHA20_POLY1305, &key)
+        .map_err(|_| "ERR invalid ENC seal key".to_string())?;
+    Ok(aead::LessSafeKey::new(unbound))
+}
+
+fn data_value_key(data_key: &[u8; DATA_KEY_LEN]) -> Result<aead::LessSafeKey, String> {
+    let unbound = aead::UnboundKey::new(&aead::CHACHA20_POLY1305, data_key)
+        .map_err(|_| "ERR invalid data encryption key".to_string())?;
+    Ok(aead::LessSafeKey::new(unbound))
+}
+
+fn derive_key(secret: &[u8], label: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(label);
+    hasher.update([0]);
+    hasher.update(secret);
+    hasher.finalize().into()
+}
+
+fn wrap_aad(table: &str, field: &str, pk: &str, writer_key_id: &str) -> Vec<u8> {
+    aad_with_writer(b"lux-dek-wrap-aad-v1", table, field, pk, writer_key_id)
+}
+
+fn value_aad(table: &str, field: &str, pk: &str, writer_key_id: &str) -> Vec<u8> {
+    aad_with_writer(b"lux-value-aad-v1", table, field, pk, writer_key_id)
+}
+
+fn aad_with_writer(
+    label: &[u8],
+    table: &str,
+    field: &str,
+    pk: &str,
+    writer_key_id: &str,
+) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(
+        label.len() + table.len() + field.len() + pk.len() + writer_key_id.len() + 4,
+    );
+    aad.extend_from_slice(label);
+    aad.push(0);
+    aad.extend_from_slice(table.as_bytes());
+    aad.push(0);
+    aad.extend_from_slice(field.as_bytes());
+    aad.push(0);
+    aad.extend_from_slice(pk.as_bytes());
+    aad.push(0);
+    aad.extend_from_slice(writer_key_id.as_bytes());
+    aad
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod adversarial_tests {
+    //! Adversarial unit tests for the core crypto envelope. These try to *break*
+    //! the construction: reuse ciphertext across (table, field, pk), tamper the
+    //! AEAD, forge the writer key id, and abuse the keyring lifecycle.
+    use super::*;
+
+    fn mem_ring(keys: &[(&str, &[u8], bool)], active: Option<&str>) -> EncryptionKeyring {
+        let config = EncryptionConfig {
+            active_key_id: active.map(str::to_string),
+            keys: keys
+                .iter()
+                .map(|(id, secret, decrypt_only)| EncryptionKeyConfig {
+                    id: id.to_string(),
+                    secret: secret.to_vec(),
+                    decrypt_only: *decrypt_only,
+                })
+                .collect(),
+            // Empty string disables persistence (resolve_path -> None), keeping
+            // these tests purely in-memory.
+            state_path: Some(String::new()),
+            seal_path: Some(String::new()),
+            auto_init: false,
+            ..Default::default()
+        };
+        EncryptionKeyring::open(&config, ".").expect("keyring opens")
+    }
+
+    fn one_key_ring() -> EncryptionKeyring {
+        mem_ring(
+            &[("k1", b"a-32-byte-ish-secret-for-tests!!", false)],
+            Some("k1"),
+        )
+    }
+
+    #[test]
+    fn round_trips_and_marks_envelope() {
+        let ring = one_key_ring();
+        let ct = ring.encrypt("users", "ssn", "42", b"123-45-6789").unwrap();
+        assert!(EncryptionKeyring::is_encrypted_value(&ct));
+        // Ciphertext must not contain the plaintext.
+        assert!(!ct.windows(11).any(|w| w == b"123-45-6789"));
+        let pt = ring.decrypt("users", "ssn", "42", &ct).unwrap();
+        assert_eq!(pt, b"123-45-6789");
+    }
+
+    #[test]
+    fn same_plaintext_encrypts_differently() {
+        let ring = one_key_ring();
+        let a = ring.encrypt("t", "f", "1", b"same").unwrap();
+        let b = ring.encrypt("t", "f", "1", b"same").unwrap();
+        assert_ne!(
+            a, b,
+            "random DEK/nonce must make ciphertext non-deterministic"
+        );
+    }
+
+    #[test]
+    fn ciphertext_is_bound_to_field_row_and_table() {
+        let ring = one_key_ring();
+        let ct = ring.encrypt("users", "ssn", "42", b"secret").unwrap();
+        // Same key, wrong field / row / table must all fail (AAD binding).
+        assert!(
+            ring.decrypt("users", "email", "42", &ct).is_err(),
+            "cross-field"
+        );
+        assert!(
+            ring.decrypt("users", "ssn", "43", &ct).is_err(),
+            "cross-row"
+        );
+        assert!(
+            ring.decrypt("orders", "ssn", "42", &ct).is_err(),
+            "cross-table"
+        );
+        // Correct coordinates still work.
+        assert!(ring.decrypt("users", "ssn", "42", &ct).is_ok());
+    }
+
+    #[test]
+    fn tampering_ciphertext_or_wrap_is_rejected() {
+        let ring = one_key_ring();
+        let base = ring.encrypt("t", "f", "1", b"the-plaintext").unwrap();
+        // Flip the final byte (inside the value ciphertext/tag).
+        let mut last = base.clone();
+        *last.last_mut().unwrap() ^= 0x01;
+        assert!(ring.decrypt("t", "f", "1", &last).is_err(), "value tag");
+        // Flip a byte in the middle (inside the wrapped-key region).
+        let mut mid = base.clone();
+        let i = ENVELOPE_MAGIC.len() + 8;
+        mid[i] ^= 0x01;
+        assert!(ring.decrypt("t", "f", "1", &mid).is_err(), "wrap region");
+    }
+
+    #[test]
+    fn forging_writer_key_id_bytes_is_rejected() {
+        let ring = one_key_ring();
+        let mut ct = ring.encrypt("t", "f", "1", b"payload").unwrap();
+        // writer_key_id is a length-prefixed field right after the magic; the id
+        // is "k1", so flip a byte of it while keeping the length. AAD binds the
+        // writer id, so unwrap should fail.
+        let id_pos = ENVELOPE_MAGIC.len() + 1;
+        ct[id_pos] ^= 0x01;
+        assert!(ring.decrypt("t", "f", "1", &ct).is_err());
+    }
+
+    #[test]
+    fn truncated_envelopes_error_without_panic() {
+        let ring = one_key_ring();
+        let ct = ring.encrypt("t", "f", "1", b"payload").unwrap();
+        for len in 0..ct.len() {
+            // Must never panic; every prefix is either an error or (only at full
+            // length) a success.
+            let _ = ring.decrypt("t", "f", "1", &ct[..len]);
+        }
+        assert!(ring.decrypt("t", "f", "1", &ct).is_ok());
+    }
+
+    #[test]
+    fn blind_index_is_deterministic_per_field_and_value() {
+        let ring = one_key_ring();
+        let a1 = ring
+            .blind_indexes("users", "email", b"alice@x.com")
+            .unwrap();
+        let a2 = ring
+            .blind_indexes("users", "email", b"alice@x.com")
+            .unwrap();
+        let b = ring.blind_indexes("users", "email", b"bob@x.com").unwrap();
+        let other_field = ring
+            .blind_indexes("users", "recovery", b"alice@x.com")
+            .unwrap();
+        assert_eq!(a1, a2, "same (field,value) -> same index");
+        assert_ne!(a1, b, "different value -> different index");
+        assert_ne!(a1, other_field, "different field -> different index");
+    }
+
+    #[test]
+    fn blind_index_has_one_entry_per_key() {
+        let ring = mem_ring(
+            &[
+                ("k1", b"secret-number-one-secret-number1", false),
+                ("k2", b"secret-number-two-secret-number2", false),
+            ],
+            Some("k2"),
+        );
+        let idx = ring.blind_indexes("t", "f", b"v").unwrap();
+        assert_eq!(idx.len(), 2);
+        assert_ne!(idx[0], idx[1], "each key derives a distinct blind index");
+    }
+
+    #[test]
+    fn active_key_cannot_be_decrypt_only() {
+        let config = EncryptionConfig {
+            active_key_id: Some("k1".into()),
+            keys: vec![EncryptionKeyConfig {
+                id: "k1".into(),
+                secret: b"decrypt-only-secret-decrypt-only".to_vec(),
+                decrypt_only: true,
+            }],
+            state_path: Some(String::new()),
+            seal_path: Some(String::new()),
+            auto_init: false,
+            ..Default::default()
+        };
+        assert!(EncryptionKeyring::open(&config, ".").is_err());
+    }
+
+    #[test]
+    fn value_decryptable_by_any_ring_holding_a_wrapped_key() {
+        // Written while both keys are in the ring -> DEK wrapped under both.
+        let writer = mem_ring(
+            &[
+                ("old", b"old-secret-old-secret-old-secre1", false),
+                ("new", b"new-secret-new-secret-new-secre2", false),
+            ],
+            Some("new"),
+        );
+        let ct = writer.encrypt("t", "f", "1", b"shared").unwrap();
+        // A reader that only has "old" must still decrypt (wrap present).
+        let reader_old = mem_ring(
+            &[("old", b"old-secret-old-secret-old-secre1", false)],
+            Some("old"),
+        );
+        assert_eq!(reader_old.decrypt("t", "f", "1", &ct).unwrap(), b"shared");
+        // A reader with an unrelated key cannot.
+        let stranger = mem_ring(
+            &[("x", b"stranger-secret-stranger-secret1", false)],
+            Some("x"),
+        );
+        assert!(stranger.decrypt("t", "f", "1", &ct).is_err());
+    }
+
+    #[test]
+    fn persisted_state_survives_reopen_and_wrong_seal_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().to_string_lossy().to_string();
+        let config = EncryptionConfig {
+            state_path: None,
+            seal_path: None,
+            auto_init: false,
+            ..Default::default()
+        };
+        // Init + encrypt.
+        let ring = EncryptionKeyring::open(&config, &data_dir).unwrap();
+        let kid = ring.init(Some("k1")).unwrap();
+        assert_eq!(kid, "k1");
+        let ct = ring.encrypt("t", "f", "1", b"persisted").unwrap();
+        drop(ring);
+
+        // Reopen from the same dir: state unseals, data decrypts.
+        let reopened = EncryptionKeyring::open(&config, &data_dir).unwrap();
+        assert!(reopened.has_active_key());
+        assert_eq!(reopened.decrypt("t", "f", "1", &ct).unwrap(), b"persisted");
+        drop(reopened);
+
+        // Corrupt the seal file: reopen must fail closed, not silently reset.
+        let seal_path = std::path::Path::new(&data_dir).join("lux.enc.seal");
+        let mut bad = [0u8; 32];
+        bad[0] = 0xAB;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bad);
+        std::fs::write(&seal_path, encoded).unwrap();
+        assert!(
+            EncryptionKeyring::open(&config, &data_dir).is_err(),
+            "wrong seal must not unseal the keyring"
+        );
+    }
+
+    #[test]
+    fn retire_rules_hold_at_keyring_level() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().to_string_lossy().to_string();
+        let config = EncryptionConfig::default();
+        let ring = EncryptionKeyring::open(&config, &data_dir).unwrap();
+        ring.init(Some("k1")).unwrap();
+        ring.rotate(Some("k2")).unwrap();
+        // Cannot retire the active key; cannot retire a nonexistent key.
+        assert!(ring.retire("k2").is_err(), "active key");
+        assert!(ring.retire("does-not-exist").is_err());
+        // Retiring the old (now decrypt-only) key is allowed at this layer.
+        assert!(ring.retire("k1").is_ok());
+    }
+
+    // ---- seal sourcing: env seal, file->env migration, rotation ----
+
+    fn seal_bytes(tag: u8) -> [u8; 32] {
+        [tag; 32]
+    }
+
+    fn env_seal_config(seal: [u8; 32], previous: Vec<[u8; 32]>) -> EncryptionConfig {
+        EncryptionConfig {
+            seal_secret: Some(seal),
+            previous_seal_secrets: previous,
+            auto_init: false,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn env_seal_round_trips_without_writing_a_seal_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().to_string_lossy().to_string();
+        let config = env_seal_config(seal_bytes(1), Vec::new());
+
+        let ring = EncryptionKeyring::open(&config, &data_dir).unwrap();
+        ring.init(Some("k1")).unwrap();
+        let ct = ring.encrypt("t", "f", "1", b"envsealed").unwrap();
+        drop(ring);
+
+        // No on-disk seal file is created when the seal comes from the env.
+        assert!(!dir.path().join("lux.enc.seal").exists());
+        assert!(dir.path().join("lux.enc").exists());
+
+        let reopened = EncryptionKeyring::open(&config, &data_dir).unwrap();
+        assert_eq!(reopened.decrypt("t", "f", "1", &ct).unwrap(), b"envsealed");
+    }
+
+    #[test]
+    fn migrates_file_seal_to_env_seal_and_deletes_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().to_string_lossy().to_string();
+
+        // Bootstrap with a file seal (no env seal), like today's local/native mode.
+        let file_config = EncryptionConfig {
+            auto_init: false,
+            ..Default::default()
+        };
+        let ring = EncryptionKeyring::open(&file_config, &data_dir).unwrap();
+        ring.init(Some("k1")).unwrap();
+        let ct = ring.encrypt("t", "f", "1", b"legacy").unwrap();
+        drop(ring);
+        assert!(dir.path().join("lux.enc.seal").exists());
+
+        // Reopen with a fresh env seal while the old file is still present: the
+        // engine unseals via the file, re-seals under the env seal, deletes file.
+        let env_config = env_seal_config(seal_bytes(7), Vec::new());
+        let migrated = EncryptionKeyring::open(&env_config, &data_dir).unwrap();
+        assert_eq!(migrated.decrypt("t", "f", "1", &ct).unwrap(), b"legacy");
+        drop(migrated);
+        assert!(
+            !dir.path().join("lux.enc.seal").exists(),
+            "seal file must be removed after migration"
+        );
+
+        // A second reopen with only the env seal (no file) still works.
+        let reopened = EncryptionKeyring::open(&env_config, &data_dir).unwrap();
+        assert_eq!(reopened.decrypt("t", "f", "1", &ct).unwrap(), b"legacy");
+    }
+
+    #[test]
+    fn rotates_seal_via_previous_and_old_seal_stops_working() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().to_string_lossy().to_string();
+        let old = seal_bytes(3);
+        let new = seal_bytes(9);
+
+        // Seal under the old env seal.
+        let old_config = env_seal_config(old, Vec::new());
+        let ring = EncryptionKeyring::open(&old_config, &data_dir).unwrap();
+        ring.init(Some("k1")).unwrap();
+        let ct = ring.encrypt("t", "f", "1", b"rotate-me").unwrap();
+        drop(ring);
+
+        // Boot with new current + old as previous: unseals and re-seals under new.
+        let rotate_config = env_seal_config(new, vec![old]);
+        let rotated = EncryptionKeyring::open(&rotate_config, &data_dir).unwrap();
+        assert_eq!(rotated.decrypt("t", "f", "1", &ct).unwrap(), b"rotate-me");
+        drop(rotated);
+
+        // The new seal alone now opens it.
+        let new_only = env_seal_config(new, Vec::new());
+        assert!(EncryptionKeyring::open(&new_only, &data_dir).is_ok());
+
+        // The old seal alone no longer opens the re-sealed state.
+        let old_only = env_seal_config(old, Vec::new());
+        assert!(
+            EncryptionKeyring::open(&old_only, &data_dir).is_err(),
+            "old seal must not open state re-sealed under the new seal"
+        );
+    }
+
+    #[test]
+    fn wrong_env_seal_with_no_previous_or_file_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().to_string_lossy().to_string();
+
+        let good = env_seal_config(seal_bytes(4), Vec::new());
+        let ring = EncryptionKeyring::open(&good, &data_dir).unwrap();
+        ring.init(Some("k1")).unwrap();
+        ring.encrypt("t", "f", "1", b"x").unwrap();
+        drop(ring);
+
+        let wrong = env_seal_config(seal_bytes(5), Vec::new());
+        assert!(
+            EncryptionKeyring::open(&wrong, &data_dir).is_err(),
+            "a wrong env seal with no fallback must fail closed"
+        );
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -2821,7 +2821,7 @@ fn route_table_create(
     // Accepts two formats per element:
     //   - plain string: "id UUID PRIMARY KEY" (passed through as-is)
     //   - object: {"name":"email","type":"STR","primaryKey":true,"unique":true,"notNull":true,
-    //              "references":"users(id)","onDelete":"CASCADE"}
+    //              "encrypted":true,"searchable":true,"references":"users(id)","onDelete":"CASCADE"}
     let mut col_specs: Vec<String> = Vec::new();
     for col in columns {
         if let Some(s) = col.as_str() {
@@ -2845,6 +2845,20 @@ fn route_table_create(
                 .unwrap_or(false)
             {
                 spec.push_str(" NOT NULL");
+            }
+            if obj
+                .get("encrypted")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                spec.push_str(" ENCRYPTED");
+            }
+            if obj
+                .get("searchable")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                spec.push_str(" SEARCHABLE");
             }
             if let Some(refs) = obj.get("references").and_then(|v| v.as_str()) {
                 spec.push_str(&format!(" REFERENCES {}", refs));
@@ -3992,6 +4006,101 @@ mod tests {
             out.contains(r#""embedding":[0.1,0.2,0.3]"#),
             "returning: {out}"
         );
+    }
+
+    fn encrypted_http_fixture() -> (
+        Arc<Store>,
+        Broker,
+        SharedSchemaCache,
+        Arc<lua::ScriptEngine>,
+    ) {
+        let config = Arc::new(crate::ServerConfig {
+            encryption: crate::EncryptionConfig {
+                active_key_id: Some("k1".to_string()),
+                keys: vec![crate::EncryptionKeyConfig {
+                    id: "k1".to_string(),
+                    secret: b"http-encryption-secret".to_vec(),
+                    decrypt_only: false,
+                }],
+                ..Default::default()
+            },
+            ..crate::ServerConfig::default()
+        });
+        let store = Arc::new(Store::new_with_config(config));
+        let cache: SharedSchemaCache =
+            Arc::new(parking_lot::RwLock::new(crate::tables::SchemaCache::new()));
+        let broker = Broker::new();
+        let script_engine = Arc::new(lua::ScriptEngine::new());
+        (store, broker, cache, script_engine)
+    }
+
+    #[test]
+    fn http_table_routes_round_trip_encrypted_columns_without_raw_plaintext() {
+        let (store, broker, cache, se) = encrypted_http_fixture();
+        let body = r#"{
+            "name":"secrets",
+            "columns":[
+                {"name":"id","type":"STR","primaryKey":true},
+                {"name":"email","type":"STR","encrypted":true,"searchable":true,"unique":true},
+                {"name":"token","type":"STR","encrypted":true}
+            ]
+        }"#;
+        let (status, _, out) = route_table_create(body, &store, &broker, &cache, &se);
+        assert_eq!(status, 200, "{out}");
+        assert!(!out.contains("error"), "{out}");
+
+        let (status, _, inserted) = route_table_insert(
+            "secrets",
+            &[],
+            r#"{"id":"s1","email":"person@example.com","token":"plain-secret"}"#,
+            &store,
+            &broker,
+            &cache,
+            &HttpAuthContext::Operator,
+        );
+        assert_eq!(status, 200, "{inserted}");
+        assert!(
+            inserted.contains(r#""email":"person@example.com""#),
+            "{inserted}"
+        );
+        assert!(inserted.contains(r#""token":"plain-secret""#), "{inserted}");
+
+        let raw_email = store
+            .hget(b"_t:secrets:row:s1", b"email", Instant::now())
+            .unwrap();
+        let raw_token = store
+            .hget(b"_t:secrets:row:s1", b"token", Instant::now())
+            .unwrap();
+        assert!(!raw_email
+            .windows(b"person@example.com".len())
+            .any(|w| w == b"person@example.com"));
+        assert!(!raw_token
+            .windows(b"plain-secret".len())
+            .any(|w| w == b"plain-secret"));
+
+        let params = vec![(
+            "where".to_string(),
+            "email = person@example.com".to_string(),
+        )];
+        let (status, _, queried) = route_table_query("secrets", &params, &store, &broker, &cache);
+        assert_eq!(status, 200, "{queried}");
+        assert!(
+            queried.contains(r#""email":"person@example.com""#),
+            "{queried}"
+        );
+        assert!(queried.contains(r#""token":"plain-secret""#), "{queried}");
+    }
+
+    #[test]
+    fn http_table_create_rejects_encrypted_default() {
+        let (store, broker, cache, se) = encrypted_http_fixture();
+        let body = r#"{
+            "name":"secrets",
+            "columns":["id STR PRIMARY KEY","token STR ENCRYPTED DEFAULT leaked"]
+        }"#;
+        let (status, _, out) = route_table_create(body, &store, &broker, &cache, &se);
+        assert_eq!(status, 200, "{out}");
+        assert!(out.contains("cannot use DEFAULT"), "{out}");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod cmd;
 mod command;
 mod disk;
 mod embedded;
+mod encryption;
 mod eviction;
 #[cfg(feature = "fuzzing")]
 pub mod fuzz_api;
@@ -48,6 +49,7 @@ pub use embedded::{
     EmbeddedPipeline, GeoMember, GeoPosition, GeoUnit, PreparedPipeline, RedisKeyType,
     ScoredMember, SetOptions,
 };
+pub use encryption::{EncryptionConfig, EncryptionKeyConfig};
 pub use eviction::{parse_eviction_policy, parse_memory_size, EvictionConfig, EvictionPolicy};
 
 const SUB_MODE_BATCH_MAX: usize = 64;
@@ -231,6 +233,8 @@ pub struct ServerConfig {
     pub eviction: EvictionConfig,
     /// Per-project application auth configuration.
     pub auth: AuthConfig,
+    /// Table column encryption key configuration.
+    pub encryption: EncryptionConfig,
     /// Enables the RESP listener. Use this instead of overloading `port = 0`.
     pub enable_resp: bool,
     /// Optional informational event sink. Library mode is silent when unset.
@@ -260,6 +264,7 @@ impl std::fmt::Debug for ServerConfig {
             .field("storage", &self.storage)
             .field("eviction", &self.eviction)
             .field("auth", &self.auth)
+            .field("encryption", &self.encryption)
             .field("enable_resp", &self.enable_resp)
             .field("on_info", &self.on_info.as_ref().map(|_| "<callback>"))
             .field("on_warn", &self.on_warn.as_ref().map(|_| "<callback>"))
@@ -287,6 +292,7 @@ impl Default for ServerConfig {
             storage: StorageConfig::default(),
             eviction: EvictionConfig::default(),
             auth: AuthConfig::default(),
+            encryption: EncryptionConfig::default(),
             enable_resp: true,
             on_info: None,
             on_warn: None,
@@ -465,6 +471,21 @@ fn validate_shard_count(config: &ServerConfig) -> std::io::Result<()> {
         ));
     }
     Ok(())
+}
+
+fn validate_encryption_config(config: &ServerConfig) -> std::io::Result<()> {
+    // Fail fast on a bad encryption config: unresolvable key material, a
+    // decrypt-only active key, or persisted state that no configured seal can
+    // unseal. Validate against the real data dir (not the process cwd, which
+    // would strand seal/state files there) with auto-init off, since creating a
+    // brand-new keyring is the store's job, not validation's.
+    let validation = EncryptionConfig {
+        auto_init: false,
+        ..config.encryption.clone()
+    };
+    crate::encryption::EncryptionKeyring::open(&validation, &config.data_dir)
+        .map(|_| ())
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))
 }
 
 pub struct ServerHandle {
@@ -2866,6 +2887,7 @@ pub async fn run_with_config(config: ServerConfig) -> std::io::Result<ServerHand
     validate_listener_security(&config)?;
     validate_auth_config(&config)?;
     validate_shard_count(&config)?;
+    validate_encryption_config(&config)?;
     let listener = if config.enable_resp {
         let addr = config.listen_addr();
         Some(TcpListener::bind(&addr).await?)

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,8 @@ async fn async_main() -> std::io::Result<()> {
         .unwrap_or(30 * 24 * 60 * 60);
     let managed_email = managed_auth_email_from_env();
 
+    let encryption = encryption_config_from_env()?;
+
     let config = lux::ServerConfig {
         bind_host: std::env::var("LUX_BIND_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
         port: std::env::var("LUX_PORT")
@@ -145,6 +147,7 @@ async fn async_main() -> std::io::Result<()> {
             initial_secret_key: std::env::var("LUX_AUTH_SECRET_KEY").ok(),
             managed_email,
         },
+        encryption,
         // The library is quiet by default; the binary maps severity-specific
         // callbacks back to the previous stdout/stderr behavior.
         on_info: Some(std::sync::Arc::new(print_info_event)),
@@ -159,6 +162,162 @@ async fn async_main() -> std::io::Result<()> {
         println!("lux v{} ready", env!("CARGO_PKG_VERSION"));
     }
     handle.wait().await
+}
+
+fn encryption_config_from_env() -> std::io::Result<lux::EncryptionConfig> {
+    let state_path = std::env::var("LUX_ENC_STATE_PATH").ok();
+    let seal_path = std::env::var("LUX_ENC_SEAL_PATH").ok();
+    let auto_init = std::env::var("LUX_ENC_AUTO_INIT").is_ok_and(|value| {
+        let value = value.to_ascii_lowercase();
+        value == "1" || value == "true"
+    });
+    let seal_secret = parse_seal_env("LUX_ENC_SEAL_KEY")
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+    let previous_seal_secrets = parse_seal_list_env("LUX_ENC_SEAL_KEY_PREVIOUS")
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+
+    // Warn once at boot when encryption is in use but the seal lives on the data
+    // volume: a stolen disk/snapshot then carries both the sealed keyring and its
+    // key. Env-sourced seals (LUX_ENC_SEAL_KEY) avoid this.
+    let encryption_in_use = auto_init
+        || std::env::var("LUX_ENCRYPTION_KEYS").is_ok()
+        || std::env::var("LUX_ENCRYPTION_KEY").is_ok();
+    if seal_secret.is_none() && encryption_in_use {
+        eprintln!(
+            "lux: warning: encryption seal key is stored on the data volume; \
+             a stolen disk or backup carries the key. Set LUX_ENC_SEAL_KEY \
+             (base64 of 32 bytes) from your secret store."
+        );
+    }
+
+    if let Ok(raw) = std::env::var("LUX_ENCRYPTION_KEYS") {
+        let mut config =
+            parse_encryption_keys_json(&raw, std::env::var("LUX_ENCRYPTION_KEY_ID").ok())
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error));
+        if let Ok(config) = &mut config {
+            config.state_path = state_path;
+            config.seal_path = seal_path;
+            config.auto_init = auto_init;
+            config.seal_secret = seal_secret;
+            config.previous_seal_secrets = previous_seal_secrets;
+        }
+        return config;
+    }
+
+    let Some(secret) = std::env::var("LUX_ENCRYPTION_KEY").ok() else {
+        return Ok(lux::EncryptionConfig {
+            state_path,
+            seal_path,
+            auto_init,
+            seal_secret,
+            previous_seal_secrets,
+            ..Default::default()
+        });
+    };
+    let id = std::env::var("LUX_ENCRYPTION_KEY_ID").unwrap_or_else(|_| "local".to_string());
+    Ok(lux::EncryptionConfig {
+        active_key_id: Some(id.clone()),
+        keys: vec![lux::EncryptionKeyConfig {
+            id,
+            secret: secret.into_bytes(),
+            decrypt_only: false,
+        }],
+        state_path,
+        seal_path,
+        auto_init,
+        seal_secret,
+        previous_seal_secrets,
+    })
+}
+
+/// Decode a single base64 seal env var into 32 bytes. Absent -> None; present but
+/// malformed / wrong length -> hard error (fail closed rather than silently
+/// falling back to a disk seal).
+fn parse_seal_env(name: &str) -> Result<Option<[u8; 32]>, String> {
+    match std::env::var(name) {
+        Ok(raw) if !raw.trim().is_empty() => Ok(Some(decode_seal_value(name, raw.trim())?)),
+        _ => Ok(None),
+    }
+}
+
+/// Decode a comma-separated list of base64 seals (previous/rotated-out keys).
+fn parse_seal_list_env(name: &str) -> Result<Vec<[u8; 32]>, String> {
+    let Ok(raw) = std::env::var(name) else {
+        return Ok(Vec::new());
+    };
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| decode_seal_value(name, s))
+        .collect()
+}
+
+fn decode_seal_value(name: &str, value: &str) -> Result<[u8; 32], String> {
+    use base64::Engine as _;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(value)
+        .map_err(|_| format!("{name} must be base64"))?;
+    bytes
+        .try_into()
+        .map_err(|_| format!("{name} must decode to exactly 32 bytes"))
+}
+
+fn parse_encryption_keys_json(
+    raw: &str,
+    active_key_id: Option<String>,
+) -> Result<lux::EncryptionConfig, String> {
+    let value = serde_json::from_str::<serde_json::Value>(raw)
+        .map_err(|error| format!("invalid LUX_ENCRYPTION_KEYS JSON: {error}"))?;
+    let items = value
+        .as_array()
+        .ok_or_else(|| "LUX_ENCRYPTION_KEYS must be a JSON array".to_string())?;
+    let mut keys = Vec::with_capacity(items.len());
+    for (idx, item) in items.iter().enumerate() {
+        let id = item
+            .get("id")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| format!("LUX_ENCRYPTION_KEYS[{idx}].id must be a non-empty string"))?;
+        let secret = item
+            .get("secret")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                format!("LUX_ENCRYPTION_KEYS[{idx}].secret must be a non-empty string")
+            })?;
+        keys.push(lux::EncryptionKeyConfig {
+            id: id.to_string(),
+            secret: secret.as_bytes().to_vec(),
+            decrypt_only: item
+                .get("decryptOnly")
+                .or_else(|| item.get("decrypt_only"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+        });
+    }
+    let active_key_id = active_key_id.or_else(|| {
+        keys.iter()
+            .rev()
+            .find(|k| !k.decrypt_only)
+            .map(|k| k.id.clone())
+    });
+    if active_key_id.is_none() {
+        return Err("LUX_ENCRYPTION_KEYS must include at least one writable key".to_string());
+    }
+    let config = lux::EncryptionConfig {
+        active_key_id,
+        keys,
+        state_path: std::env::var("LUX_ENC_STATE_PATH").ok(),
+        seal_path: std::env::var("LUX_ENC_SEAL_PATH").ok(),
+        auto_init: std::env::var("LUX_ENC_AUTO_INIT").is_ok_and(|value| {
+            let value = value.to_ascii_lowercase();
+            value == "1" || value == "true"
+        }),
+        // Filled in by the caller from LUX_ENC_SEAL_KEY / _PREVIOUS.
+        seal_secret: None,
+        previous_seal_secrets: Vec::new(),
+    };
+    Ok(config)
 }
 
 fn managed_auth_email_from_env() -> Option<lux::AuthManagedEmailConfig> {
@@ -271,5 +430,58 @@ fn print_error_event(event: lux::ServerErrorEvent) {
         lux::ServerErrorEvent::HttpServerFailed { error } => {
             eprintln!("http server error: {error}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_seal_value, parse_encryption_keys_json};
+
+    #[test]
+    fn decode_seal_value_requires_base64_of_32_bytes() {
+        use base64::Engine as _;
+        let good = base64::engine::general_purpose::STANDARD.encode([7u8; 32]);
+        assert_eq!(decode_seal_value("X", &good).unwrap(), [7u8; 32]);
+
+        // Not base64.
+        assert!(decode_seal_value("X", "not base64!!").is_err());
+        // Base64 but wrong length (16 bytes).
+        let short = base64::engine::general_purpose::STANDARD.encode([1u8; 16]);
+        let err = decode_seal_value("X", &short).unwrap_err();
+        assert!(err.contains("32 bytes"), "{err}");
+    }
+
+    #[test]
+    fn encryption_keys_json_parses_rotation_network() {
+        let config = parse_encryption_keys_json(
+            r#"[
+                {"id":"k1","secret":"old","decryptOnly":true},
+                {"id":"k2","secret":"new"}
+            ]"#,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(config.active_key_id.as_deref(), Some("k2"));
+        assert_eq!(config.keys.len(), 2);
+        assert!(config.keys[0].decrypt_only);
+        assert!(!config.keys[1].decrypt_only);
+    }
+
+    #[test]
+    fn encryption_keys_json_fails_closed_on_bad_config() {
+        let err = parse_encryption_keys_json("not-json", None).unwrap_err();
+        assert!(err.contains("invalid LUX_ENCRYPTION_KEYS JSON"), "{err}");
+
+        let err = parse_encryption_keys_json(r#"{"id":"k1"}"#, None).unwrap_err();
+        assert!(err.contains("must be a JSON array"), "{err}");
+
+        let err = parse_encryption_keys_json(r#"[{"id":"k1"}]"#, None).unwrap_err();
+        assert!(err.contains("secret must be a non-empty string"), "{err}");
+
+        let err =
+            parse_encryption_keys_json(r#"[{"id":"k1","secret":"old","decryptOnly":true}]"#, None)
+                .unwrap_err();
+        assert!(err.contains("at least one writable key"), "{err}");
     }
 }

--- a/src/shard_exec.rs
+++ b/src/shard_exec.rs
@@ -278,11 +278,17 @@ impl ShardExecutor {
             .all(|command| command.args.len() == 2 && command.args[0].eq_ignore_ascii_case(b"GET"))
         {
             for command in commands {
-                Store::get_and_write(&shard.data, command.args[1], now, out);
+                self.store
+                    .get_kv_and_write_from_shard(&shard.data, command.args[1], now, out);
             }
         } else {
             for command in commands {
-                cmd::execute_on_shard_read(&shard.data, command.args, out, now);
+                if command.args.len() == 2 && command.args[0].eq_ignore_ascii_case(b"GET") {
+                    self.store
+                        .get_kv_and_write_from_shard(&shard.data, command.args[1], now, out);
+                } else {
+                    cmd::execute_on_shard_read(&shard.data, command.args, out, now);
+                }
             }
         }
     }
@@ -305,11 +311,18 @@ impl ShardExecutor {
             args.len() == 2 && args[0].eq_ignore_ascii_case(b"GET")
         }) {
             for command in commands {
-                Store::get_and_write(&shard.data, command.argv()[1], now, out);
+                self.store
+                    .get_kv_and_write_from_shard(&shard.data, command.argv()[1], now, out);
             }
         } else {
             for command in commands {
-                cmd::execute_on_shard_read(&shard.data, command.argv(), out, now);
+                let args = command.argv();
+                if args.len() == 2 && args[0].eq_ignore_ascii_case(b"GET") {
+                    self.store
+                        .get_kv_and_write_from_shard(&shard.data, args[1], now, out);
+                } else {
+                    cmd::execute_on_shard_read(&shard.data, args, out, now);
+                }
             }
         }
     }
@@ -318,6 +331,7 @@ impl ShardExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::store::SetOptions;
     use std::sync::Arc;
 
     #[test]
@@ -369,6 +383,49 @@ mod tests {
 
         assert_eq!(before, store.shard_version(shard_idx));
         assert_eq!(&out[..], b"$-1\r\n");
+    }
+
+    #[test]
+    fn read_batch_get_decrypts_encrypted_strings() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(Store::new_with_config(Arc::new(crate::ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            ..Default::default()
+        })));
+        store.encryption().init(Some("k1")).unwrap();
+        let now = Instant::now();
+        store
+            .set_conditional(
+                b"secret",
+                b"abcdef",
+                SetOptions {
+                    ttl: None,
+                    keep_ttl: false,
+                    nx: false,
+                    xx: false,
+                    ifeq: None,
+                    get: false,
+                    encrypted: true,
+                },
+                now,
+            )
+            .unwrap();
+
+        let broker = Broker::new();
+        let executor = ShardExecutor::new(store.clone(), broker);
+        let shard_idx = store.shard_for_key(b"secret");
+        let get: [&[u8]; 2] = [b"GET", b"secret"];
+        let commands = [ShardPipelineCommand {
+            args: &get,
+            access: PipelineAccess::Read,
+        }];
+        let mut out = BytesMut::new();
+
+        executor
+            .execute_pipeline_batch(shard_idx, &commands, &mut out, now)
+            .unwrap();
+
+        assert_eq!(&out[..], b"$6\r\nabcdef\r\n");
     }
 
     #[test]

--- a/src/store/hashes.rs
+++ b/src/store/hashes.rs
@@ -1,11 +1,81 @@
 use super::*;
 
+/// `(fields_added, stored_pairs)` where each stored pair is the on-disk
+/// `(field, value)` bytes (value is ciphertext when the column is encrypted).
+type HsetKvOutcome = (i64, Vec<(Vec<u8>, Vec<u8>)>);
+
 impl Store {
     pub fn hset(&self, key: &[u8], pairs: &[(&[u8], &[u8])], now: Instant) -> Result<i64, String> {
         let idx = self.shard_index(key);
         let mut shard = self.shards[idx].write();
         shard.version += 1;
         self.hset_on_shard(&mut shard, key, pairs, now)
+    }
+
+    pub(crate) fn hset_kv(
+        &self,
+        key: &[u8],
+        pairs: &[(&[u8], &[u8])],
+        encrypted: bool,
+        now: Instant,
+    ) -> Result<HsetKvOutcome, String> {
+        let idx = self.shard_index(key);
+        let mut shard = self.shards[idx].write();
+        shard.version += 1;
+        let ks = key_bytes(key);
+        let entry = match shard.data.entry(ks) {
+            hashbrown::hash_map::Entry::Occupied(o) => o.into_mut(),
+            hashbrown::hash_map::Entry::Vacant(v) => {
+                self.key_added();
+                v.insert(Entry {
+                    value: StoreValue::Hash(HashMap::new()),
+                    expires_at: None,
+                    lru_clock: self.lru_clock(),
+                })
+            }
+        };
+        if entry.is_expired_at(now) {
+            entry.value = StoreValue::Hash(HashMap::new());
+            entry.expires_at = None;
+        }
+        match &mut entry.value {
+            StoreValue::Hash(map) => {
+                let mut added = 0i64;
+                let mut mem_delta: isize = 0;
+                let mut stored_pairs = Vec::with_capacity(pairs.len());
+                for (field, value) in pairs {
+                    let field_name = key_string(field);
+                    let existing_encrypted = map.get(&field_name).is_some_and(|raw| {
+                        crate::encryption::EncryptionKeyring::is_encrypted_value(raw)
+                    });
+                    let stored_value = if encrypted || existing_encrypted {
+                        self.encrypt_hash_field_value(key, field, value)?
+                    } else {
+                        value.to_vec()
+                    };
+                    let new_size = (field.len() + stored_value.len() + 64) as isize;
+                    if let Some(old_val) =
+                        map.insert(field_name, Bytes::copy_from_slice(&stored_value))
+                    {
+                        mem_delta += stored_value.len() as isize - old_val.len() as isize;
+                    } else {
+                        added += 1;
+                        mem_delta += new_size;
+                    }
+                    stored_pairs.push((field.to_vec(), stored_value));
+                }
+                if mem_delta > 0 {
+                    shard.used_memory += mem_delta as usize;
+                    self.mem_add(mem_delta as usize);
+                } else if mem_delta < 0 {
+                    let freed = (-mem_delta) as usize;
+                    shard.used_memory = shard.used_memory.saturating_sub(freed);
+                    self.mem_sub(freed);
+                }
+                Ok((added, stored_pairs))
+            }
+            _ => Err(WRONGTYPE.to_string()),
+        }
     }
 
     /// HSET variant for callers that already hold the correct shard write lock.
@@ -67,7 +137,13 @@ impl Store {
         let shard = self.shards[idx].read();
         match shard.data.get(key) {
             Some(entry) if !entry.is_expired_at(now) => match &entry.value {
-                StoreValue::Hash(map) => map.get(key_str(field)).cloned(),
+                StoreValue::Hash(map) => map
+                    .get(key_str(field))
+                    .cloned()
+                    .map(|value| self.decrypt_hash_field_value(key, field, value))
+                    .transpose()
+                    .ok()
+                    .flatten(),
                 _ => None,
             },
             _ => None,
@@ -96,7 +172,11 @@ impl Store {
             Some(entry) if !entry.is_expired_at(now) => match &entry.value {
                 StoreValue::Hash(map) => fields
                     .iter()
-                    .map(|f| map.get(key_str(f)).cloned())
+                    .map(|f| {
+                        map.get(key_str(f))
+                            .cloned()
+                            .and_then(|value| self.decrypt_hash_field_value(key, f, value).ok())
+                    })
                     .collect(),
                 _ => fields.iter().map(|_| None).collect(),
             },
@@ -134,9 +214,13 @@ impl Store {
         let shard = self.shards[idx].read();
         match shard.data.get(key) {
             Some(entry) if !entry.is_expired_at(now) => match &entry.value {
-                StoreValue::Hash(map) => {
-                    Ok(map.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
-                }
+                StoreValue::Hash(map) => map
+                    .iter()
+                    .map(|(k, v)| {
+                        self.decrypt_hash_field_value(key, k.as_bytes(), v.clone())
+                            .map(|value| (k.clone(), value))
+                    })
+                    .collect(),
                 _ => Err(WRONGTYPE.to_string()),
             },
             _ => Ok(vec![]),
@@ -160,7 +244,10 @@ impl Store {
         let shard = self.shards[idx].read();
         match shard.data.get(key) {
             Some(entry) if !entry.is_expired_at(now) => match &entry.value {
-                StoreValue::Hash(map) => Ok(map.values().cloned().collect()),
+                StoreValue::Hash(map) => map
+                    .iter()
+                    .map(|(k, v)| self.decrypt_hash_field_value(key, k.as_bytes(), v.clone()))
+                    .collect(),
                 _ => Err(WRONGTYPE.to_string()),
             },
             _ => Ok(vec![]),

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -76,6 +76,7 @@ pub struct SetOptions<'a> {
     pub xx: bool,
     pub ifeq: Option<&'a [u8]>,
     pub get: bool,
+    pub encrypted: bool,
 }
 
 #[derive(Clone, Default)]
@@ -305,6 +306,7 @@ impl StoreMetrics {
 
 pub struct Store {
     config: Arc<crate::ServerConfig>,
+    encryption: crate::encryption::EncryptionKeyring,
     shards: Box<[RwLock<Shard>]>,
     metrics: StoreMetrics,
     /// Serializes Lua script execution for this runtime without blocking other
@@ -359,12 +361,29 @@ fn parse_table_vector_key(key: &str) -> Option<(&str, &str, &str)> {
     Some((table, field, pk))
 }
 
+fn parse_table_row_key(key: &str) -> Option<(&str, &str)> {
+    let rest = key.strip_prefix("_t:")?;
+    let (table, pk) = rest.split_once(":row:")?;
+    if table.is_empty() || pk.is_empty() {
+        return None;
+    }
+    Some((table, pk))
+}
+
 fn table_vector_index_name(table: &str, field: &str) -> String {
     format!("{}.{}", table, field)
 }
 
 fn table_vector_key_for_pk(table: &str, field: &str, pk: &str) -> String {
     format!("_t:{}:vec:{}:{}", table, field, pk)
+}
+
+fn encrypted_value_would_be_orphaned(value: &[u8], remaining_key_ids: &HashSet<String>) -> bool {
+    crate::encryption::EncryptionKeyring::is_encrypted_value(value)
+        && !crate::encryption::EncryptionKeyring::envelope_decryptable_by_any(
+            value,
+            remaining_key_ids,
+        )
 }
 
 pub(crate) struct TableVectorCandidateQuery<'a> {
@@ -467,6 +486,9 @@ impl Store {
     }
 
     pub fn new_with_config(config: Arc<crate::ServerConfig>) -> Self {
+        let encryption =
+            crate::encryption::EncryptionKeyring::open(&config.encryption, &config.data_dir)
+                .unwrap_or_else(|e| panic!("invalid encryption config: {e}"));
         let n = config.shards;
         let shards: Vec<RwLock<Shard>> = (0..n)
             .map(|_| {
@@ -506,6 +528,7 @@ impl Store {
 
         Self {
             config,
+            encryption,
             shards: shards.into_boxed_slice(),
             metrics: StoreMetrics::new(),
             script_gate: RwLock::new(()),
@@ -519,6 +542,134 @@ impl Store {
 
     pub fn config(&self) -> &crate::ServerConfig {
         &self.config
+    }
+
+    pub(crate) fn encryption(&self) -> &crate::encryption::EncryptionKeyring {
+        &self.encryption
+    }
+
+    pub(crate) fn enc_rewrap_all(&self) -> Result<usize, String> {
+        let mut count = 0usize;
+        for idx in 0..self.shards.len() {
+            let mut shard = self.shards[idx].write();
+            let mut shard_changed = false;
+            let mut mem_delta: isize = 0;
+            let mut disk_remove = Vec::new();
+            for (key, entry) in shard.data.iter_mut() {
+                if entry.is_expired_at(Instant::now()) {
+                    continue;
+                }
+                match &mut entry.value {
+                    StoreValue::Str(value) => {
+                        if crate::encryption::EncryptionKeyring::is_encrypted_value(value) {
+                            let key_name = key_string(key);
+                            let new_value = self
+                                .encryption()
+                                .reencrypt("__lux_kv", "value", &key_name, value)?;
+                            mem_delta += new_value.len() as isize - value.len() as isize;
+                            *value = Bytes::from(new_value);
+                            count += 1;
+                            shard_changed = true;
+                            disk_remove.push(key.clone());
+                        }
+                    }
+                    StoreValue::StrBuf(value) => {
+                        if crate::encryption::EncryptionKeyring::is_encrypted_value(value) {
+                            let key_name = key_string(key);
+                            let new_value = self
+                                .encryption()
+                                .reencrypt("__lux_kv", "value", &key_name, value)?;
+                            mem_delta += new_value.len() as isize - value.len() as isize;
+                            *value = new_value;
+                            count += 1;
+                            shard_changed = true;
+                            disk_remove.push(key.clone());
+                        }
+                    }
+                    StoreValue::Hash(map) => {
+                        let key_name = key_string(key);
+                        let table_row = parse_table_row_key(&key_name)
+                            .map(|(table, pk)| (table.to_string(), pk.to_string()));
+                        for (field, value) in map.iter_mut() {
+                            if !crate::encryption::EncryptionKeyring::is_encrypted_value(value) {
+                                continue;
+                            }
+                            let new_value = if let Some((table, pk)) = &table_row {
+                                self.encryption().reencrypt(table, field, pk, value)?
+                            } else {
+                                self.encryption().reencrypt(
+                                    "__lux_hash",
+                                    field,
+                                    &key_name,
+                                    value,
+                                )?
+                            };
+                            mem_delta += new_value.len() as isize - value.len() as isize;
+                            *value = Bytes::from(new_value);
+                            count += 1;
+                            shard_changed = true;
+                            disk_remove.push(key.clone());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if shard_changed {
+                shard.version += 1;
+                if mem_delta > 0 {
+                    shard.used_memory += mem_delta as usize;
+                    self.mem_add(mem_delta as usize);
+                } else if mem_delta < 0 {
+                    let freed = (-mem_delta) as usize;
+                    shard.used_memory = shard.used_memory.saturating_sub(freed);
+                    self.mem_sub(freed);
+                }
+            }
+            drop(shard);
+            for key in disk_remove {
+                self.remove_from_disk(&key);
+            }
+        }
+        Ok(count)
+    }
+
+    pub(crate) fn enc_retire_key(&self, key_id: &str) -> Result<(), String> {
+        let remaining = self.encryption().remaining_key_ids_without(key_id);
+        if remaining.is_empty() {
+            return Err("ERR ENC cannot retire the last key".to_string());
+        }
+        for shard in self.shards.iter() {
+            let shard = shard.read();
+            for entry in shard.data.values() {
+                match &entry.value {
+                    StoreValue::Str(value) => {
+                        if encrypted_value_would_be_orphaned(value, &remaining) {
+                            return Err(
+                                "ERR ENC key is still required by encrypted data".to_string()
+                            );
+                        }
+                    }
+                    StoreValue::StrBuf(value) => {
+                        if encrypted_value_would_be_orphaned(value, &remaining) {
+                            return Err(
+                                "ERR ENC key is still required by encrypted data".to_string()
+                            );
+                        }
+                    }
+                    StoreValue::Hash(map) => {
+                        for value in map.values() {
+                            if encrypted_value_would_be_orphaned(value, &remaining) {
+                                return Err(
+                                    "ERR ENC key is still required by encrypted data".to_string()
+                                );
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        self.encryption().retire(key_id)
     }
 
     fn insert_vector_indexes(&self, key: String, dims: u32, data: Vec<f32>) {
@@ -1103,6 +1254,119 @@ impl Store {
     }
 
     #[inline(always)]
+    fn user_kv_key(key: &[u8]) -> String {
+        key_string(key)
+    }
+
+    #[inline(always)]
+    fn user_hash_field(field: &[u8]) -> String {
+        key_string(field)
+    }
+
+    #[inline(always)]
+    fn is_table_storage_key(key: &[u8]) -> bool {
+        key.starts_with(b"_t:")
+    }
+
+    pub(crate) fn decrypt_kv_string_value(
+        &self,
+        key: &[u8],
+        value: Bytes,
+    ) -> Result<Bytes, String> {
+        if !crate::encryption::EncryptionKeyring::is_encrypted_value(&value) {
+            return Ok(value);
+        }
+        let key_name = Self::user_kv_key(key);
+        self.encryption()
+            .decrypt("__lux_kv", "value", &key_name, &value)
+            .map(Bytes::from)
+    }
+
+    fn encrypt_kv_string_value(&self, key: &[u8], value: &[u8]) -> Result<Vec<u8>, String> {
+        let key_name = Self::user_kv_key(key);
+        self.encryption()
+            .encrypt("__lux_kv", "value", &key_name, value)
+    }
+
+    pub(crate) fn decrypt_hash_field_value(
+        &self,
+        key: &[u8],
+        field: &[u8],
+        value: Bytes,
+    ) -> Result<Bytes, String> {
+        if Self::is_table_storage_key(key)
+            || !crate::encryption::EncryptionKeyring::is_encrypted_value(&value)
+        {
+            return Ok(value);
+        }
+        let key_name = Self::user_kv_key(key);
+        let field_name = Self::user_hash_field(field);
+        self.encryption()
+            .decrypt("__lux_hash", &field_name, &key_name, &value)
+            .map(Bytes::from)
+    }
+
+    fn encrypt_hash_field_value(
+        &self,
+        key: &[u8],
+        field: &[u8],
+        value: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        let key_name = Self::user_kv_key(key);
+        let field_name = Self::user_hash_field(field);
+        self.encryption()
+            .encrypt("__lux_hash", &field_name, &key_name, value)
+    }
+
+    pub(crate) fn kv_string_is_encrypted(&self, key: &[u8], now: Instant) -> bool {
+        let idx = self.shard_index(key);
+        let shard = self.shards[idx].read();
+        Self::get_from_shard(&shard.data, key, now)
+            .as_ref()
+            .is_some_and(|value| crate::encryption::EncryptionKeyring::is_encrypted_value(value))
+    }
+
+    pub(crate) fn hash_fields_need_encryption(
+        &self,
+        key: &[u8],
+        fields: &[&[u8]],
+        now: Instant,
+    ) -> bool {
+        if Self::is_table_storage_key(key) {
+            return false;
+        }
+        let idx = self.shard_index(key);
+        let shard = self.shards[idx].read();
+        let Some(entry) = shard
+            .data
+            .get(key)
+            .filter(|entry| !entry.is_expired_at(now))
+        else {
+            return false;
+        };
+        let StoreValue::Hash(map) = &entry.value else {
+            return false;
+        };
+        fields.iter().any(|field| {
+            map.get(key_str(field)).is_some_and(|value| {
+                crate::encryption::EncryptionKeyring::is_encrypted_value(value)
+            })
+        })
+    }
+
+    pub(crate) fn get_raw_string(&self, key: &[u8], now: Instant) -> Option<Bytes> {
+        let idx = self.shard_index(key);
+        let shard = self.shards[idx].read();
+        Self::get_from_shard(&shard.data, key, now)
+    }
+
+    pub(crate) fn get_kv_string(&self, key: &[u8], now: Instant) -> Result<Option<Bytes>, String> {
+        self.get_raw_string(key, now)
+            .map(|value| self.decrypt_kv_string_value(key, value))
+            .transpose()
+    }
+
+    #[inline(always)]
     #[allow(dead_code)]
     pub(crate) fn get_and_write(
         data: &ShardData,
@@ -1114,6 +1378,29 @@ impl Store {
             Some(entry) if !entry.is_expired_at(now) => {
                 if let Some(s) = entry.value.string_bytes() {
                     crate::resp::write_bulk_raw(out, s);
+                } else {
+                    crate::resp::write_null(out);
+                }
+            }
+            _ => crate::resp::write_null(out),
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn get_kv_and_write_from_shard(
+        &self,
+        data: &ShardData,
+        key: &[u8],
+        now: Instant,
+        out: &mut bytes::BytesMut,
+    ) {
+        match data.get(key) {
+            Some(entry) if !entry.is_expired_at(now) => {
+                if let Some(s) = entry.value.string_to_bytes() {
+                    match self.decrypt_kv_string_value(key, s) {
+                        Ok(value) => crate::resp::write_bulk_raw(out, &value),
+                        Err(err) => crate::resp::write_error(out, &err),
+                    }
                 } else {
                     crate::resp::write_null(out);
                 }
@@ -1327,6 +1614,7 @@ impl Store {
         let mut exists = false;
         let mut old = None;
         let mut old_expires_at = None;
+        let mut existing_encrypted = false;
         let mut ifeq_matches = options.ifeq.is_none();
         if let Some(entry) = shard
             .data
@@ -1335,19 +1623,23 @@ impl Store {
         {
             exists = true;
             old_expires_at = entry.expires_at;
+            existing_encrypted = entry
+                .value
+                .string_bytes()
+                .is_some_and(crate::encryption::EncryptionKeyring::is_encrypted_value);
             if options.get {
-                old = Some(
-                    entry
-                        .value
-                        .string_to_bytes()
-                        .ok_or_else(|| WRONGTYPE.to_string())?,
-                );
+                let raw = entry
+                    .value
+                    .string_to_bytes()
+                    .ok_or_else(|| WRONGTYPE.to_string())?;
+                old = Some(self.decrypt_kv_string_value(key, raw)?);
             }
             if let Some(expected) = options.ifeq {
-                let current = entry
+                let raw = entry
                     .value
-                    .string_bytes()
+                    .string_to_bytes()
                     .ok_or_else(|| WRONGTYPE.to_string())?;
+                let current = self.decrypt_kv_string_value(key, raw)?;
                 ifeq_matches = current == expected;
             }
         }
@@ -1363,7 +1655,12 @@ impl Store {
             } else {
                 options.ttl.map(|d| now + d)
             };
-            let new_value = StoreValue::Str(Bytes::copy_from_slice(value));
+            let stored_value = if options.encrypted || existing_encrypted {
+                self.encrypt_kv_string_value(key, value)?
+            } else {
+                value.to_vec()
+            };
+            let new_value = StoreValue::Str(Bytes::from(stored_value));
             let mem = estimate_entry_memory(key, &new_value);
             let old_entry = shard.data.insert(
                 key_bytes(key),

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -264,6 +264,8 @@ pub struct FieldDef {
     pub default_value: Option<String>, // DEFAULT value for the column
     pub sequence_partition: Option<String>, // SEQUENCE PARTITION BY <column>
     pub references: Option<ForeignKey>,
+    pub encrypted: bool,
+    pub searchable: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -605,6 +607,292 @@ fn ttl_wal_tokens(ttl: Option<TtlOp>) -> Option<(&'static [u8], Vec<u8>)> {
     }
 }
 
+fn schema_has_encrypted_fields(schema: &[FieldDef]) -> bool {
+    schema.iter().any(|field| field.encrypted)
+}
+
+fn log_raw_row_wal(store: &Store, table: &str, pk: &str, now: Instant) {
+    if !store.wal_enabled() {
+        return;
+    }
+    let rk = row_key_for_pk(table, pk);
+    let Ok(row) = store.hgetall(rk.as_bytes(), now) else {
+        return;
+    };
+    if row.is_empty() {
+        return;
+    }
+    let mut a: Vec<Vec<u8>> = Vec::with_capacity(row.len() * 2 + 3);
+    a.push(b"TROWSET".to_vec());
+    a.push(table.as_bytes().to_vec());
+    a.push(pk.as_bytes().to_vec());
+    for (field, value) in row {
+        a.push(field.into_bytes());
+        a.push(value.to_vec());
+    }
+    let refs: Vec<&[u8]> = a.iter().map(|v| v.as_slice()).collect();
+    let _ = store.wal_log_command(&refs);
+}
+
+pub(crate) fn table_apply_wal_row(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    table: &str,
+    pk_str: &str,
+    raw_pairs: &[(&[u8], &[u8])],
+    now: Instant,
+) -> Result<(), String> {
+    let schema = load_schema(store, cache, table, now)?;
+    let rk = row_key_for_pk(table, pk_str);
+
+    if let Some(old_row) = get_row_including_expired(store, table, &schema, pk_str, now) {
+        let old_map: std::collections::HashMap<String, String> = old_row.into_iter().collect();
+        for field in &schema {
+            if let Some(old_val) = old_map.get(&field.name) {
+                remove_from_index(store, table, field, old_val, pk_str, now);
+                if field.unique {
+                    remove_unique_entries(store, table, field, old_val, now);
+                }
+            }
+        }
+    }
+
+    let mut raw_map: std::collections::HashMap<String, Vec<u8>> = std::collections::HashMap::new();
+    for (field, value) in raw_pairs {
+        raw_map.insert(String::from_utf8_lossy(field).to_string(), value.to_vec());
+    }
+
+    let ikey = ids_key(table);
+    let score: f64 = store
+        .zscore(ikey.as_bytes(), pk_str.as_bytes(), now)
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| {
+            pk_str
+                .parse::<f64>()
+                .unwrap_or_else(|_| next_id(store, &format!("{}__order", table), now) as f64)
+        });
+    let _ = store.zadd(
+        ikey.as_bytes(),
+        &[(pk_str.as_bytes(), score)],
+        false,
+        false,
+        false,
+        false,
+        false,
+        now,
+    );
+
+    if let Some(pk_field) = schema.iter().find(|f| f.primary_key) {
+        if pk_field.field_type == FieldType::Int {
+            if let Ok(id) = pk_str.parse::<i64>() {
+                bump_seq_to_at_least(store, table, id, now);
+            }
+        }
+    } else if let Ok(id) = pk_str.parse::<i64>() {
+        bump_seq_to_at_least(store, table, id, now);
+    }
+
+    for field in &schema {
+        let Some(raw) = raw_map.get(&field.name) else {
+            continue;
+        };
+        let value = decode_stored_value(store, table, field, pk_str, raw)?;
+        add_to_index(store, table, field, &value, pk_str, now);
+        if field.unique {
+            let ukey = uniq_key(table, &field.name);
+            for index_value in searchable_index_values(store, table, field, &value)? {
+                store.hset(
+                    ukey.as_bytes(),
+                    &[(index_value.as_bytes() as &[u8], pk_str.as_bytes() as &[u8])],
+                    now,
+                )?;
+            }
+        }
+    }
+
+    for pi in &load_path_indexes(store, cache, table, now) {
+        if let Some((root, rest)) = pi.path.split_once('.') {
+            if let Some(root_field) = schema.iter().find(|f| f.name == root) {
+                if root_field.encrypted {
+                    continue;
+                }
+                if let Some(raw) = raw_map.get(root) {
+                    if let Ok(bytes) = stored_plain_bytes(store, table, root_field, pk_str, raw) {
+                        if let Some(scalar) =
+                            extract_json_scalar(&root_field.field_type.decode_value(&bytes), rest)
+                        {
+                            add_to_index(
+                                store,
+                                table,
+                                &synthetic_path_fielddef(pi),
+                                &scalar,
+                                pk_str,
+                                now,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(ttl_bytes) = raw_map.get(std::str::from_utf8(HIDDEN_TTL_FIELD).unwrap_or("")) {
+        if let Some(deadline_ms) = std::str::from_utf8(ttl_bytes)
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+        {
+            let member = ttl_member(table, pk_str);
+            let _ = store.zadd(
+                ttl_index_key().as_bytes(),
+                &[(member.as_bytes(), deadline_ms as f64)],
+                false,
+                false,
+                false,
+                false,
+                false,
+                now,
+            );
+        }
+    } else {
+        let member = ttl_member(table, pk_str);
+        let _ = store.zrem(ttl_index_key().as_bytes(), &[member.as_bytes()], now);
+        let _ = store.hdel(rk.as_bytes(), &[HIDDEN_TTL_FIELD], now);
+    }
+
+    let pair_refs: Vec<(&[u8], &[u8])> = raw_pairs.iter().map(|(k, v)| (*k, *v)).collect();
+    store.hset(rk.as_bytes(), &pair_refs, now)?;
+    Ok(())
+}
+
+fn field_supports_encryption(field: &FieldDef) -> Result<(), String> {
+    if field.searchable && !field.encrypted {
+        return Err(format!(
+            "ERR SEARCHABLE column '{}' must also be ENCRYPTED",
+            field.name
+        ));
+    }
+    if !field.encrypted {
+        return Ok(());
+    }
+    if field.primary_key {
+        return Err(format!(
+            "ERR encrypted column '{}' cannot be a PRIMARY KEY",
+            field.name
+        ));
+    }
+    if field.references.is_some() || matches!(field.field_type, FieldType::Ref(_)) {
+        return Err(format!(
+            "ERR encrypted column '{}' cannot be a foreign key",
+            field.name
+        ));
+    }
+    if field.sequence_partition.is_some() {
+        return Err(format!(
+            "ERR encrypted column '{}' cannot be a SEQUENCE column",
+            field.name
+        ));
+    }
+    if matches!(field.field_type, FieldType::Vector(_)) {
+        return Err(format!(
+            "ERR encrypted column '{}' cannot use VECTOR type",
+            field.name
+        ));
+    }
+    if field.default_value.is_some() {
+        return Err(format!(
+            "ERR encrypted column '{}' cannot use DEFAULT",
+            field.name
+        ));
+    }
+    if field.searchable && matches!(field.field_type, FieldType::Json | FieldType::Array) {
+        return Err(format!(
+            "ERR encrypted column '{}' cannot be SEARCHABLE with JSON or ARRAY type",
+            field.name
+        ));
+    }
+    if field.unique && field.encrypted && !field.searchable {
+        return Err(format!(
+            "ERR UNIQUE encrypted column '{}' must be SEARCHABLE",
+            field.name
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_encryption_ready(store: &Store, fields: &[FieldDef]) -> Result<(), String> {
+    if fields.iter().any(|f| f.encrypted) && !store.encryption().has_active_key() {
+        return Err(
+            "ERR encrypted columns require ENC INIT or an active encryption key".to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn encode_stored_value(
+    store: &Store,
+    table: &str,
+    field: &FieldDef,
+    pk: &str,
+    value: &str,
+) -> Result<Vec<u8>, String> {
+    let encoded = field.field_type.encode_value(value)?;
+    if field.encrypted {
+        store
+            .encryption()
+            .encrypt(table, &field.name, pk, encoded.as_slice())
+    } else {
+        Ok(encoded)
+    }
+}
+
+pub(crate) fn decode_stored_value(
+    store: &Store,
+    table: &str,
+    field: &FieldDef,
+    pk: &str,
+    raw: &[u8],
+) -> Result<String, String> {
+    let bytes = stored_plain_bytes(store, table, field, pk, raw)?;
+    Ok(field.field_type.decode_value(&bytes))
+}
+
+pub(crate) fn stored_plain_bytes(
+    store: &Store,
+    table: &str,
+    field: &FieldDef,
+    pk: &str,
+    raw: &[u8],
+) -> Result<Vec<u8>, String> {
+    if field.encrypted {
+        store.encryption().decrypt(table, &field.name, pk, raw)
+    } else {
+        Ok(raw.to_vec())
+    }
+}
+
+fn searchable_index_values(
+    store: &Store,
+    table: &str,
+    field: &FieldDef,
+    value: &str,
+) -> Result<Vec<String>, String> {
+    if field.encrypted {
+        if !field.searchable {
+            return Err(format!(
+                "ERR encrypted column '{}' is not SEARCHABLE",
+                field.name
+            ));
+        }
+        let encoded = field.field_type.encode_value(value)?;
+        store
+            .encryption()
+            .blind_indexes(table, &field.name, encoded.as_slice())
+    } else {
+        Ok(vec![value.to_string()])
+    }
+}
+
 /// Read-validate a unique-index hit: does the holder row actually still carry
 /// `value` in `field`? A stale entry (row gone or value changed without the index
 /// being updated) returns false, so the uniqueness check treats it as free.
@@ -618,14 +906,44 @@ fn uniq_holder_holds_value(
 ) -> bool {
     let rk = row_key_for_pk(table, holder_pk);
     match store.hget(rk.as_bytes(), field.name.as_bytes(), now) {
-        // Compare in the stored (encoded) form so the match is exact.
-        Some(raw) => field
-            .field_type
-            .encode_value(value)
-            .map(|enc| enc == raw)
+        Some(raw) => decode_stored_value(store, table, field, holder_pk, &raw)
+            .map(|stored| stored == value)
             .unwrap_or(false),
         None => false,
     }
+}
+
+fn remove_unique_entries(store: &Store, table: &str, field: &FieldDef, value: &str, now: Instant) {
+    let ukey = uniq_key(table, &field.name);
+    match searchable_index_values(store, table, field, value) {
+        Ok(index_values) => {
+            for index_value in index_values {
+                let _ = store.hdel(ukey.as_bytes(), &[index_value.as_bytes()], now);
+            }
+        }
+        Err(_) => {
+            let _ = store.hdel(ukey.as_bytes(), &[value.as_bytes()], now);
+        }
+    }
+}
+
+fn unique_holder_for_value(
+    store: &Store,
+    table: &str,
+    field: &FieldDef,
+    value: &str,
+    now: Instant,
+) -> Result<Option<String>, String> {
+    if !field.unique {
+        return Ok(None);
+    }
+    let ukey = uniq_key(table, &field.name);
+    for index_value in searchable_index_values(store, table, field, value)? {
+        if let Some(holder) = store.hget(ukey.as_bytes(), index_value.as_bytes(), now) {
+            return Ok(Some(String::from_utf8_lossy(&holder).to_string()));
+        }
+    }
+    Ok(None)
 }
 
 /// Register a new row's TTL deadline in the global `_t:_ttl` index and return the
@@ -850,10 +1168,20 @@ fn parse_field_def(spec: &str) -> Result<FieldDef, String> {
     let mut default_value: Option<String> = None;
     let mut sequence_partition: Option<String> = None;
     let mut references: Option<ForeignKey> = None;
+    let mut encrypted = false;
+    let mut searchable = false;
 
     let mut i = 2;
     while i < tokens.len() {
         match tokens[i].to_uppercase().as_str() {
+            "ENCRYPTED" => {
+                encrypted = true;
+                i += 1;
+            }
+            "SEARCHABLE" => {
+                searchable = true;
+                i += 1;
+            }
             "DEFAULT" => {
                 i += 1;
                 if i >= tokens.len() {
@@ -966,7 +1294,7 @@ fn parse_field_def(spec: &str) -> Result<FieldDef, String> {
         }
     }
 
-    Ok(FieldDef {
+    let field = FieldDef {
         name,
         field_type,
         primary_key,
@@ -975,7 +1303,11 @@ fn parse_field_def(spec: &str) -> Result<FieldDef, String> {
         default_value,
         sequence_partition,
         references,
-    })
+        encrypted,
+        searchable,
+    };
+    field_supports_encryption(&field)?;
+    Ok(field)
 }
 
 /// Parse "table(column)" or "table( column )" into (table, column)
@@ -1092,6 +1424,12 @@ fn encode_field_def(def: &FieldDef) -> String {
     if let Some(partition) = &def.sequence_partition {
         parts.push(format!("seqpart:{}", partition));
     }
+    if def.encrypted {
+        parts.push("encrypted".to_string());
+    }
+    if def.searchable {
+        parts.push("searchable".to_string());
+    }
     parts.join("|")
 }
 
@@ -1123,6 +1461,8 @@ fn decode_field_def(name: &str, encoded: &str) -> FieldDef {
     let mut default_value: Option<String> = None;
     let mut sequence_partition: Option<String> = None;
     let mut references: Option<ForeignKey> = None;
+    let mut encrypted = false;
+    let mut searchable = false;
 
     for flag in &parts[1..] {
         match *flag {
@@ -1156,6 +1496,8 @@ fn decode_field_def(name: &str, encoded: &str) -> FieldDef {
             s if s.starts_with("seqpart:") => {
                 sequence_partition = Some(s[8..].to_string());
             }
+            "encrypted" => encrypted = true,
+            "searchable" => searchable = true,
             _ => {}
         }
     }
@@ -1169,6 +1511,8 @@ fn decode_field_def(name: &str, encoded: &str) -> FieldDef {
         default_value,
         sequence_partition,
         references,
+        encrypted,
+        searchable,
     }
 }
 
@@ -1251,6 +1595,8 @@ fn synthetic_path_fielddef(pi: &PathIndex) -> FieldDef {
         default_value: None,
         sequence_partition: None,
         references: None,
+        encrypted: false,
+        searchable: false,
     }
 }
 
@@ -1336,11 +1682,15 @@ pub fn table_create_path_index(
     if rest.is_empty() {
         return Err("ERR index path must address a value inside the JSON column".to_string());
     }
-    if !schema
+    let root_field = schema
         .iter()
-        .any(|f| f.name == root && f.field_type == FieldType::Json)
-    {
-        return Err(format!("ERR '{}' is not a JSON column", root));
+        .find(|f| f.name == root && f.field_type == FieldType::Json)
+        .ok_or_else(|| format!("ERR '{}' is not a JSON column", root))?;
+    if root_field.encrypted {
+        return Err(format!(
+            "ERR cannot create path index on encrypted column '{}'",
+            root
+        ));
     }
     let field_type = parse_index_type(type_token).ok_or_else(|| {
         format!(
@@ -1622,6 +1972,18 @@ fn add_to_index(
     pk_str: &str,
     now: Instant,
 ) {
+    if field.encrypted {
+        if !field.searchable {
+            return;
+        }
+        if let Ok(index_values) = searchable_index_values(store, table, field, value) {
+            for index_value in index_values {
+                let skey = idx_str_key(table, &field.name, &index_value);
+                let _ = store.sadd(skey.as_bytes(), &[pk_str.as_bytes()], now);
+            }
+        }
+        return;
+    }
     match &field.field_type {
         FieldType::Int
         | FieldType::Float
@@ -1672,6 +2034,18 @@ fn remove_from_index(
     pk_str: &str,
     now: Instant,
 ) {
+    if field.encrypted {
+        if !field.searchable {
+            return;
+        }
+        if let Ok(index_values) = searchable_index_values(store, table, field, value) {
+            for index_value in index_values {
+                let skey = idx_str_key(table, &field.name, &index_value);
+                let _ = store.srem(skey.as_bytes(), &[pk_str.as_bytes()], now);
+            }
+        }
+        return;
+    }
     match &field.field_type {
         FieldType::Int
         | FieldType::Float
@@ -1721,6 +2095,7 @@ pub fn table_create(
     // `... WITH TTL <secs>` gives every row in the table a default expiry.
     let (col_args, default_ttl) = split_with_ttl(col_args);
     let fields = parse_column_list(col_args)?;
+    ensure_encryption_ready(store, &fields)?;
 
     // Validate that referenced tables exist
     for field in &fields {
@@ -1972,6 +2347,16 @@ pub fn table_upsert_returning_ttl(
         };
         conflict_values.push((conflict.as_str(), cval));
     }
+    for (conflict, _) in &conflict_values {
+        if let Some(field) = schema.iter().find(|f| f.name == *conflict) {
+            if field.encrypted && !field.searchable {
+                return Err(format!(
+                    "ERR encrypted column '{}' must be SEARCHABLE for upsert conflict matching",
+                    field.name
+                ));
+            }
+        }
+    }
 
     let existing_pk: Option<String> = if conflicts.len() == 1 {
         let conflict = conflicts[0].as_str();
@@ -1988,13 +2373,21 @@ pub fn table_upsert_returning_ttl(
         } else {
             // Match via the unique index when present; otherwise scan rows for
             // compatibility with unconstrained conflict targets.
-            let ukey = uniq_key(table, conflict);
-            match store
-                .hget(ukey.as_bytes(), cval.as_bytes(), now)
-                .map(|b| String::from_utf8_lossy(&b).to_string())
+            let conflict_field = schema.iter().find(|f| f.name == conflict);
+            match conflict_field
+                .filter(|f| f.unique)
+                .map(|field| unique_holder_for_value(store, table, field, cval, now))
+                .transpose()?
+                .flatten()
             {
                 Some(pk) if !purge_if_expired(store, cache, table, &pk, now) => Some(pk),
-                _ => find_row_by_fields(store, table, &schema, &[(conflict, cval)], now),
+                Some(_) => {
+                    if let Some(field) = conflict_field {
+                        remove_unique_entries(store, table, field, cval, now);
+                    }
+                    find_row_by_fields(store, table, &schema, &[(conflict, cval)], now)
+                }
+                None => find_row_by_fields(store, table, &schema, &[(conflict, cval)], now),
             }
         }
     } else {
@@ -2185,18 +2578,22 @@ fn table_insert_pk(
         // and the insert is allowed -- never a false "duplicate".
         if field.unique {
             let ukey = uniq_key(table, &field.name);
-            if let Some(holder) = store.hget(ukey.as_bytes(), value.as_bytes(), now) {
-                let holder_pk = String::from_utf8_lossy(&holder).to_string();
-                let absent = purge_if_expired(store, cache, table, &holder_pk, now);
-                if !absent && uniq_holder_holds_value(store, table, field, &holder_pk, value, now) {
-                    return Err(format!(
-                        "ERR unique constraint violation on column '{}': value '{}' already exists",
-                        field.name, value
-                    ));
+            for index_value in searchable_index_values(store, table, field, value)? {
+                if let Some(holder) = store.hget(ukey.as_bytes(), index_value.as_bytes(), now) {
+                    let holder_pk = String::from_utf8_lossy(&holder).to_string();
+                    let absent = purge_if_expired(store, cache, table, &holder_pk, now);
+                    if !absent
+                        && uniq_holder_holds_value(store, table, field, &holder_pk, value, now)
+                    {
+                        return Err(format!(
+                            "ERR unique constraint violation on column '{}': value '{}' already exists",
+                            field.name, value
+                        ));
+                    }
+                    // Stale entry -> drop it so it doesn't block this (valid) insert,
+                    // which writes the fresh holder below.
+                    let _ = store.hdel(ukey.as_bytes(), &[index_value.as_bytes()], now);
                 }
-                // Stale entry -> drop it so it doesn't block this (valid) insert,
-                // which writes the fresh holder below.
-                let _ = store.hdel(ukey.as_bytes(), &[value.as_bytes()], now);
             }
         }
 
@@ -2291,12 +2688,12 @@ fn table_insert_pk(
 
     for field in &schema {
         if let Some(value) = provided.get(field.name.as_str()) {
-            let encoded = field.field_type.encode_value(value)?;
+            let encoded = encode_stored_value(store, table, field, &pk_str, value)?;
             pairs_owned.push((field.name.clone(), encoded));
         } else if field.primary_key {
             // Explicit PK that was auto-generated (INT auto-increment or UUIDv7).
             // Encode with the PK column's own type, not a hardcoded INT.
-            let encoded = field.field_type.encode_value(&pk_str)?;
+            let encoded = encode_stored_value(store, table, field, &pk_str, &pk_str)?;
             pairs_owned.push((field.name.clone(), encoded));
         }
     }
@@ -2333,11 +2730,13 @@ fn table_insert_pk(
 
             if field.unique {
                 let ukey = uniq_key(table, &field.name);
-                store.hset(
-                    ukey.as_bytes(),
-                    &[(value.as_bytes() as &[u8], pk_str.as_bytes() as &[u8])],
-                    now,
-                )?;
+                for index_value in searchable_index_values(store, table, field, value)? {
+                    store.hset(
+                        ukey.as_bytes(),
+                        &[(index_value.as_bytes() as &[u8], pk_str.as_bytes() as &[u8])],
+                        now,
+                    )?;
+                }
             }
         }
     }
@@ -2345,6 +2744,9 @@ fn table_insert_pk(
     // Declared JSON path indexes (cached empty for un-indexed tables => cheap).
     for pi in &load_path_indexes(store, cache, table, now) {
         if let Some((root, rest)) = pi.path.split_once('.') {
+            if schema.iter().any(|f| f.name == root && f.encrypted) {
+                continue;
+            }
             if let Some(raw) = provided.get(root).copied() {
                 if let Some(scalar) = extract_json_scalar(raw, rest) {
                     add_to_index(
@@ -2378,7 +2780,9 @@ fn table_insert_pk(
 
     // WAL: log the RESOLVED insert (explicit PK + the resolved column values that
     // were actually stored) so crash replay reproduces this exact row.
-    if store.wal_enabled() {
+    if store.wal_enabled() && schema_has_encrypted_fields(&schema) {
+        log_raw_row_wal(store, table, &pk_str, now);
+    } else if store.wal_enabled() {
         let mut a: Vec<Vec<u8>> = Vec::with_capacity(provided.len() * 2 + 6);
         a.push(b"TINSERT".to_vec());
         a.push(table.as_bytes().to_vec());
@@ -2481,14 +2885,18 @@ fn table_update_by_pk_str(
         }
 
         if field.unique {
-            let ukey = uniq_key(table, &field.name);
-            if let Some(existing_pk_bytes) = store.hget(ukey.as_bytes(), fval.as_bytes(), now) {
-                let existing_pk = String::from_utf8_lossy(&existing_pk_bytes).to_string();
+            if let Some(existing_pk) = unique_holder_for_value(store, table, field, fval, now)? {
                 if existing_pk != pk_str {
-                    return Err(format!(
-                        "ERR unique constraint violation on field '{}'",
-                        field.name
-                    ));
+                    let absent = purge_if_expired(store, cache, table, &existing_pk, now);
+                    if !absent
+                        && uniq_holder_holds_value(store, table, field, &existing_pk, fval, now)
+                    {
+                        return Err(format!(
+                            "ERR unique constraint violation on field '{}'",
+                            field.name
+                        ));
+                    }
+                    remove_unique_entries(store, table, field, fval, now);
                 }
             }
         }
@@ -2500,19 +2908,20 @@ fn table_update_by_pk_str(
         if let Some(old_val) = old_map.get(*fname) {
             remove_from_index(store, table, field, old_val, pk_str, now);
             if field.unique {
-                let ukey = uniq_key(table, &field.name);
-                let _ = store.hdel(ukey.as_bytes(), &[old_val.as_bytes()], now);
+                remove_unique_entries(store, table, field, old_val, now);
             }
         }
 
         add_to_index(store, table, field, fval, pk_str, now);
         if field.unique {
             let ukey = uniq_key(table, &field.name);
-            let _ = store.hset(
-                ukey.as_bytes(),
-                &[(fval.as_bytes() as &[u8], pk_str.as_bytes() as &[u8])],
-                now,
-            );
+            for index_value in searchable_index_values(store, table, field, fval)? {
+                let _ = store.hset(
+                    ukey.as_bytes(),
+                    &[(index_value.as_bytes() as &[u8], pk_str.as_bytes() as &[u8])],
+                    now,
+                );
+            }
         }
     }
 
@@ -2521,6 +2930,9 @@ fn table_update_by_pk_str(
         let Some((root, rest)) = pi.path.split_once('.') else {
             continue;
         };
+        if schema.iter().any(|f| f.name == root && f.encrypted) {
+            continue;
+        }
         let Some(new_raw) = field_values
             .iter()
             .find(|(k, _)| *k == root)
@@ -2542,7 +2954,7 @@ fn table_update_by_pk_str(
     let mut pairs_owned: Vec<(String, Vec<u8>)> = Vec::new();
     for (fname, fval) in field_values {
         let field = schema.iter().find(|f| f.name == *fname).unwrap();
-        let encoded = field.field_type.encode_value(fval)?;
+        let encoded = encode_stored_value(store, table, field, pk_str, fval)?;
         pairs_owned.push((fname.to_string(), encoded));
     }
     let pair_refs: Vec<(&[u8], &[u8])> = pairs_owned
@@ -2560,7 +2972,9 @@ fn table_update_by_pk_str(
     // a different row on replay. (A WHERE-update logs one such command per matched
     // row.) The TTL op is logged as a trailing `TTL <secs>` clause so replay
     // preserves the row's deadline instead of resetting it.
-    if store.wal_enabled() {
+    if store.wal_enabled() && schema_has_encrypted_fields(&schema) {
+        log_raw_row_wal(store, table, pk_str, now);
+    } else if store.wal_enabled() {
         let pkcol = pk_column_name(&schema);
         let mut a: Vec<Vec<u8>> = Vec::with_capacity(field_values.len() * 2 + 9);
         a.push(b"TUPDATE".to_vec());
@@ -2760,8 +3174,7 @@ fn table_delete_inner(
         if let Some(val) = row_map.get(&field.name) {
             remove_from_index(store, table, field, val, pk_str, now);
             if field.unique {
-                let ukey = uniq_key(table, &field.name);
-                let _ = store.hdel(ukey.as_bytes(), &[val.as_bytes()], now);
+                remove_unique_entries(store, table, field, val, now);
             }
         }
         // A VECTOR column stores its embedding in a side key with its own ANN
@@ -2776,6 +3189,9 @@ fn table_delete_inner(
     // Remove declared JSON path index entries for this row.
     for pi in &load_path_indexes(store, cache, table, now) {
         if let Some((root, rest)) = pi.path.split_once('.') {
+            if schema.iter().any(|f| f.name == root && f.encrypted) {
+                continue;
+            }
             if let Some(raw) = row_map.get(root) {
                 if let Some(scalar) = extract_json_scalar(raw, rest) {
                     remove_from_index(
@@ -2974,6 +3390,8 @@ fn implicit_id_field_for(schema: &[FieldDef]) -> Option<FieldDef> {
             default_value: None,
             sequence_partition: None,
             references: None,
+            encrypted: false,
+            searchable: false,
         })
     }
 }
@@ -3330,6 +3748,12 @@ pub fn table_schema(
         if !field.nullable {
             parts.push("NOT NULL".to_string());
         }
+        if field.encrypted {
+            parts.push("ENCRYPTED".to_string());
+        }
+        if field.searchable {
+            parts.push("SEARCHABLE".to_string());
+        }
         if let Some(fk) = &field.references {
             let on_delete = match fk.on_delete {
                 OnDelete::Restrict => "ON DELETE RESTRICT",
@@ -3355,6 +3779,7 @@ pub fn table_add_column(
 ) -> Result<(), String> {
     let schema = load_schema(store, cache, table, now)?;
     let new_field = parse_field_def(field_spec)?;
+    ensure_encryption_ready(store, std::slice::from_ref(&new_field))?;
 
     if schema.iter().any(|f| f.name == new_field.name) {
         return Err(format!("ERR field '{}' already exists", new_field.name));
@@ -3395,12 +3820,10 @@ pub fn table_add_column(
 
         for pk_str in row_ids {
             let rk = row_key_for_pk(table, &pk_str);
-            let encoded = if backfill_value == "NULL" {
-                // Store empty/NULL value
-                vec![]
-            } else {
-                new_field.field_type.encode_value(&backfill_value)?
-            };
+            if backfill_value == "NULL" {
+                continue;
+            }
+            let encoded = encode_stored_value(store, table, &new_field, &pk_str, &backfill_value)?;
             store.hset(
                 rk.as_bytes(),
                 &[(new_field.name.as_bytes() as &[u8], encoded.as_slice())],
@@ -3408,16 +3831,15 @@ pub fn table_add_column(
             )?;
 
             // Add to indexes if needed
-            if backfill_value != "NULL" {
-                add_to_index(store, table, &new_field, &backfill_value, &pk_str, now);
-                if new_field.unique {
-                    let ukey = uniq_key(table, &new_field.name);
+            add_to_index(store, table, &new_field, &backfill_value, &pk_str, now);
+            if new_field.unique {
+                let ukey = uniq_key(table, &new_field.name);
+                for index_value in
+                    searchable_index_values(store, table, &new_field, &backfill_value)?
+                {
                     store.hset(
                         ukey.as_bytes(),
-                        &[(
-                            backfill_value.as_bytes() as &[u8],
-                            pk_str.as_bytes() as &[u8],
-                        )],
+                        &[(index_value.as_bytes() as &[u8], pk_str.as_bytes() as &[u8])],
                         now,
                     )?;
                 }
@@ -3504,6 +3926,7 @@ fn get_all_row_ids(store: &Store, table: &str, now: Instant) -> Vec<String> {
 mod tests {
     use super::*;
     use crate::store::Store;
+    use crate::{EncryptionConfig, EncryptionKeyConfig, StorageConfig, StorageMode};
     use std::sync::Arc;
     use std::time::Instant;
 
@@ -3513,6 +3936,40 @@ mod tests {
 
     fn now() -> Instant {
         Instant::now()
+    }
+
+    fn encrypted_store() -> Arc<Store> {
+        Arc::new(Store::new_with_config(Arc::new(crate::ServerConfig {
+            encryption: EncryptionConfig {
+                active_key_id: Some("k2".to_string()),
+                keys: vec![
+                    EncryptionKeyConfig {
+                        id: "k1".to_string(),
+                        secret: b"old-key-secret".to_vec(),
+                        decrypt_only: true,
+                    },
+                    EncryptionKeyConfig {
+                        id: "k2".to_string(),
+                        secret: b"new-key-secret".to_vec(),
+                        decrypt_only: false,
+                    },
+                ],
+                ..Default::default()
+            },
+            ..crate::ServerConfig::default()
+        })))
+    }
+
+    fn select_err(
+        store: &Store,
+        cache: &SharedSchemaCache,
+        plan: &SelectPlan,
+        now: Instant,
+    ) -> String {
+        match table_select(store, cache, plan, now) {
+            Ok(_) => panic!("expected table_select to fail"),
+            Err(err) => err,
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -3544,6 +4001,1327 @@ mod tests {
 
         let f = parse_field_def("embedding VECTOR(3)").unwrap();
         assert_eq!(f.field_type, FieldType::Vector(3));
+    }
+
+    #[test]
+    fn encrypted_field_schema_roundtrips() {
+        let field = parse_field_def("token STR ENCRYPTED SEARCHABLE UNIQUE").unwrap();
+        assert!(field.encrypted);
+        assert!(field.searchable);
+        assert!(field.unique);
+
+        let encoded = encode_field_def(&field);
+        let decoded = decode_field_def("token", &encoded);
+        assert!(decoded.encrypted);
+        assert!(decoded.searchable);
+        assert!(decoded.unique);
+    }
+
+    #[test]
+    fn encrypted_field_rejects_invalid_combinations() {
+        assert!(parse_field_def("id UUID PRIMARY KEY ENCRYPTED").is_err());
+        assert!(parse_field_def("owner UUID REFERENCES users(id) ENCRYPTED").is_err());
+        assert!(parse_field_def("embedding VECTOR(3) ENCRYPTED").is_err());
+        assert!(parse_field_def("token STR SEARCHABLE").is_err());
+        assert!(parse_field_def("token STR ENCRYPTED UNIQUE").is_err());
+        assert!(parse_field_def("token STR ENCRYPTED DEFAULT seeded").is_err());
+    }
+
+    #[test]
+    fn encrypted_field_stores_ciphertext_and_returns_plaintext() {
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "secrets",
+            &["id UUID PRIMARY KEY, token STR ENCRYPTED, email STR ENCRYPTED SEARCHABLE"],
+            now,
+        )
+        .unwrap();
+        let id = "018f9d72-7c8d-7000-8000-000000000001";
+        table_insert(
+            &store,
+            &cache,
+            "secrets",
+            &[
+                ("id", id),
+                ("token", "topsecret"),
+                ("email", "a@example.com"),
+            ],
+            now,
+        )
+        .unwrap();
+
+        let raw = store
+            .hget(row_key_for_pk("secrets", id).as_bytes(), b"token", now)
+            .unwrap();
+        assert!(!raw.windows(b"topsecret".len()).any(|w| w == b"topsecret"));
+
+        let row = get_row(
+            &store,
+            "secrets",
+            &load_schema(&store, &cache, "secrets", now).unwrap(),
+            id,
+            now,
+        )
+        .unwrap();
+        assert_eq!(
+            row.iter().find(|(k, _)| k == "token").unwrap().1,
+            "topsecret"
+        );
+
+        let plan = parse_select(&[
+            "*",
+            "FROM",
+            "secrets",
+            "WHERE",
+            "email",
+            "=",
+            "a@example.com",
+        ])
+        .unwrap();
+        let rows = rows_of(table_select(&store, &cache, &plan, now).unwrap());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(cell(&rows[0], "token"), "topsecret");
+    }
+
+    #[test]
+    fn encrypted_value_can_be_decrypted_by_non_writer_network_key() {
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "secrets",
+            &["id UUID PRIMARY KEY, token STR ENCRYPTED"],
+            now,
+        )
+        .unwrap();
+        let id = "018f9d72-7c8d-7000-8000-000000000001";
+        table_insert(
+            &store,
+            &cache,
+            "secrets",
+            &[("id", id), ("token", "network-secret")],
+            now,
+        )
+        .unwrap();
+        let raw = store
+            .hget(row_key_for_pk("secrets", id).as_bytes(), b"token", now)
+            .unwrap();
+        let field = load_schema(&store, &cache, "secrets", now)
+            .unwrap()
+            .into_iter()
+            .find(|f| f.name == "token")
+            .unwrap();
+
+        let old_key_store = Store::new_with_config(Arc::new(crate::ServerConfig {
+            encryption: EncryptionConfig {
+                active_key_id: Some("k1".to_string()),
+                keys: vec![EncryptionKeyConfig {
+                    id: "k1".to_string(),
+                    secret: b"old-key-secret".to_vec(),
+                    decrypt_only: false,
+                }],
+                ..Default::default()
+            },
+            ..crate::ServerConfig::default()
+        }));
+        let plaintext = decode_stored_value(&old_key_store, "secrets", &field, id, &raw).unwrap();
+        assert_eq!(plaintext, "network-secret");
+    }
+
+    #[test]
+    fn encrypted_key_rotation_survives_wal_replay_update_and_search() {
+        let dir = tempfile::tempdir().unwrap();
+        let old_only = Arc::new(crate::ServerConfig {
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            encryption: EncryptionConfig {
+                active_key_id: Some("k1".to_string()),
+                keys: vec![EncryptionKeyConfig {
+                    id: "k1".to_string(),
+                    secret: b"old-key-secret".to_vec(),
+                    decrypt_only: false,
+                }],
+                ..Default::default()
+            },
+            ..crate::ServerConfig::default()
+        });
+        let rotated = Arc::new(crate::ServerConfig {
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            encryption: EncryptionConfig {
+                active_key_id: Some("k2".to_string()),
+                keys: vec![
+                    EncryptionKeyConfig {
+                        id: "k1".to_string(),
+                        secret: b"old-key-secret".to_vec(),
+                        decrypt_only: true,
+                    },
+                    EncryptionKeyConfig {
+                        id: "k2".to_string(),
+                        secret: b"new-key-secret".to_vec(),
+                        decrypt_only: false,
+                    },
+                ],
+                ..Default::default()
+            },
+            ..crate::ServerConfig::default()
+        });
+
+        let store = Arc::new(Store::new_with_config(old_only.clone()));
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "accounts",
+            &[
+                "id UUID PRIMARY KEY,",
+                "email STR ENCRYPTED SEARCHABLE UNIQUE,",
+                "token STR ENCRYPTED",
+            ],
+            now,
+        )
+        .unwrap();
+        let first = "018f9d72-7c8d-7000-8000-000000000001";
+        table_insert(
+            &store,
+            &cache,
+            "accounts",
+            &[
+                ("id", first),
+                ("email", "old@example.com"),
+                ("token", "old-token"),
+            ],
+            now,
+        )
+        .unwrap();
+        store.fsync_wal();
+
+        let rotated_store = Arc::new(Store::new_with_config(rotated.clone()));
+        rotated_store.replay_wal(&crate::pubsub::Broker::new());
+        let rotated_cache = make_cache();
+        let old_query = parse_select(&[
+            "*",
+            "FROM",
+            "accounts",
+            "WHERE",
+            "email",
+            "=",
+            "old@example.com",
+        ])
+        .unwrap();
+        let rows = rows_of(table_select(&rotated_store, &rotated_cache, &old_query, now).unwrap());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(cell(&rows[0], "token"), "old-token");
+
+        table_update_by_pk_str(
+            &rotated_store,
+            &rotated_cache,
+            "accounts",
+            first,
+            &[("email", "rotated@example.com"), ("token", "new-token")],
+            None,
+            now,
+        )
+        .unwrap();
+        let second = "018f9d72-7c8d-7000-8000-000000000002";
+        table_insert(
+            &rotated_store,
+            &rotated_cache,
+            "accounts",
+            &[
+                ("id", second),
+                ("email", "fresh@example.com"),
+                ("token", "fresh-token"),
+            ],
+            now,
+        )
+        .unwrap();
+        rotated_store.fsync_wal();
+
+        let mut wal_bytes = Vec::new();
+        for entry in std::fs::read_dir(dir.path()).unwrap() {
+            let path = entry.unwrap().path().join("wal.lux");
+            if path.exists() {
+                wal_bytes.extend(std::fs::read(path).unwrap());
+            }
+        }
+        for plaintext in [
+            b"old@example.com".as_slice(),
+            b"rotated@example.com".as_slice(),
+            b"fresh@example.com".as_slice(),
+            b"old-token".as_slice(),
+            b"new-token".as_slice(),
+            b"fresh-token".as_slice(),
+        ] {
+            assert!(
+                !wal_bytes.windows(plaintext.len()).any(|w| w == plaintext),
+                "plaintext leaked into encrypted WAL"
+            );
+        }
+
+        let restored = Arc::new(Store::new_with_config(rotated));
+        restored.replay_wal(&crate::pubsub::Broker::new());
+        let restored_cache = make_cache();
+        let old_rows = rows_of(table_select(&restored, &restored_cache, &old_query, now).unwrap());
+        assert_eq!(old_rows.len(), 0);
+
+        let rotated_query = parse_select(&[
+            "*",
+            "FROM",
+            "accounts",
+            "WHERE",
+            "email",
+            "=",
+            "rotated@example.com",
+        ])
+        .unwrap();
+        let rows = rows_of(table_select(&restored, &restored_cache, &rotated_query, now).unwrap());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(cell(&rows[0], "id"), first);
+        assert_eq!(cell(&rows[0], "token"), "new-token");
+
+        let fresh_query = parse_select(&[
+            "*",
+            "FROM",
+            "accounts",
+            "WHERE",
+            "email",
+            "=",
+            "fresh@example.com",
+        ])
+        .unwrap();
+        let rows = rows_of(table_select(&restored, &restored_cache, &fresh_query, now).unwrap());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(cell(&rows[0], "id"), second);
+        assert_eq!(cell(&rows[0], "token"), "fresh-token");
+
+        table_insert(
+            &restored,
+            &restored_cache,
+            "accounts",
+            &[
+                ("id", "018f9d72-7c8d-7000-8000-000000000003"),
+                ("email", "old@example.com"),
+                ("token", "reused-old-email"),
+            ],
+            now,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn encrypted_searchable_unique_uses_plaintext_semantics() {
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "accounts",
+            &["id UUID PRIMARY KEY, email STR ENCRYPTED SEARCHABLE UNIQUE"],
+            now,
+        )
+        .unwrap();
+        table_insert(
+            &store,
+            &cache,
+            "accounts",
+            &[
+                ("id", "018f9d72-7c8d-7000-8000-000000000001"),
+                ("email", "a@example.com"),
+            ],
+            now,
+        )
+        .unwrap();
+        let err = table_insert(
+            &store,
+            &cache,
+            "accounts",
+            &[
+                ("id", "018f9d72-7c8d-7000-8000-000000000002"),
+                ("email", "a@example.com"),
+            ],
+            now,
+        )
+        .unwrap_err();
+        assert!(err.contains("unique constraint"));
+    }
+
+    #[test]
+    fn encrypted_query_guards_reject_unsupported_filters_and_ordering() {
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "secrets",
+            &[
+                "id UUID PRIMARY KEY,",
+                "token STR ENCRYPTED,",
+                "email STR ENCRYPTED SEARCHABLE,",
+                "profile JSON ENCRYPTED",
+            ],
+            now,
+        )
+        .unwrap();
+        table_insert(
+            &store,
+            &cache,
+            "secrets",
+            &[
+                ("id", "018f9d72-7c8d-7000-8000-000000000001"),
+                ("token", "topsecret"),
+                ("email", "a@example.com"),
+                ("profile", r#"{"ssn":"1234"}"#),
+            ],
+            now,
+        )
+        .unwrap();
+
+        let non_searchable =
+            parse_select(&["*", "FROM", "secrets", "WHERE", "token", "=", "topsecret"]).unwrap();
+        let err = select_err(&store, &cache, &non_searchable, now);
+        assert!(err.contains("must be SEARCHABLE"), "{err}");
+
+        let range = parse_select(&["*", "FROM", "secrets", "WHERE", "email", ">", "a"]).unwrap();
+        let err = select_err(&store, &cache, &range, now);
+        assert!(err.contains("only supports equality filters"), "{err}");
+
+        let order = parse_select(&["*", "FROM", "secrets", "ORDER", "BY", "email"]).unwrap();
+        let err = select_err(&store, &cache, &order, now);
+        assert!(err.contains("does not support ORDER BY"), "{err}");
+
+        let json_path =
+            parse_select(&["*", "FROM", "secrets", "WHERE", "profile.ssn", "=", "1234"]).unwrap();
+        let err = select_err(&store, &cache, &json_path, now);
+        assert!(err.contains("does not support JSON path filters"), "{err}");
+
+        let json_order =
+            parse_select(&["*", "FROM", "secrets", "ORDER", "BY", "profile.ssn"]).unwrap();
+        let err = select_err(&store, &cache, &json_order, now);
+        assert!(err.contains("does not support ORDER BY"), "{err}");
+    }
+
+    #[test]
+    fn encrypted_mutation_guards_reject_unsupported_predicates_and_conflicts() {
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "secrets",
+            &[
+                "id UUID PRIMARY KEY,",
+                "token STR ENCRYPTED,",
+                "email STR ENCRYPTED SEARCHABLE,",
+                "note STR",
+            ],
+            now,
+        )
+        .unwrap();
+        let id = "018f9d72-7c8d-7000-8000-000000000001";
+        table_insert(
+            &store,
+            &cache,
+            "secrets",
+            &[
+                ("id", id),
+                ("token", "topsecret"),
+                ("email", "a@example.com"),
+                ("note", "before"),
+            ],
+            now,
+        )
+        .unwrap();
+
+        let err = table_update_where(
+            &store,
+            &cache,
+            "secrets",
+            &[("note", "leaked")],
+            &["token", "=", "topsecret"],
+            now,
+        )
+        .unwrap_err();
+        assert!(err.contains("must be SEARCHABLE"), "{err}");
+
+        let err = table_delete_where(
+            &store,
+            &cache,
+            "secrets",
+            &["email", ">", "a@example.com"],
+            now,
+        )
+        .unwrap_err();
+        assert!(err.contains("only supports equality filters"), "{err}");
+
+        let err = table_upsert_returning(
+            &store,
+            &cache,
+            "secrets",
+            &[("token", "topsecret"), ("note", "upserted")],
+            Some("token"),
+            now,
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("must be SEARCHABLE for upsert conflict"),
+            "{err}"
+        );
+
+        let updated = table_update_where(
+            &store,
+            &cache,
+            "secrets",
+            &[("note", "matched")],
+            &["email", "=", "a@example.com"],
+            now,
+        )
+        .unwrap();
+        assert_eq!(updated, 1);
+        let row = get_row(
+            &store,
+            "secrets",
+            &load_schema(&store, &cache, "secrets", now).unwrap(),
+            id,
+            now,
+        )
+        .unwrap();
+        assert_eq!(cell(&row, "note"), "matched");
+
+        let deleted = table_delete_where(
+            &store,
+            &cache,
+            "secrets",
+            &["email", "=", "a@example.com"],
+            now,
+        )
+        .unwrap();
+        assert_eq!(deleted, 1);
+        assert!(get_row(
+            &store,
+            "secrets",
+            &load_schema(&store, &cache, "secrets", now).unwrap(),
+            id,
+            now,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn encrypted_json_and_array_cannot_be_searchable_and_paths_reject() {
+        assert!(parse_field_def("meta JSON ENCRYPTED SEARCHABLE").is_err());
+        assert!(parse_field_def("tags ARRAY ENCRYPTED SEARCHABLE").is_err());
+
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "events",
+            &["id UUID PRIMARY KEY, meta JSON ENCRYPTED"],
+            now,
+        )
+        .unwrap();
+        let id = "018f9d72-7c8d-7000-8000-000000000001";
+        let meta = r#"{"kind":"login","count":1}"#;
+        table_insert(&store, &cache, "events", &[("id", id), ("meta", meta)], now).unwrap();
+
+        let raw = store
+            .hget(row_key_for_pk("events", id).as_bytes(), b"meta", now)
+            .unwrap();
+        assert!(!raw.windows(b"login".len()).any(|window| window == b"login"));
+
+        let whole = parse_select(&["*", "FROM", "events", "WHERE", "meta", "=", meta]).unwrap();
+        let err = select_err(&store, &cache, &whole, now);
+        assert!(err.contains("must be SEARCHABLE"), "{err}");
+
+        let path =
+            parse_select(&["*", "FROM", "events", "WHERE", "meta.kind", "=", "login"]).unwrap();
+        let err = select_err(&store, &cache, &path, now);
+        assert!(err.contains("does not support JSON path filters"), "{err}");
+    }
+
+    #[test]
+    fn encrypted_join_keys_are_rejected() {
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "users",
+            &["id UUID PRIMARY KEY, email STR ENCRYPTED SEARCHABLE, org_id STR"],
+            now,
+        )
+        .unwrap();
+        table_create(
+            &store,
+            &cache,
+            "profiles",
+            &["id UUID PRIMARY KEY, email STR, org_secret STR ENCRYPTED SEARCHABLE"],
+            now,
+        )
+        .unwrap();
+
+        let left_encrypted = parse_select(&[
+            "*", "FROM", "users", "u", "JOIN", "profiles", "p", "ON", "u.email", "=", "p.email",
+        ])
+        .unwrap();
+        let err = select_err(&store, &cache, &left_encrypted, now);
+        assert!(err.contains("does not support JOIN"), "{err}");
+
+        let right_encrypted = parse_select(&[
+            "*",
+            "FROM",
+            "users",
+            "u",
+            "JOIN",
+            "profiles",
+            "p",
+            "ON",
+            "u.org_id",
+            "=",
+            "p.org_secret",
+        ])
+        .unwrap();
+        let err = select_err(&store, &cache, &right_encrypted, now);
+        assert!(err.contains("does not support JOIN"), "{err}");
+    }
+
+    #[test]
+    fn encrypted_searchable_unique_rekeys_on_update() {
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "accounts",
+            &["id UUID PRIMARY KEY, email STR ENCRYPTED SEARCHABLE UNIQUE"],
+            now,
+        )
+        .unwrap();
+        let first = "018f9d72-7c8d-7000-8000-000000000001";
+        let second = "018f9d72-7c8d-7000-8000-000000000002";
+        table_insert(
+            &store,
+            &cache,
+            "accounts",
+            &[("id", first), ("email", "old@example.com")],
+            now,
+        )
+        .unwrap();
+        table_insert(
+            &store,
+            &cache,
+            "accounts",
+            &[("id", second), ("email", "other@example.com")],
+            now,
+        )
+        .unwrap();
+
+        table_update_by_pk_str(
+            &store,
+            &cache,
+            "accounts",
+            first,
+            &[("email", "new@example.com")],
+            None,
+            now,
+        )
+        .unwrap();
+
+        table_insert(
+            &store,
+            &cache,
+            "accounts",
+            &[
+                ("id", "018f9d72-7c8d-7000-8000-000000000003"),
+                ("email", "old@example.com"),
+            ],
+            now,
+        )
+        .unwrap();
+        let err = table_insert(
+            &store,
+            &cache,
+            "accounts",
+            &[
+                ("id", "018f9d72-7c8d-7000-8000-000000000004"),
+                ("email", "new@example.com"),
+            ],
+            now,
+        )
+        .unwrap_err();
+        assert!(err.contains("unique constraint"), "{err}");
+    }
+
+    #[test]
+    fn encrypted_searchable_unique_delete_cleans_blind_indexes_and_allows_reuse() {
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "accounts",
+            &["id UUID PRIMARY KEY, email STR ENCRYPTED SEARCHABLE UNIQUE"],
+            now,
+        )
+        .unwrap();
+        let first = "018f9d72-7c8d-7000-8000-000000000001";
+        let second = "018f9d72-7c8d-7000-8000-000000000002";
+        table_insert(
+            &store,
+            &cache,
+            "accounts",
+            &[("id", first), ("email", "deleted@example.com")],
+            now,
+        )
+        .unwrap();
+        table_insert(
+            &store,
+            &cache,
+            "accounts",
+            &[("id", second), ("email", "other@example.com")],
+            now,
+        )
+        .unwrap();
+
+        let deleted = table_delete_where(
+            &store,
+            &cache,
+            "accounts",
+            &["email", "=", "deleted@example.com"],
+            now,
+        )
+        .unwrap();
+        assert_eq!(deleted, 1);
+
+        let email_field = load_schema(&store, &cache, "accounts", now)
+            .unwrap()
+            .into_iter()
+            .find(|field| field.name == "email")
+            .unwrap();
+        let ukey = uniq_key("accounts", "email");
+        for index_value in
+            searchable_index_values(&store, "accounts", &email_field, "deleted@example.com")
+                .unwrap()
+        {
+            assert!(
+                store
+                    .hget(ukey.as_bytes(), index_value.as_bytes(), now)
+                    .is_none(),
+                "deleted encrypted unique value left a stale holder"
+            );
+            let skey = idx_str_key("accounts", "email", &index_value);
+            let members = store.smembers(skey.as_bytes(), now).unwrap_or_default();
+            assert!(
+                !members.iter().any(|member| member == first),
+                "deleted encrypted searchable value left a stale index member"
+            );
+        }
+
+        table_update_by_pk_str(
+            &store,
+            &cache,
+            "accounts",
+            second,
+            &[("email", "deleted@example.com")],
+            None,
+            now,
+        )
+        .unwrap();
+        let plan = parse_select(&[
+            "*",
+            "FROM",
+            "accounts",
+            "WHERE",
+            "email",
+            "=",
+            "deleted@example.com",
+        ])
+        .unwrap();
+        let rows = rows_of(table_select(&store, &cache, &plan, now).unwrap());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(cell(&rows[0], "id"), second);
+    }
+
+    #[test]
+    fn encrypted_add_column_rejects_default_and_keeps_existing_rows_readable() {
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "profiles",
+            &["id UUID PRIMARY KEY, name STR"],
+            now,
+        )
+        .unwrap();
+        let id = "018f9d72-7c8d-7000-8000-000000000001";
+        table_insert(
+            &store,
+            &cache,
+            "profiles",
+            &[("id", id), ("name", "Ada")],
+            now,
+        )
+        .unwrap();
+
+        let err = table_add_column(
+            &store,
+            &cache,
+            "profiles",
+            "email STR ENCRYPTED SEARCHABLE UNIQUE DEFAULT seeded@example.com",
+            now,
+        )
+        .unwrap_err();
+        assert!(err.contains("cannot use DEFAULT"), "{err}");
+
+        table_add_column(
+            &store,
+            &cache,
+            "profiles",
+            "email STR ENCRYPTED SEARCHABLE UNIQUE",
+            now,
+        )
+        .unwrap();
+
+        let row = get_row(
+            &store,
+            "profiles",
+            &load_schema(&store, &cache, "profiles", now).unwrap(),
+            id,
+            now,
+        )
+        .unwrap();
+        assert_eq!(cell(&row, "name"), "Ada");
+        assert!(row.iter().all(|(field, _)| field != "email"));
+
+        let second = "018f9d72-7c8d-7000-8000-000000000002";
+        table_insert(
+            &store,
+            &cache,
+            "profiles",
+            &[
+                ("id", second),
+                ("name", "Grace"),
+                ("email", "grace@example.com"),
+            ],
+            now,
+        )
+        .unwrap();
+        let raw = store
+            .hget(row_key_for_pk("profiles", second).as_bytes(), b"email", now)
+            .unwrap();
+        assert!(!raw
+            .windows(b"grace@example.com".len())
+            .any(|window| window == b"grace@example.com"));
+
+        let plan = parse_select(&[
+            "*",
+            "FROM",
+            "profiles",
+            "WHERE",
+            "email",
+            "=",
+            "grace@example.com",
+        ])
+        .unwrap();
+        let rows = rows_of(table_select(&store, &cache, &plan, now).unwrap());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(cell(&rows[0], "id"), second);
+    }
+
+    #[test]
+    fn encrypted_returning_paths_emit_plaintext_and_store_ciphertext() {
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "secrets",
+            &[
+                "id",
+                "STR",
+                "PRIMARY",
+                "KEY,",
+                "email",
+                "STR",
+                "ENCRYPTED",
+                "SEARCHABLE",
+                "UNIQUE,",
+                "token",
+                "STR",
+                "ENCRYPTED",
+            ],
+            now,
+        )
+        .unwrap();
+
+        let inserted = table_insert_returning(
+            &store,
+            &cache,
+            "secrets",
+            &[
+                ("id", "s1"),
+                ("email", "person@example.com"),
+                ("token", "first-secret"),
+            ],
+            now,
+        )
+        .unwrap();
+        assert!(inserted
+            .iter()
+            .any(|(k, v)| k == "token" && v == "first-secret"));
+        let raw = store
+            .hget(row_key_for_pk("secrets", "s1").as_bytes(), b"token", now)
+            .unwrap();
+        assert!(!raw
+            .windows(b"first-secret".len())
+            .any(|w| w == b"first-secret"));
+
+        let updated = table_update_where_returning(
+            &store,
+            &cache,
+            "secrets",
+            &[("token", "second-secret")],
+            &["email", "=", "person@example.com"],
+            now,
+        )
+        .unwrap();
+        assert_eq!(updated.len(), 1);
+        assert!(updated[0]
+            .iter()
+            .any(|(k, v)| k == "token" && v == "second-secret"));
+        let raw = store
+            .hget(row_key_for_pk("secrets", "s1").as_bytes(), b"token", now)
+            .unwrap();
+        assert!(!raw
+            .windows(b"second-secret".len())
+            .any(|w| w == b"second-secret"));
+
+        let deleted = table_delete_where_returning(
+            &store,
+            &cache,
+            "secrets",
+            &["email", "=", "person@example.com"],
+            now,
+        )
+        .unwrap();
+        assert_eq!(deleted.len(), 1);
+        assert!(deleted[0]
+            .iter()
+            .any(|(k, v)| k == "token" && v == "second-secret"));
+        assert!(get_row(
+            &store,
+            "secrets",
+            &load_schema(&store, &cache, "secrets", now).unwrap(),
+            "s1",
+            now,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn encrypted_upsert_on_searchable_unique_replays_with_ttl_clear() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(crate::ServerConfig {
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            encryption: EncryptionConfig {
+                active_key_id: Some("k2".to_string()),
+                keys: vec![EncryptionKeyConfig {
+                    id: "k2".to_string(),
+                    secret: b"new-key-secret".to_vec(),
+                    decrypt_only: false,
+                }],
+                ..Default::default()
+            },
+            ..crate::ServerConfig::default()
+        });
+        let store = Arc::new(Store::new_with_config(config.clone()));
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "accounts",
+            &[
+                "id UUID PRIMARY KEY,",
+                "email STR ENCRYPTED SEARCHABLE UNIQUE,",
+                "name STR ENCRYPTED",
+            ],
+            now,
+        )
+        .unwrap();
+        let id = "018f9d72-7c8d-7000-8000-000000000001";
+        table_insert_ttl(
+            &store,
+            &cache,
+            "accounts",
+            &[("id", id), ("email", "a@example.com"), ("name", "old")],
+            Some(TtlOp::Set(3600)),
+            now,
+        )
+        .unwrap();
+        let row = table_upsert_returning_ttl(
+            &store,
+            &cache,
+            "accounts",
+            &[("email", "a@example.com"), ("name", "updated")],
+            Some("email"),
+            Some(TtlOp::Clear),
+            now,
+        )
+        .unwrap();
+        assert_eq!(cell(&row, "id"), id);
+        assert_eq!(cell(&row, "name"), "updated");
+        store.fsync_wal();
+
+        let restored = Arc::new(Store::new_with_config(config));
+        restored.replay_wal(&crate::pubsub::Broker::new());
+        let restored_cache = make_cache();
+        let plan = parse_select(&[
+            "*",
+            "FROM",
+            "accounts",
+            "WHERE",
+            "email",
+            "=",
+            "a@example.com",
+        ])
+        .unwrap();
+        let rows = rows_of(table_select(&restored, &restored_cache, &plan, now).unwrap());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(cell(&rows[0], "id"), id);
+        assert_eq!(cell(&rows[0], "name"), "updated");
+        let rk = row_key_for_pk("accounts", id);
+        assert!(restored
+            .hget(rk.as_bytes(), HIDDEN_TTL_FIELD, now)
+            .is_none());
+    }
+
+    #[test]
+    fn encrypted_snapshot_does_not_store_plaintext_and_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(crate::ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            encryption: EncryptionConfig {
+                active_key_id: Some("k2".to_string()),
+                keys: vec![
+                    EncryptionKeyConfig {
+                        id: "k1".to_string(),
+                        secret: b"old-key-secret".to_vec(),
+                        decrypt_only: true,
+                    },
+                    EncryptionKeyConfig {
+                        id: "k2".to_string(),
+                        secret: b"new-key-secret".to_vec(),
+                        decrypt_only: false,
+                    },
+                ],
+                ..Default::default()
+            },
+            ..crate::ServerConfig::default()
+        });
+        let store = Arc::new(Store::new_with_config(config.clone()));
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "secrets",
+            &["id UUID PRIMARY KEY, token STR ENCRYPTED"],
+            now,
+        )
+        .unwrap();
+        let id = "018f9d72-7c8d-7000-8000-000000000001";
+        table_insert(
+            &store,
+            &cache,
+            "secrets",
+            &[("id", id), ("token", "snapshot-topsecret")],
+            now,
+        )
+        .unwrap();
+
+        let snapshot_path = crate::snapshot::snapshot_for_backup(&store).unwrap();
+        let snapshot = std::fs::read(snapshot_path).unwrap();
+        assert!(!snapshot
+            .windows(b"snapshot-topsecret".len())
+            .any(|w| w == b"snapshot-topsecret"));
+
+        let restored = Arc::new(Store::new_with_config(config));
+        crate::snapshot::load(&restored).unwrap();
+        let restored_cache = make_cache();
+        let row = get_row(
+            &restored,
+            "secrets",
+            &load_schema(&restored, &restored_cache, "secrets", now).unwrap(),
+            id,
+            now,
+        )
+        .unwrap();
+        assert_eq!(cell(&row, "token"), "snapshot-topsecret");
+    }
+
+    #[test]
+    fn encrypted_wal_does_not_store_plaintext_and_replays_latest_update() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(crate::ServerConfig {
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            encryption: EncryptionConfig {
+                active_key_id: Some("k2".to_string()),
+                keys: vec![
+                    EncryptionKeyConfig {
+                        id: "k1".to_string(),
+                        secret: b"old-key-secret".to_vec(),
+                        decrypt_only: true,
+                    },
+                    EncryptionKeyConfig {
+                        id: "k2".to_string(),
+                        secret: b"new-key-secret".to_vec(),
+                        decrypt_only: false,
+                    },
+                ],
+                ..Default::default()
+            },
+            ..crate::ServerConfig::default()
+        });
+        let store = Arc::new(Store::new_with_config(config.clone()));
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "secrets",
+            &["id UUID PRIMARY KEY, token STR ENCRYPTED"],
+            now,
+        )
+        .unwrap();
+        let id = "018f9d72-7c8d-7000-8000-000000000001";
+        table_insert(
+            &store,
+            &cache,
+            "secrets",
+            &[("id", id), ("token", "wal-topsecret")],
+            now,
+        )
+        .unwrap();
+        table_update_by_pk_str(
+            &store,
+            &cache,
+            "secrets",
+            id,
+            &[("token", "wal-newsecret")],
+            None,
+            now,
+        )
+        .unwrap();
+        store.fsync_wal();
+
+        let mut wal_bytes = Vec::new();
+        for entry in std::fs::read_dir(dir.path()).unwrap() {
+            let path = entry.unwrap().path().join("wal.lux");
+            if path.exists() {
+                wal_bytes.extend(std::fs::read(path).unwrap());
+            }
+        }
+        assert!(!wal_bytes
+            .windows(b"wal-topsecret".len())
+            .any(|w| w == b"wal-topsecret"));
+        assert!(!wal_bytes
+            .windows(b"wal-newsecret".len())
+            .any(|w| w == b"wal-newsecret"));
+        assert!(wal_bytes.windows(b"TROWSET".len()).any(|w| w == b"TROWSET"));
+
+        let restored = Arc::new(Store::new_with_config(config));
+        restored.replay_wal(&crate::pubsub::Broker::new());
+        let restored_cache = make_cache();
+        let row = get_row(
+            &restored,
+            "secrets",
+            &load_schema(&restored, &restored_cache, "secrets", now).unwrap(),
+            id,
+            now,
+        )
+        .unwrap();
+        assert_eq!(cell(&row, "token"), "wal-newsecret");
+    }
+
+    #[test]
+    fn encrypted_wal_replay_preserves_uuid_row_order_after_update() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(crate::ServerConfig {
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            encryption: EncryptionConfig {
+                active_key_id: Some("k2".to_string()),
+                keys: vec![EncryptionKeyConfig {
+                    id: "k2".to_string(),
+                    secret: b"new-key-secret".to_vec(),
+                    decrypt_only: false,
+                }],
+                ..Default::default()
+            },
+            ..crate::ServerConfig::default()
+        });
+        let store = Arc::new(Store::new_with_config(config.clone()));
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "secrets",
+            &["id UUID PRIMARY KEY, token STR ENCRYPTED"],
+            now,
+        )
+        .unwrap();
+        let first = "018f9d72-7c8d-7000-8000-000000000001";
+        let second = "018f9d72-7c8d-7000-8000-000000000002";
+        table_insert(
+            &store,
+            &cache,
+            "secrets",
+            &[("id", first), ("token", "first")],
+            now,
+        )
+        .unwrap();
+        table_insert(
+            &store,
+            &cache,
+            "secrets",
+            &[("id", second), ("token", "second")],
+            now,
+        )
+        .unwrap();
+        table_update_by_pk_str(
+            &store,
+            &cache,
+            "secrets",
+            first,
+            &[("token", "first-updated")],
+            None,
+            now,
+        )
+        .unwrap();
+        store.fsync_wal();
+
+        let restored = Arc::new(Store::new_with_config(config));
+        restored.replay_wal(&crate::pubsub::Broker::new());
+        let restored_cache = make_cache();
+        let plan = parse_select(&["*", "FROM", "secrets", "LIMIT", "2"]).unwrap();
+        let rows = rows_of(table_select(&restored, &restored_cache, &plan, now).unwrap());
+        assert_eq!(rows.len(), 2);
+        assert_eq!(cell(&rows[0], "id"), first);
+        assert_eq!(cell(&rows[0], "token"), "first-updated");
+        assert_eq!(cell(&rows[1], "id"), second);
+    }
+
+    #[test]
+    fn encrypted_wal_replay_clears_hidden_ttl_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(crate::ServerConfig {
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            encryption: EncryptionConfig {
+                active_key_id: Some("k2".to_string()),
+                keys: vec![EncryptionKeyConfig {
+                    id: "k2".to_string(),
+                    secret: b"new-key-secret".to_vec(),
+                    decrypt_only: false,
+                }],
+                ..Default::default()
+            },
+            ..crate::ServerConfig::default()
+        });
+        let store = Arc::new(Store::new_with_config(config.clone()));
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "secrets",
+            &["id UUID PRIMARY KEY, token STR ENCRYPTED"],
+            now,
+        )
+        .unwrap();
+        let id = "018f9d72-7c8d-7000-8000-000000000001";
+        table_insert_ttl(
+            &store,
+            &cache,
+            "secrets",
+            &[("id", id), ("token", "ttl-secret")],
+            Some(TtlOp::Set(3600)),
+            now,
+        )
+        .unwrap();
+        table_update_by_pk_str(
+            &store,
+            &cache,
+            "secrets",
+            id,
+            &[("token", "ttl-cleared")],
+            Some(TtlOp::Clear),
+            now,
+        )
+        .unwrap();
+        store.fsync_wal();
+
+        let restored = Arc::new(Store::new_with_config(config));
+        restored.replay_wal(&crate::pubsub::Broker::new());
+        let rk = row_key_for_pk("secrets", id);
+        assert!(restored
+            .hget(rk.as_bytes(), HIDDEN_TTL_FIELD, now)
+            .is_none());
+        assert_eq!(
+            restored
+                .zscore(
+                    ttl_index_key().as_bytes(),
+                    ttl_member("secrets", id).as_bytes(),
+                    now
+                )
+                .unwrap(),
+            None
+        );
+        let restored_cache = make_cache();
+        let row = get_row(
+            &restored,
+            "secrets",
+            &load_schema(&restored, &restored_cache, "secrets", now).unwrap(),
+            id,
+            now,
+        )
+        .unwrap();
+        assert_eq!(cell(&row, "token"), "ttl-cleared");
     }
 
     #[test]
@@ -5748,6 +7526,25 @@ mod tests {
         let err =
             table_create_path_index(&store, &cache, "events", "kind.x", "STR", now).unwrap_err();
         assert!(err.contains("not a JSON column"), "{err}");
+    }
+
+    #[test]
+    fn tindex_rejects_encrypted_json_column() {
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "events",
+            &["id INT PRIMARY KEY, meta JSON ENCRYPTED"],
+            now,
+        )
+        .unwrap();
+        let err =
+            table_create_path_index(&store, &cache, "events", "meta.ssn", "STR", now).unwrap_err();
+        assert!(err.contains("encrypted column"), "{err}");
+        assert!(load_path_indexes(&store, &cache, "events", now).is_empty());
     }
 
     // -------------------------------------------------------------------------

--- a/src/tables/select.rs
+++ b/src/tables/select.rs
@@ -13,11 +13,9 @@ pub(crate) fn get_row(
 ) -> Option<Vec<(String, String)>> {
     // Build a lookup map on the fly - only called from paths that don't have a pre-built map.
     // Hot paths (table_select) use get_row_with_map directly.
-    let type_map: hashbrown::HashMap<&str, &FieldType> = schema
-        .iter()
-        .map(|f| (f.name.as_str(), &f.field_type))
-        .collect();
-    get_row_with_map(store, table, &type_map, pk_str, now)
+    let field_map: hashbrown::HashMap<&str, &FieldDef> =
+        schema.iter().map(|f| (f.name.as_str(), f)).collect();
+    get_row_with_map(store, table, &field_map, pk_str, now)
 }
 
 /// Like `get_row`, but returns the row even when its TTL has expired. The
@@ -30,11 +28,9 @@ pub(crate) fn get_row_including_expired(
     pk_str: &str,
     now: Instant,
 ) -> Option<Vec<(String, String)>> {
-    let type_map: hashbrown::HashMap<&str, &FieldType> = schema
-        .iter()
-        .map(|f| (f.name.as_str(), &f.field_type))
-        .collect();
-    get_row_with_map_impl(store, table, &type_map, pk_str, now, true)
+    let field_map: hashbrown::HashMap<&str, &FieldDef> =
+        schema.iter().map(|f| (f.name.as_str(), f)).collect();
+    get_row_with_map_impl(store, table, &field_map, pk_str, now, true)
 }
 
 /// Hot-path row fetch: takes a pre-built field-type map to avoid O(N) schema scan per field.
@@ -42,18 +38,18 @@ pub(crate) fn get_row_including_expired(
 pub(crate) fn get_row_with_map(
     store: &Store,
     table: &str,
-    type_map: &hashbrown::HashMap<&str, &FieldType>,
+    field_map: &hashbrown::HashMap<&str, &FieldDef>,
     pk_str: &str,
     now: Instant,
 ) -> Option<Vec<(String, String)>> {
-    get_row_with_map_impl(store, table, type_map, pk_str, now, false)
+    get_row_with_map_impl(store, table, field_map, pk_str, now, false)
 }
 
 #[inline]
 fn get_row_with_map_impl(
     store: &Store,
     table: &str,
-    type_map: &hashbrown::HashMap<&str, &FieldType>,
+    field_map: &hashbrown::HashMap<&str, &FieldDef>,
     pk_str: &str,
     now: Instant,
     include_expired: bool,
@@ -82,8 +78,11 @@ fn get_row_with_map_impl(
             }
             continue; // never expose the hidden TTL field
         }
-        let decoded = match type_map.get(k.as_str()) {
-            Some(ft) => ft.decode_value(&v),
+        let decoded = match field_map.get(k.as_str()) {
+            Some(field) => match decode_stored_value(store, table, field, pk_str, &v) {
+                Ok(decoded) => decoded,
+                Err(_) => return None,
+            },
             None => String::from_utf8_lossy(&v).to_string(),
         };
         out.push((k, decoded));
@@ -312,18 +311,26 @@ pub(crate) fn row_passes_conditions(
                 f.name == root && matches!(f.field_type, FieldType::Json | FieldType::Array)
             }) {
                 let raw = store.hget(rk.as_bytes(), root.as_bytes(), now);
-                return eval_json_path_binary(raw.as_deref(), rest, cond);
+                let decoded = raw.and_then(|bytes| {
+                    let field = schema.iter().find(|f| f.name == root)?;
+                    stored_plain_bytes(store, table, field, pk, &bytes).ok()
+                });
+                return eval_json_path_binary(decoded.as_deref(), rest, cond);
             }
         }
         let bare = bare_col(&cond.field);
         if let Some(fd) = schema.iter().find(|f| f.name == bare) {
             if matches!(fd.field_type, FieldType::Json | FieldType::Array) {
                 let raw = store.hget(rk.as_bytes(), bare.as_bytes(), now);
-                return eval_json_whole_binary(raw.as_deref(), cond);
+                let decoded =
+                    raw.and_then(|bytes| stored_plain_bytes(store, table, fd, pk, &bytes).ok());
+                return eval_json_whole_binary(decoded.as_deref(), cond);
             }
             return match store.hget(rk.as_bytes(), bare.as_bytes(), now) {
                 Some(b) => {
-                    let val = fd.field_type.decode_value(&b);
+                    let Ok(val) = decode_stored_value(store, table, fd, pk, &b) else {
+                        return false;
+                    };
                     let row = [(bare.to_string(), val)];
                     matches_condition(
                         &row,
@@ -478,6 +485,24 @@ pub(crate) fn candidates_from_index(
     limit: Option<usize>,
     now: Instant,
 ) -> Option<Vec<String>> {
+    if field_def.encrypted {
+        if !field_def.searchable || cond.op != CmpOp::Eq {
+            return None;
+        }
+        let index_values = searchable_index_values(store, table, field_def, &cond.value).ok()?;
+        let mut members = Vec::new();
+        for index_value in index_values {
+            let skey = idx_str_key(table, &cond.field, &index_value);
+            members.extend(store.smembers(skey.as_bytes(), now).unwrap_or_default());
+        }
+        members.sort();
+        members.dedup();
+        let members = match limit {
+            Some(n) => members.into_iter().take(n).collect(),
+            None => members,
+        };
+        return Some(members);
+    }
     match &field_def.field_type {
         FieldType::Str | FieldType::Uuid => {
             if cond.op == CmpOp::Eq {
@@ -1093,11 +1118,25 @@ pub fn table_select(
 
     // Validate WHERE columns
     for cond in &conditions {
-        let bare = bare_col(&cond.field);
-        if !schema.iter().any(|f| f.name == bare) {
-            // Might be a join column - validate later
+        validate_encrypted_condition(cond, &schema)?;
+    }
+    if let Some((order_col, _)) = &plan.order_by {
+        let order_col = strip_alias(order_col, table_alias);
+        if let Some(root) = encrypted_path_root(&order_col, &schema) {
+            return Err(format!(
+                "ERR encrypted column '{}' does not support ORDER BY",
+                root.name
+            ));
+        }
+        let bare = bare_col(&order_col);
+        if schema.iter().any(|f| f.name == bare && f.encrypted) {
+            return Err(format!(
+                "ERR encrypted column '{}' does not support ORDER BY",
+                bare
+            ));
         }
     }
+    validate_encrypted_joins(store, cache, plan, &schema, table_alias, now)?;
 
     // ---- Fast-path aggregates (no row fetches needed) ----
     // We handle the common aggregate-only queries directly against the indexes,
@@ -1120,11 +1159,9 @@ pub fn table_select(
     }
 
     // ---- Scan primary table ----
-    // Build a field-type lookup map ONCE per query so get_row doesn't O(N) scan per field.
-    let type_map: hashbrown::HashMap<&str, &FieldType> = schema
-        .iter()
-        .map(|f| (f.name.as_str(), &f.field_type))
-        .collect();
+    // Build a field lookup map ONCE per query so get_row doesn't O(N) scan per field.
+    let field_map: hashbrown::HashMap<&str, &FieldDef> =
+        schema.iter().map(|f| (f.name.as_str(), f)).collect();
     let implicit_id_field = if schema.iter().any(|f| f.primary_key) {
         None
     } else {
@@ -1137,6 +1174,8 @@ pub fn table_select(
             default_value: None,
             sequence_partition: None,
             references: None,
+            encrypted: false,
+            searchable: false,
         })
     };
 
@@ -1167,7 +1206,7 @@ pub fn table_select(
     let near_candidate_pks = if plan.near.is_some() && !conditions.is_empty() {
         let mut candidates = HashSet::new();
         for pk_str in &scan.row_ids {
-            let Some(row) = get_row_with_map(store, &plan.table, &type_map, pk_str, now) else {
+            let Some(row) = get_row_with_map(store, &plan.table, &field_map, pk_str, now) else {
                 continue;
             };
             if row_matches_base_conditions(&row, &schema, implicit_id_field.as_ref(), &conditions) {
@@ -1227,7 +1266,7 @@ pub fn table_select(
         ) {
             return None;
         }
-        let mut row = get_row_with_map(store, &plan.table, &type_map, &pk_str, now)?;
+        let mut row = get_row_with_map(store, &plan.table, &field_map, &pk_str, now)?;
         if let Some(similarity) = vector_similarity
             .as_ref()
             .and_then(|scores| scores.get(&pk_str))
@@ -1383,6 +1422,90 @@ pub fn table_select(
     };
 
     Ok(SelectResult::Rows(rows))
+}
+
+fn validate_encrypted_condition(cond: &WhereClause, schema: &[FieldDef]) -> Result<(), String> {
+    if cond.op == CmpOp::Or {
+        for clause in &cond.or_clauses {
+            validate_encrypted_condition(clause, schema)?;
+        }
+        return Ok(());
+    }
+    if let Some(root) = encrypted_path_root(&cond.field, schema) {
+        return Err(format!(
+            "ERR encrypted column '{}' does not support JSON path filters",
+            root.name
+        ));
+    }
+    let bare = bare_col(&cond.field);
+    let Some(field) = schema.iter().find(|f| f.name == bare) else {
+        return Ok(()); // Might be a join column - validate later.
+    };
+    if !field.encrypted {
+        return Ok(());
+    }
+    match cond.op {
+        CmpOp::Eq if field.searchable => Ok(()),
+        CmpOp::IsNull | CmpOp::IsNotNull => Ok(()),
+        CmpOp::Eq => Err(format!(
+            "ERR encrypted column '{}' must be SEARCHABLE for equality filters",
+            field.name
+        )),
+        _ => Err(format!(
+            "ERR encrypted column '{}' only supports equality filters when SEARCHABLE",
+            field.name
+        )),
+    }
+}
+
+fn encrypted_path_root<'a>(field: &str, schema: &'a [FieldDef]) -> Option<&'a FieldDef> {
+    let (root, rest) = field.split_once('.')?;
+    if rest.is_empty() {
+        return None;
+    }
+    schema.iter().find(|f| f.name == root && f.encrypted)
+}
+
+fn validate_encrypted_joins(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    plan: &SelectPlan,
+    left_schema: &[FieldDef],
+    left_alias: &str,
+    now: Instant,
+) -> Result<(), String> {
+    for join in &plan.joins {
+        let right_schema = load_schema(store, cache, &join.table, now)?;
+        for col in [&join.left_col, &join.right_col] {
+            if let Some(field) =
+                join_column_field(col, left_schema, left_alias, &right_schema, &join.alias)
+            {
+                if field.encrypted {
+                    return Err(format!(
+                        "ERR encrypted column '{}' does not support JOIN",
+                        field.name
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn join_column_field<'a>(
+    col: &str,
+    left_schema: &'a [FieldDef],
+    left_alias: &str,
+    right_schema: &'a [FieldDef],
+    right_alias: &str,
+) -> Option<&'a FieldDef> {
+    let bare = bare_col(col);
+    match col.split_once('.').map(|(alias, _)| alias) {
+        Some(alias) if alias == right_alias => right_schema.iter().find(|f| f.name == bare),
+        Some(alias) if alias == left_alias => left_schema.iter().find(|f| f.name == bare),
+        Some(_) => None,
+        None => left_schema.iter().find(|f| f.name == bare),
+    }
 }
 
 pub(crate) fn plan_table_scan(
@@ -1719,6 +1842,8 @@ pub(crate) fn build_candidate_set(
                     default_value: None,
                     sequence_partition: None,
                     references: None,
+                    encrypted: false,
+                    searchable: false,
                 };
                 if let Some(pks) =
                     candidates_from_index(store, table, cond, &synthetic, index_limit, now)
@@ -1806,6 +1931,9 @@ pub(crate) fn candidates_from_order_index(
         ids_key(table)
     } else {
         let field = schema.iter().find(|f| f.name == scan.column)?;
+        if field.encrypted {
+            return None;
+        }
         match &field.field_type {
             FieldType::Int
             | FieldType::Float
@@ -2639,6 +2767,7 @@ pub(crate) fn scan_matching_pks(
     // Validate WHERE fields (allow "id" for implicit-PK tables and JSON dot-paths).
     let has_implicit_pk = !schema.iter().any(|f| f.primary_key);
     for cond in conditions {
+        validate_encrypted_condition(cond, &schema)?;
         validate_where_field(cond, &schema, has_implicit_pk)?;
     }
     let implicit_id = implicit_id_field_for(&schema);

--- a/tests/live_ws.rs
+++ b/tests/live_ws.rs
@@ -405,6 +405,92 @@ async fn live_websocket_table_subscription_receives_http_insert() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_encrypted_table_streams_plaintext_rows_without_key_event_value_leak() {
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start_lux_with_env(resp_port, http_port, None, &[("LUX_ENC_AUTO_INIT", "1")]);
+
+    let (status, created) = http_json_request(
+        http_port,
+        "POST",
+        "/v1/tables",
+        r#"{"name":"encrypted_messages","columns":[{"name":"id","type":"STR","primaryKey":true},{"name":"email","type":"STR","encrypted":true,"searchable":true},{"name":"token","type":"STR","encrypted":true}]}"#,
+        None,
+    );
+    assert_eq!(status, 200, "create encrypted table: {created}");
+
+    let mut table_ws = connect_live(http_port, None).await;
+    send_json(
+        &mut table_ws,
+        json!({
+            "type":"live.subscribe",
+            "id":"messages",
+            "spec":{
+                "kind":"table",
+                "table":"encrypted_messages",
+                "where":{"email":"a@example.com"}
+            }
+        }),
+    )
+    .await;
+    assert_eq!(recv_json(&mut table_ws).await["type"], "live.subscribed");
+    let snapshot = recv_live_event(&mut table_ws, "messages").await;
+    assert_eq!(snapshot["kind"], "snapshot");
+    assert_eq!(snapshot["rows"].as_array().unwrap().len(), 0);
+
+    let mut key_ws = connect_live(http_port, None).await;
+    send_json(
+        &mut key_ws,
+        json!({"type":"live.subscribe","id":"keys","spec":{"kind":"key","pattern":"encrypted_messages"}}),
+    )
+    .await;
+    assert_eq!(recv_json(&mut key_ws).await["type"], "live.subscribed");
+
+    let (status, inserted) = http_json_request(
+        http_port,
+        "POST",
+        "/v1/tables/encrypted_messages",
+        r#"{"id":"msg-1","email":"a@example.com","token":"live-secret"}"#,
+        None,
+    );
+    assert_eq!(status, 200, "insert encrypted row: {inserted}");
+    assert_eq!(inserted["result"]["token"], "live-secret");
+
+    let key_event = recv_live_event(&mut key_ws, "keys").await;
+    assert_eq!(key_event["kind"], "key.update");
+    assert_eq!(key_event["key"], "encrypted_messages");
+    let key_json = key_event.to_string();
+    assert!(
+        !key_json.contains("live-secret") && !key_json.contains("a@example.com"),
+        "key event leaked encrypted table values: {key_json}"
+    );
+
+    let insert = recv_live_event(&mut table_ws, "messages").await;
+    assert_eq!(insert["kind"], "insert");
+    assert_eq!(insert["pk"], "msg-1");
+    assert_eq!(insert["row"]["email"], "a@example.com");
+    assert_eq!(insert["row"]["token"], "live-secret");
+    let insert_json = insert.to_string();
+    assert!(
+        !insert_json.contains("LUXENC2"),
+        "table live event exposed encrypted envelope bytes: {insert_json}"
+    );
+
+    let (status, updated) = http_json_request(
+        http_port,
+        "PATCH",
+        "/v1/tables/encrypted_messages?where=email=a@example.com",
+        r#"{"token":"rotated-secret"}"#,
+        None,
+    );
+    assert_eq!(status, 200, "update encrypted row: {updated}");
+    let update = recv_live_event(&mut table_ws, "messages").await;
+    assert_eq!(update["kind"], "update");
+    assert_eq!(update["row"]["token"], "rotated-secret");
+    assert_eq!(update["previous"]["token"], "live-secret");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn live_websocket_join_reacts_to_joined_table_insert() {
     let resp_port = free_port();
     let http_port = free_port();

--- a/tests/redis_parity_inventory.rs
+++ b/tests/redis_parity_inventory.rs
@@ -265,6 +265,7 @@ const INVENTORY: &[CommandInventory] = &[
     missing("ZUNION", "compatibility gap"),
     supported("ZUNIONSTORE"),
     lux_native("DELIFEQ"),
+    lux_native("ENC"),
     lux_native("GRANT"),
     lux_native("KSUB"),
     lux_native("KUNSUB"),


### PR DESCRIPTION
Column/value encryption at rest, plus the seal-key hardening so the key that unseals the keyring lives off the data volume.

## What changed
- Envelope encryption for table columns and KV values: per-value random DEK, ChaCha20-Poly1305, AAD bound to `(table, field, pk, writer_key_id)`; DEK wrapped per keyring key. Searchable encrypted columns via deterministic HMAC blind index. `ENC INIT/ROTATE/RETIRE/REWRAP/STATUS/LIST` lifecycle. WAL logs ciphertext, never plaintext.
- Query guards: encrypted columns reject ORDER BY, JOIN, JSON-path filters, range ops, DEFAULT, PK/FK/vector/sequence use; equality only when SEARCHABLE.
- Seal sourcing (hardening): `LUX_ENC_SEAL_KEY` (base64 32B) instead of an on-disk seal file, so a stolen volume no longer carries the key. Rotation via `LUX_ENC_SEAL_KEY_PREVIOUS`; automatic file->env migration on open (re-seals, deletes the file); keyring state fsynced (tmp + dir) on write. `validate_encryption_config` no longer writes seal material into the process cwd.

## Verification
- `cargo test --release`: 902 pass, 0 fail. Includes a new adversarial unit suite for the crypto core (AAD cross-row/field/table rejection, AEAD tamper + writer-id forgery rejection, truncation no-panic, blind-index properties) and seal tests (env round-trip, file->env migration + file deletion, rotation via previous, fail-closed on stale seal).
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` clean.
- End-to-end verified against the release binary: env seal, restart persistence, migration, rotation, fail-closed.

## Release note
Publishing the engine image is a manual `v*` tag (bumps `ghcr.io/lux-db/lux:latest`, which every cloud customer instance tracks). Merging this PR does not publish; the tag is a separate deliberate step.