### PR TITLE
release: engine v0.25.0 + cli v0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "lux"
-version = "0.24.6"
+version = "0.25.0"
 dependencies = [
  "argon2",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lux"
-version = "0.24.6"
+version = "0.25.0"
 edition = "2021"
 description = "An open-source application database engine with tables, cache, vectors, auth, realtime, queues, time series, and Redis-compatible commands."
 license = "MIT"

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -698,7 +698,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lux-cli"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lux-cli"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 description = "CLI for Lux"
 license = "MIT"


### PR DESCRIPTION
Version bump for the encryption-at-rest release.

- Engine `0.24.6` → `0.25.0` (minor): column + KV envelope encryption, searchable blind index, env-sourced seal + rotation + file→env migration.
- CLI `0.21.1` → `0.22.0` (minor): `lux enc <status|list|init|rotate|rewrap|retire>` and `LUX_ENC_AUTO_INIT=1` in `lux start`.

Only `Cargo.toml` + `Cargo.lock` change. After merge, tags `v0.25.0` (engine image + binaries) and `cli-v0.22.0` (CLI binaries) publish the release.