### PR TITLE
feat(enc): grant-gated decryption for encrypted columns

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -133,6 +133,11 @@ struct AccessClaims {
     role: String,
     iat: usize,
     exp: usize,
+    // Anonymous (signInAnonymously) sessions. Gates decryption of ENCRYPTED
+    // columns: anonymous callers get NULL, real users get plaintext. Defaulted
+    // so tokens minted before this field decode (missing -> not anonymous).
+    #[serde(default)]
+    is_anonymous: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -172,6 +177,9 @@ pub(crate) struct AuthPrincipal {
     pub email: String,
     pub session_id: String,
     pub role: String,
+    /// Anonymous (signInAnonymously) session. Encrypted columns are NULLed for
+    /// these principals; real users and the operator get plaintext.
+    pub is_anonymous: bool,
 }
 
 pub(crate) fn is_reserved_auth_table(table: &str) -> bool {
@@ -1426,6 +1434,7 @@ fn jwks(store: &Store, cache: &SharedSchemaCache) -> (u16, &'static str, String)
         order_by: None,
         limit: Some(100),
         offset: None,
+        decrypt_authorized: true,
     };
     match tables::table_select(store, cache, &plan, Instant::now()) {
         Ok(SelectResult::Rows(rows)) => {
@@ -1462,6 +1471,7 @@ fn admin_list_users(store: &Store, cache: &SharedSchemaCache) -> (u16, &'static 
         order_by: None,
         limit: Some(1000),
         offset: None,
+        decrypt_authorized: true,
     };
     match tables::table_select(store, cache, &plan, Instant::now()) {
         Ok(SelectResult::Rows(rows)) => {
@@ -1790,6 +1800,7 @@ fn admin_list_providers(store: &Store, cache: &SharedSchemaCache) -> (u16, &'sta
         order_by: None,
         limit: Some(100),
         offset: None,
+        decrypt_authorized: true,
     };
     match tables::table_select(store, cache, &plan, Instant::now()) {
         Ok(SelectResult::Rows(rows)) => {
@@ -2481,6 +2492,7 @@ fn admin_list_keys(store: &Store, cache: &SharedSchemaCache) -> (u16, &'static s
         order_by: None,
         limit: Some(1000),
         offset: None,
+        decrypt_authorized: true,
     };
     match tables::table_select(store, cache, &plan, Instant::now()) {
         Ok(SelectResult::Rows(rows)) => {
@@ -2819,6 +2831,14 @@ fn sign_access_token(
 ) -> Result<String, String> {
     let now = unix_seconds();
     let exp = now + store.config().auth.access_token_ttl.as_secs();
+    // Derive is_anonymous from the user's stored app metadata so every mint path
+    // (signin, anonymous, refresh) stamps it consistently without threading a flag.
+    let is_anonymous = find_row_by_field(store, cache, USERS_TABLE, "id", user_id, Instant::now())
+        .ok()
+        .flatten()
+        .as_ref()
+        .map(row_is_anonymous)
+        .unwrap_or(false);
     let claims = AccessClaims {
         iss: store.config().auth.issuer.clone(),
         sub: user_id.to_string(),
@@ -2827,6 +2847,7 @@ fn sign_access_token(
         role: "authenticated".to_string(),
         iat: now as usize,
         exp: exp as usize,
+        is_anonymous,
     };
     let signing_key = active_signing_key(store, cache, Instant::now())?
         .ok_or_else(|| "missing active auth signing key".to_string())?;
@@ -2876,6 +2897,7 @@ pub(crate) fn authenticate_access_token(
         email: claims.email,
         session_id: claims.session_id,
         role: claims.role,
+        is_anonymous: claims.is_anonymous,
     })
 }
 
@@ -4189,9 +4211,18 @@ fn sanitize_header_value(value: &str) -> String {
     value.replace(['\r', '\n'], "")
 }
 
+/// A user is anonymous when their app metadata records the anonymous provider
+/// (set by `signin_anonymous`). Single source of truth for the flag.
+fn row_is_anonymous(row: &HashMap<String, String>) -> bool {
+    parse_json_string(row.get("raw_app_meta_data"))
+        .get("provider")
+        .and_then(Value::as_str)
+        == Some("anonymous")
+}
+
 fn user_map_json(row: &HashMap<String, String>) -> Value {
     let app_metadata = parse_json_string(row.get("raw_app_meta_data"));
-    let is_anonymous = app_metadata.get("provider").and_then(Value::as_str) == Some("anonymous");
+    let is_anonymous = row_is_anonymous(row);
     json!({
         "id": row.get("id").cloned().unwrap_or_default(),
         "email": row.get("email").cloned().unwrap_or_default(),
@@ -4284,6 +4315,7 @@ fn find_row_by_field(
         order_by: None,
         limit: Some(1),
         offset: None,
+        decrypt_authorized: true,
     };
     match tables::table_select(store, cache, &plan, now)? {
         SelectResult::Rows(rows) => Ok(rows
@@ -4957,6 +4989,7 @@ fn find_rows_by_field(
         order_by: None,
         limit: Some(1000),
         offset: None,
+        decrypt_authorized: true,
     };
     match tables::table_select(store, cache, &plan, now)? {
         SelectResult::Rows(rows) => Ok(rows
@@ -5199,7 +5232,23 @@ mod tests {
             email: "u@x.dev".into(),
             session_id: "sess".into(),
             role: "authenticated".into(),
+            is_anonymous: false,
         }
+    }
+
+    #[test]
+    fn row_is_anonymous_detects_provider() {
+        let anon = HashMap::from([(
+            "raw_app_meta_data".to_string(),
+            r#"{"provider":"anonymous"}"#.to_string(),
+        )]);
+        assert!(row_is_anonymous(&anon));
+        let real = HashMap::from([(
+            "raw_app_meta_data".to_string(),
+            r#"{"provider":"email","providers":["email"]}"#.to_string(),
+        )]);
+        assert!(!row_is_anonymous(&real));
+        assert!(!row_is_anonymous(&HashMap::new())); // missing metadata -> not anonymous
     }
 
     fn cond(c: &str, o: &str, v: &str) -> crate::grants::ResolvedCond {

--- a/src/http.rs
+++ b/src/http.rs
@@ -26,6 +26,17 @@ enum HttpAuthContext {
     User(crate::auth::AuthPrincipal),
 }
 
+/// Whether this caller may see decrypted values of ENCRYPTED columns. The
+/// operator and real authenticated users can; anonymous (signInAnonymously)
+/// principals cannot (encrypted columns are omitted from their reads).
+fn decrypt_authorized(ctx: &HttpAuthContext) -> bool {
+    match ctx {
+        HttpAuthContext::Operator => true,
+        HttpAuthContext::User(p) => !p.is_anonymous,
+        HttpAuthContext::Anonymous => false,
+    }
+}
+
 /// Constant-time byte comparison to prevent timing attacks on auth tokens.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
@@ -335,8 +346,11 @@ async fn handle_request(
                 let where_clause = get_param(&params, "where").unwrap_or("");
                 let combined = combine_where(where_clause, filter.as_deref().unwrap_or(""));
                 let scoped = params_with_where(&params, &combined);
-                return stream_table_query(socket, table, &scoped, prefer, store, cache, max_rows)
-                    .await;
+                let da = decrypt_authorized(&auth_context);
+                return stream_table_query(
+                    socket, table, &scoped, prefer, store, cache, max_rows, da,
+                )
+                .await;
             }
             ["v1", "tables", table, "count"] => {
                 let filter = match enforce_table_read(store, cache, &auth_context, table) {
@@ -399,7 +413,13 @@ async fn handle_request(
                 let body = match id.parse::<i64>() {
                     Ok(id_i64) => {
                         match crate::tables::table_get_filtered(
-                            store, cache, table, id_i64, scope, now,
+                            store,
+                            cache,
+                            table,
+                            id_i64,
+                            scope,
+                            now,
+                            decrypt_authorized(&auth_context),
                         ) {
                             // A row that exists but is out of grant scope reads as
                             // not-found, so we don't leak that it exists.
@@ -487,6 +507,7 @@ async fn stream_snapshot(
     Ok(true)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn stream_table_query(
     socket: &mut tokio::net::TcpStream,
     table: &str,
@@ -495,18 +516,20 @@ async fn stream_table_query(
     store: &Arc<Store>,
     cache: &SharedSchemaCache,
     max_rows: Option<usize>,
+    decrypt_authorized: bool,
 ) -> std::io::Result<bool> {
     use tokio::io::AsyncWriteExt;
 
     let now = std::time::Instant::now();
 
-    let (parsed, plan) = match parse_http_table_query(params, table, max_rows) {
+    let (parsed, mut plan) = match parse_http_table_query(params, table, max_rows) {
         Ok(v) => v,
         Err(e) => {
             let body = format!(r#"{{"error":"{}"}}"#, escape_json(&e));
             return send_json(socket, 400, "Bad Request", &body).await;
         }
     };
+    plan.decrypt_authorized = decrypt_authorized;
     let has_where = parsed.has_where;
     let offset = parsed.offset;
     let count_exact = prefer.contains("count=exact");
@@ -1788,7 +1811,11 @@ fn fetch_live_table_rows(
         tokens.push(offset.to_string());
     }
     let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
-    let plan = crate::tables::parse_select(&refs).map_err(|e| live_error("TSELECT_ERROR", &e))?;
+    let mut plan =
+        crate::tables::parse_select(&refs).map_err(|e| live_error("TSELECT_ERROR", &e))?;
+    // Anonymous subscribers get encrypted columns omitted; operator (no principal)
+    // and real users see plaintext. Covers both the initial fetch and change refetch.
+    plan.decrypt_authorized = spec.principal.as_ref().is_none_or(|p| !p.is_anonymous);
     if let Some(err) = crate::auth::reserved_plan_access_error(&plan) {
         return Err(live_error("FORBIDDEN", &err));
     }
@@ -2537,7 +2564,14 @@ fn route_request_with_auth(
             let where_clause = get_param(params, "where").unwrap_or("");
             let combined = combine_where(where_clause, filter.as_deref().unwrap_or(""));
             let scoped = params_with_where(params, &combined);
-            route_table_query(table, &scoped, store, broker, cache)
+            route_table_query(
+                table,
+                &scoped,
+                store,
+                broker,
+                cache,
+                decrypt_authorized(auth),
+            )
         }
         ("GET", ["tables", table, "schema"]) => {
             if let Err(resp) = enforce_table_read(store, cache, auth, table) {
@@ -2885,6 +2919,7 @@ fn route_table_query(
     store: &Arc<Store>,
     _broker: &Broker,
     cache: &SharedSchemaCache,
+    decrypt_authorized: bool,
 ) -> (u16, &'static str, String) {
     if let Some(err) = crate::auth::reserved_table_access_error(table) {
         return (
@@ -2898,14 +2933,17 @@ fn route_table_query(
 
     let cols = render_columns(store, cache, table, now);
     match parse_http_table_query(params, table, None) {
-        Ok((_, plan)) => match crate::tables::table_select(store, cache, &plan, now) {
-            Ok(result) => ok(select_result_to_json(result, &cols)),
-            Err(e) => (
-                400,
-                "Bad Request",
-                format!(r#"{{"error":"{}"}}"#, escape_json(&e)),
-            ),
-        },
+        Ok((_, mut plan)) => {
+            plan.decrypt_authorized = decrypt_authorized;
+            match crate::tables::table_select(store, cache, &plan, now) {
+                Ok(result) => ok(select_result_to_json(result, &cols)),
+                Err(e) => (
+                    400,
+                    "Bad Request",
+                    format!(r#"{{"error":"{}"}}"#, escape_json(&e)),
+                ),
+            }
+        }
         Err(e) => (
             400,
             "Bad Request",
@@ -4082,7 +4120,8 @@ mod tests {
             "where".to_string(),
             "email = person@example.com".to_string(),
         )];
-        let (status, _, queried) = route_table_query("secrets", &params, &store, &broker, &cache);
+        let (status, _, queried) =
+            route_table_query("secrets", &params, &store, &broker, &cache, true);
         assert_eq!(status, 200, "{queried}");
         assert!(
             queried.contains(r#""email":"person@example.com""#),
@@ -4392,11 +4431,16 @@ mod tests {
     }
 
     fn user_ctx(uid: &str) -> HttpAuthContext {
+        user_ctx_kind(uid, false)
+    }
+
+    fn user_ctx_kind(uid: &str, is_anonymous: bool) -> HttpAuthContext {
         HttpAuthContext::User(crate::auth::AuthPrincipal {
             user_id: uid.to_string(),
             email: format!("{uid}@x.dev"),
             session_id: "sess".to_string(),
             role: "authenticated".to_string(),
+            is_anonymous,
         })
     }
 
@@ -4426,7 +4470,8 @@ mod tests {
         let filter = enforce_table_read(&store, &cache, &alice, "messages").unwrap();
         let combined = combine_where("", filter.as_deref().unwrap_or(""));
         let scoped = params_with_where(&[], &combined);
-        let (status, _, body) = route_table_query("messages", &scoped, &store, &broker, &cache);
+        let (status, _, body) =
+            route_table_query("messages", &scoped, &store, &broker, &cache, true);
         assert_eq!(status, 200, "{body}");
         assert!(body.contains("\"a1\"") && body.contains("\"a2\""), "{body}");
         assert!(!body.contains("\"b1\""), "bob's row leaked: {body}");
@@ -4442,7 +4487,8 @@ mod tests {
         let filter = enforce_table_read(&store, &cache, &alice, "messages").unwrap();
         let combined = combine_where("body = a1", filter.as_deref().unwrap_or(""));
         let scoped = params_with_where(&[], &combined);
-        let (status, _, body) = route_table_query("messages", &scoped, &store, &broker, &cache);
+        let (status, _, body) =
+            route_table_query("messages", &scoped, &store, &broker, &cache, true);
         assert_eq!(status, 200, "{body}");
         assert!(body.contains("\"a1\""), "{body}");
         assert!(
@@ -4462,7 +4508,7 @@ mod tests {
         let filter =
             enforce_table_read(&store, &cache, &HttpAuthContext::Operator, "messages").unwrap();
         assert!(filter.is_none());
-        let (status, _, body) = route_table_query("messages", &[], &store, &broker, &cache);
+        let (status, _, body) = route_table_query("messages", &[], &store, &broker, &cache, true);
         assert_eq!(status, 200, "{body}");
         assert!(
             body.contains("\"b1\""),
@@ -4586,7 +4632,7 @@ mod tests {
         let filter = enforce_table_read(store, cache, ctx, "messages").unwrap();
         let combined = combine_where("", filter.as_deref().unwrap_or(""));
         let scoped = params_with_where(&[], &combined);
-        let (status, _, body) = route_table_query("messages", &scoped, store, broker, cache);
+        let (status, _, body) = route_table_query("messages", &scoped, store, broker, cache, true);
         (status, body)
     }
 
@@ -4964,12 +5010,12 @@ mod tests {
 
         // id=1 is alice's -> visible; id=3 is bob's -> reads as not-found.
         assert!(
-            crate::tables::table_get_filtered(&store, &cache, "messages", 1, scope, now)
+            crate::tables::table_get_filtered(&store, &cache, "messages", 1, scope, now, true)
                 .unwrap()
                 .is_some()
         );
         assert!(
-            crate::tables::table_get_filtered(&store, &cache, "messages", 3, scope, now)
+            crate::tables::table_get_filtered(&store, &cache, "messages", 3, scope, now, true)
                 .unwrap()
                 .is_none()
         );

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -427,6 +427,12 @@ pub struct SelectPlan {
     // LIMIT / OFFSET
     pub limit: Option<usize>,
     pub offset: Option<usize>,
+
+    // Whether the caller may see decrypted values of ENCRYPTED columns. True for
+    // the operator/secret key and real authenticated users; false for anonymous
+    // (signInAnonymously) principals, who get NULL for encrypted columns. Set by
+    // the HTTP auth boundary; defaults true for internal/RESP/operator queries.
+    pub decrypt_authorized: bool,
 }
 
 fn schema_key(table: &str) -> String {
@@ -1711,7 +1717,7 @@ pub fn table_create_path_index(
     };
     let synthetic = synthetic_path_fielddef(&pi);
     for pk_str in get_all_row_ids(store, table, now) {
-        let Some(row) = get_row(store, table, &schema, &pk_str, now) else {
+        let Some(row) = get_row(store, table, &schema, &pk_str, now, true) else {
             continue;
         };
         if let Some(raw) = row.iter().find(|(k, _)| k == root).map(|(_, v)| v.as_str()) {
@@ -1739,7 +1745,7 @@ pub fn table_drop_path_index(
     let (root, rest) = path.split_once('.').unwrap_or((path, ""));
     let synthetic = synthetic_path_fielddef(pi);
     for pk_str in get_all_row_ids(store, table, now) {
-        let Some(row) = get_row(store, table, &schema, &pk_str, now) else {
+        let Some(row) = get_row(store, table, &schema, &pk_str, now, true) else {
             continue;
         };
         if let Some(raw) = row.iter().find(|(k, _)| k == root).map(|(_, v)| v.as_str()) {
@@ -1948,7 +1954,7 @@ fn find_row_by_fields(
     now: Instant,
 ) -> Option<String> {
     for pk_str in get_all_row_ids(store, table, now) {
-        let Some(row) = get_row(store, table, schema, &pk_str, now) else {
+        let Some(row) = get_row(store, table, schema, &pk_str, now, true) else {
             continue;
         };
         if fields
@@ -2254,7 +2260,7 @@ pub fn table_insert_returning_ttl(
 ) -> Result<Vec<(String, String)>, String> {
     let schema = load_schema(store, cache, table, now)?;
     let pk_str = table_insert_pk(store, cache, table, field_values, ttl, now)?;
-    let mut row = get_row(store, table, &schema, &pk_str, now)
+    let mut row = get_row(store, table, &schema, &pk_str, now, true)
         .ok_or_else(|| format!("ERR inserted row not found in table '{}'", table))?;
     row.sort_by(|a, b| a.0.cmp(&b.0));
     Ok(row)
@@ -2415,7 +2421,7 @@ pub fn table_upsert_returning_ttl(
             if !updates.is_empty() {
                 table_update_by_pk_str(store, cache, table, &pk, &updates, ttl, now)?;
             }
-            let mut row = get_row(store, table, &schema, &pk, now)
+            let mut row = get_row(store, table, &schema, &pk, now, true)
                 .ok_or_else(|| format!("ERR upserted row not found in table '{}'", table))?;
             row.sort_by(|a, b| a.0.cmp(&b.0));
             Ok(row)
@@ -2819,7 +2825,9 @@ pub fn table_get(
 ) -> Result<Vec<(String, String)>, String> {
     let schema = load_schema(store, cache, table, now)?;
     let pk_str = id.to_string();
-    let row = get_row(store, table, &schema, &pk_str, now)
+    // Direct by-id fetch is the operator/full-access path; gated by-id reads go
+    // through table_get_filtered -> table_select with the plan's decrypt flag.
+    let row = get_row(store, table, &schema, &pk_str, now, true)
         .ok_or_else(|| format!("ERR row {} not found in table '{}'", id, table))?;
     let mut result = row;
     result.sort_by(|a, b| a.0.cmp(&b.0));
@@ -2860,7 +2868,7 @@ fn table_update_by_pk_str(
     let schema = load_schema(store, cache, table, now)?;
     let rk = row_key_for_pk(table, pk_str);
 
-    let old_row = get_row(store, table, &schema, pk_str, now)
+    let old_row = get_row(store, table, &schema, pk_str, now, true)
         .ok_or_else(|| format!("ERR row '{}' not found in table '{}'", pk_str, table))?;
 
     let old_map: std::collections::HashMap<String, String> = old_row.into_iter().collect();
@@ -3464,7 +3472,7 @@ pub fn table_update_where_returning_ttl(
 ) -> Result<Vec<Vec<(String, String)>>, String> {
     let (schema, pks) =
         table_update_where_pks(store, cache, table, field_values, where_args, ttl, now)?;
-    Ok(rows_for_pks(store, table, &schema, &pks, now))
+    Ok(rows_for_pks(store, table, &schema, &pks, now, true))
 }
 
 /// Apply an UPDATE, returning (schema, primary keys of the updated rows).
@@ -3523,7 +3531,7 @@ pub fn table_delete_where_returning(
 ) -> Result<Vec<Vec<(String, String)>>, String> {
     let conditions = parse_where_conditions(where_args)?;
     let (schema, matched) = scan_matching_pks(store, cache, table, &conditions, now)?;
-    let rows = rows_for_pks(store, table, &schema, &matched, now);
+    let rows = rows_for_pks(store, table, &schema, &matched, now, true);
     for pk_str in &matched {
         table_delete_inner(store, cache, table, pk_str, now, 0)?;
     }
@@ -3565,7 +3573,7 @@ pub fn table_drop(
             .iter()
             .any(|field| matches!(field.field_type, FieldType::Vector(_)))
         {
-            if let Some(row) = get_row(store, table, &schema, pk_str, now) {
+            if let Some(row) = get_row(store, table, &schema, pk_str, now, true) {
                 for field in &schema {
                     if let Some((_, value)) = row.iter().find(|(k, _)| k == &field.name) {
                         remove_from_index(store, table, field, value, pk_str, now);
@@ -3682,9 +3690,12 @@ pub fn table_get_filtered(
     id: i64,
     filter: &str,
     now: Instant,
+    decrypt_authorized: bool,
 ) -> Result<Option<Vec<(String, String)>>, String> {
-    // No filter (operator / unconditional grant): direct PK fetch, no plan.
-    if filter.trim().is_empty() {
+    // Full-access with no row filter: direct PK fetch, no plan. When the caller
+    // isn't decrypt-authorized we fall through to the plan path so encrypted
+    // columns get gated even on an unconditional grant.
+    if filter.trim().is_empty() && decrypt_authorized {
         return match table_get(store, cache, table, id, now) {
             Ok(row) => Ok(Some(row)),
             Err(e) if e.contains("not found") => Ok(None),
@@ -3711,7 +3722,8 @@ pub fn table_get_filtered(
         toks.extend(filter.split_whitespace().map(ToString::to_string));
     }
     let refs: Vec<&str> = toks.iter().map(|s| s.as_str()).collect();
-    let plan = parse_select(&refs)?;
+    let mut plan = parse_select(&refs)?;
+    plan.decrypt_authorized = decrypt_authorized;
     match table_select(store, cache, &plan, now)? {
         SelectResult::Rows(mut rows) => Ok(rows.drain(..).next()),
         SelectResult::Aggregate(_) => Ok(None),
@@ -4065,6 +4077,7 @@ mod tests {
             &load_schema(&store, &cache, "secrets", now).unwrap(),
             id,
             now,
+            true,
         )
         .unwrap();
         assert_eq!(
@@ -4085,6 +4098,74 @@ mod tests {
         let rows = rows_of(table_select(&store, &cache, &plan, now).unwrap());
         assert_eq!(rows.len(), 1);
         assert_eq!(cell(&rows[0], "token"), "topsecret");
+    }
+
+    #[test]
+    fn unauthorized_reads_omit_encrypted_columns() {
+        let store = encrypted_store();
+        let cache = make_cache();
+        let now = now();
+        table_create(
+            &store,
+            &cache,
+            "secrets",
+            &["id UUID PRIMARY KEY, token STR ENCRYPTED, email STR UNIQUE ENCRYPTED SEARCHABLE, plan STR"],
+            now,
+        )
+        .unwrap();
+        let id = "018f9d72-7c8d-7000-8000-000000000001";
+        table_insert(
+            &store,
+            &cache,
+            "secrets",
+            &[
+                ("id", id),
+                ("token", "topsecret"),
+                ("email", "a@example.com"),
+                ("plan", "pro"),
+            ],
+            now,
+        )
+        .unwrap();
+
+        let has = |rows: &[Vec<(String, String)>], col: &str| rows[0].iter().any(|(k, _)| k == col);
+
+        // Authorized: encrypted columns decrypt and come back.
+        let mut plan = parse_select(&["*", "FROM", "secrets"]).unwrap();
+        plan.decrypt_authorized = true;
+        let rows = rows_of(table_select(&store, &cache, &plan, now).unwrap());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(cell(&rows[0], "token"), "topsecret");
+        assert_eq!(cell(&rows[0], "email"), "a@example.com");
+
+        // Unauthorized (anonymous): encrypted columns are omitted, plaintext ones stay.
+        plan.decrypt_authorized = false;
+        let rows = rows_of(table_select(&store, &cache, &plan, now).unwrap());
+        assert_eq!(rows.len(), 1);
+        assert!(!has(&rows, "token"), "encrypted token must be omitted");
+        assert!(!has(&rows, "email"), "encrypted email must be omitted");
+        assert!(has(&rows, "id"), "primary key stays");
+        assert_eq!(cell(&rows[0], "plan"), "pro"); // non-encrypted column stays
+
+        // Searchable equality on the encrypted column still matches (blind index),
+        // but the value is still withheld from an unauthorized caller.
+        let mut plan = parse_select(&[
+            "*",
+            "FROM",
+            "secrets",
+            "WHERE",
+            "email",
+            "=",
+            "a@example.com",
+        ])
+        .unwrap();
+        plan.decrypt_authorized = false;
+        let rows = rows_of(table_select(&store, &cache, &plan, now).unwrap());
+        assert_eq!(rows.len(), 1, "blind-index filter still matches");
+        assert!(
+            !has(&rows, "email"),
+            "matched row still withholds the encrypted value"
+        );
     }
 
     #[test]
@@ -4498,6 +4579,7 @@ mod tests {
             &load_schema(&store, &cache, "secrets", now).unwrap(),
             id,
             now,
+            true,
         )
         .unwrap();
         assert_eq!(cell(&row, "note"), "matched");
@@ -4517,6 +4599,7 @@ mod tests {
             &load_schema(&store, &cache, "secrets", now).unwrap(),
             id,
             now,
+            true,
         )
         .is_none());
     }
@@ -4810,6 +4893,7 @@ mod tests {
             &load_schema(&store, &cache, "profiles", now).unwrap(),
             id,
             now,
+            true,
         )
         .unwrap();
         assert_eq!(cell(&row, "name"), "Ada");
@@ -4937,6 +5021,7 @@ mod tests {
             &load_schema(&store, &cache, "secrets", now).unwrap(),
             "s1",
             now,
+            true,
         )
         .is_none());
     }
@@ -5081,6 +5166,7 @@ mod tests {
             &load_schema(&restored, &restored_cache, "secrets", now).unwrap(),
             id,
             now,
+            true,
         )
         .unwrap();
         assert_eq!(cell(&row, "token"), "snapshot-topsecret");
@@ -5168,6 +5254,7 @@ mod tests {
             &load_schema(&restored, &restored_cache, "secrets", now).unwrap(),
             id,
             now,
+            true,
         )
         .unwrap();
         assert_eq!(cell(&row, "token"), "wal-newsecret");
@@ -5319,6 +5406,7 @@ mod tests {
             &load_schema(&restored, &restored_cache, "secrets", now).unwrap(),
             id,
             now,
+            true,
         )
         .unwrap();
         assert_eq!(cell(&row, "token"), "ttl-cleared");

--- a/src/tables/select.rs
+++ b/src/tables/select.rs
@@ -10,12 +10,13 @@ pub(crate) fn get_row(
     schema: &[FieldDef],
     pk_str: &str,
     now: Instant,
+    decrypt_authorized: bool,
 ) -> Option<Vec<(String, String)>> {
     // Build a lookup map on the fly - only called from paths that don't have a pre-built map.
     // Hot paths (table_select) use get_row_with_map directly.
     let field_map: hashbrown::HashMap<&str, &FieldDef> =
         schema.iter().map(|f| (f.name.as_str(), f)).collect();
-    get_row_with_map(store, table, &field_map, pk_str, now)
+    get_row_with_map(store, table, &field_map, pk_str, now, decrypt_authorized)
 }
 
 /// Like `get_row`, but returns the row even when its TTL has expired. The
@@ -30,10 +31,13 @@ pub(crate) fn get_row_including_expired(
 ) -> Option<Vec<(String, String)>> {
     let field_map: hashbrown::HashMap<&str, &FieldDef> =
         schema.iter().map(|f| (f.name.as_str(), f)).collect();
-    get_row_with_map_impl(store, table, &field_map, pk_str, now, true)
+    // Expired-row reads are for internal index cleanup on the delete path, which
+    // always needs plaintext.
+    get_row_with_map_impl(store, table, &field_map, pk_str, now, true, true)
 }
 
 /// Hot-path row fetch: takes a pre-built field-type map to avoid O(N) schema scan per field.
+/// `decrypt_authorized` false omits ENCRYPTED columns from the result (anonymous principals).
 #[inline]
 pub(crate) fn get_row_with_map(
     store: &Store,
@@ -41,8 +45,17 @@ pub(crate) fn get_row_with_map(
     field_map: &hashbrown::HashMap<&str, &FieldDef>,
     pk_str: &str,
     now: Instant,
+    decrypt_authorized: bool,
 ) -> Option<Vec<(String, String)>> {
-    get_row_with_map_impl(store, table, field_map, pk_str, now, false)
+    get_row_with_map_impl(
+        store,
+        table,
+        field_map,
+        pk_str,
+        now,
+        false,
+        decrypt_authorized,
+    )
 }
 
 #[inline]
@@ -53,6 +66,7 @@ fn get_row_with_map_impl(
     pk_str: &str,
     now: Instant,
     include_expired: bool,
+    decrypt_authorized: bool,
 ) -> Option<Vec<(String, String)>> {
     let rk = row_key_for_pk(table, pk_str);
     let pairs = store.hgetall(rk.as_bytes(), now).unwrap_or_default();
@@ -79,6 +93,9 @@ fn get_row_with_map_impl(
             continue; // never expose the hidden TTL field
         }
         let decoded = match field_map.get(k.as_str()) {
+            // Grant-gated decryption: an unauthorized (anonymous) principal never
+            // sees an encrypted column's value — omit it from the row entirely.
+            Some(field) if field.encrypted && !decrypt_authorized => continue,
             Some(field) => match decode_stored_value(store, table, field, pk_str, &v) {
                 Ok(decoded) => decoded,
                 Err(_) => return None,
@@ -905,6 +922,9 @@ pub fn parse_select(args: &[&str]) -> Result<SelectPlan, String> {
         order_by,
         limit,
         offset,
+        // Default: full decryption. The HTTP auth boundary lowers this to false
+        // for anonymous principals after parsing; RESP/internal callers stay true.
+        decrypt_authorized: true,
     })
 }
 
@@ -1206,7 +1226,10 @@ pub fn table_select(
     let near_candidate_pks = if plan.near.is_some() && !conditions.is_empty() {
         let mut candidates = HashSet::new();
         for pk_str in &scan.row_ids {
-            let Some(row) = get_row_with_map(store, &plan.table, &field_map, pk_str, now) else {
+            // Candidate pre-filter for NEAR: decode fully so WHERE evaluation is
+            // correct; the gated projection happens at the row-emit site below.
+            let Some(row) = get_row_with_map(store, &plan.table, &field_map, pk_str, now, true)
+            else {
                 continue;
             };
             if row_matches_base_conditions(&row, &schema, implicit_id_field.as_ref(), &conditions) {
@@ -1266,7 +1289,14 @@ pub fn table_select(
         ) {
             return None;
         }
-        let mut row = get_row_with_map(store, &plan.table, &field_map, &pk_str, now)?;
+        let mut row = get_row_with_map(
+            store,
+            &plan.table,
+            &field_map,
+            &pk_str,
+            now,
+            plan.decrypt_authorized,
+        )?;
         if let Some(similarity) = vector_similarity
             .as_ref()
             .and_then(|scores| scores.get(&pk_str))
@@ -1327,7 +1357,16 @@ pub fn table_select(
     // ---- Hash Joins ----
     for join in &plan.joins {
         // Pass the limit so the join can stop early once satisfied
-        rows = hash_join(store, cache, rows, join, plan.limit, plan.offset, now)?;
+        rows = hash_join(
+            store,
+            cache,
+            rows,
+            join,
+            plan.limit,
+            plan.offset,
+            now,
+            plan.decrypt_authorized,
+        )?;
     }
 
     // ---- Post-join WHERE filter (for conditions referencing join columns) ----
@@ -1969,6 +2008,7 @@ pub(crate) fn candidates_from_order_index(
 ///
 /// Builds an in-memory HashMap of the right table keyed on the join column,
 /// then iterates the left rows performing O(1) lookups.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn hash_join(
     store: &Store,
     cache: &SharedSchemaCache,
@@ -1977,6 +2017,7 @@ pub(crate) fn hash_join(
     limit: Option<usize>,
     offset: Option<usize>,
     now: Instant,
+    decrypt_authorized: bool,
 ) -> Result<Vec<Vec<(String, String)>>, String> {
     let right_schema = load_schema(store, cache, &join.table, now)?;
     let right_alias = &join.alias;
@@ -1990,7 +2031,14 @@ pub(crate) fn hash_join(
         hashbrown::HashMap::with_capacity(right_ids.len());
 
     for pk_str in right_ids {
-        if let Some(row) = get_row(store, &join.table, &right_schema, &pk_str, now) {
+        if let Some(row) = get_row(
+            store,
+            &join.table,
+            &right_schema,
+            &pk_str,
+            now,
+            decrypt_authorized,
+        ) {
             let key_val = row
                 .iter()
                 .find(|(k, _)| k == &right_key)
@@ -2790,7 +2838,8 @@ pub(crate) fn scan_matching_pks(
 
     let mut matched = Vec::new();
     for pk_str in row_ids {
-        let Some(row) = get_row(store, table, &schema, &pk_str, now) else {
+        // Internal WHERE re-check: needs plaintext regardless of caller.
+        let Some(row) = get_row(store, table, &schema, &pk_str, now, true) else {
             continue;
         };
         if row_matches_base_conditions(&row, &schema, implicit_id.as_ref(), conditions) {
@@ -2828,10 +2877,11 @@ pub(crate) fn rows_for_pks(
     schema: &[FieldDef],
     pks: &[String],
     now: Instant,
+    decrypt_authorized: bool,
 ) -> Vec<Vec<(String, String)>> {
     pks.iter()
         .filter_map(|pk| {
-            get_row(store, table, schema, pk, now).map(|mut r| {
+            get_row(store, table, schema, pk, now, decrypt_authorized).map(|mut r| {
                 r.sort_by(|a, b| a.0.cmp(&b.0));
                 r
             })
@@ -2880,7 +2930,8 @@ pub(crate) fn scan_projected_column(
             // The pk *is* the projected value (it may not be a stored field).
             Some(pk.clone())
         } else {
-            get_row(store, table, &schema, pk, now).and_then(|row| {
+            // Internal grant-subquery membership resolution: needs plaintext.
+            get_row(store, table, &schema, pk, now, true).and_then(|row| {
                 row.into_iter()
                     .find(|(k, _)| k == projected)
                     .map(|(_, v)| v)

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -465,6 +465,92 @@ fn http_auth_anonymous_signin_issues_session() {
 }
 
 #[test]
+fn http_encrypted_columns_hidden_from_anonymous_users() {
+    // Grant-gated decryption end to end: an ENCRYPTED column decrypts for the
+    // operator and real authenticated users, but is omitted for anonymous
+    // (signInAnonymously) callers — even though both carry role "authenticated".
+    let server = LuxServer::builder()
+        .http()
+        .password("rootsecret")
+        .env("LUX_AUTH_ENABLED", "true")
+        .env("LUX_ENC_AUTO_INIT", "1")
+        .start();
+    let http = server.http_port();
+
+    // Operator (RESP): encrypted column + a plaintext column, one row, and an
+    // unconditional read grant so authenticated users can read the table.
+    let mut op = server.conn();
+    let mut run = |args: &[&str]| {
+        op.write_all(&resp_cmd(args)).unwrap();
+        read_all(&mut op)
+    };
+    assert!(run(&["AUTH", "rootsecret"]).contains("+OK"));
+    let created = run(&[
+        "TCREATE",
+        "secrets",
+        "id",
+        "UUID",
+        "PRIMARY",
+        "KEY",
+        ",",
+        "ssn",
+        "STR",
+        "ENCRYPTED",
+        ",",
+        "name",
+        "STR",
+    ]);
+    assert!(created.contains("+OK"), "TCREATE: {created}");
+    run(&["TINSERT", "secrets", "ssn", "123-45-6789", "name", "Alice"]);
+    let granted = run(&["GRANT", "read", "ON", "secrets"]);
+    assert!(!granted.contains("-ERR"), "GRANT: {granted}");
+
+    // Anonymous + real-user tokens.
+    let (s, b) = http_request(http, "POST", "/auth/v1/signin/anonymous", Some("{}"), None);
+    assert_eq!(s, 200, "anon signin: {b}");
+    let anon_tok = serde_json::from_str::<serde_json::Value>(&b).unwrap()["access_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let (s, b) = http_request(
+        http,
+        "POST",
+        "/auth/v1/signup",
+        Some(r#"{"email":"real@example.com","password":"password123"}"#),
+        None,
+    );
+    assert_eq!(s, 200, "signup: {b}");
+    let real_tok = serde_json::from_str::<serde_json::Value>(&b).unwrap()["access_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Operator and real user both see the decrypted ssn.
+    let (_, op_body) = http_request(http, "GET", "/v1/tables/secrets", None, Some("rootsecret"));
+    assert!(
+        op_body.contains("123-45-6789"),
+        "operator must see ssn: {op_body}"
+    );
+    let (_, real_body) = http_request(http, "GET", "/v1/tables/secrets", None, Some(&real_tok));
+    assert!(
+        real_body.contains("123-45-6789"),
+        "real user must see ssn: {real_body}"
+    );
+
+    // Anonymous user: the row is visible (plaintext name) but the encrypted ssn
+    // is withheld.
+    let (_, anon_body) = http_request(http, "GET", "/v1/tables/secrets", None, Some(&anon_tok));
+    assert!(
+        anon_body.contains("Alice"),
+        "anon should see the row: {anon_body}"
+    );
+    assert!(
+        !anon_body.contains("123-45-6789"),
+        "anon must NOT see encrypted ssn: {anon_body}"
+    );
+}
+
+#[test]
 fn http_auth_anonymous_signin_can_be_disabled() {
     let server = LuxServer::builder()
         .http()


### PR DESCRIPTION
Encrypted columns become field-level access-controlled: they decrypt only for the operator/secret key and real authenticated users. Anonymous (`signInAnonymously`) callers get the encrypted column **omitted** from reads; the secret key and real users see plaintext.

## How
- `is_anonymous` flows from the access token into `AuthPrincipal` (derived from the user's `app_metadata.provider == "anonymous"`; `serde(default)` so tokens minted before this decode as non-anonymous).
- A `decrypt_authorized` flag rides on `SelectPlan` (and a param on `table_get_filtered`) and threads to the single decode choke point (`get_row_with_map_impl`): unauthorized principals get the encrypted column omitted from the row.
- Wired at every HTTP read: table GET / query / by-id / `.live()`. RESP (operator) and internal/write paths stay full-decrypt.
- Blind-index equality search still matches rows for anonymous callers; only the column value is withheld.

## Notes
- Authorization-gated, not per-user crypto: the engine holds the keyring and can decrypt; it refuses to return plaintext to anonymous callers.
- Follow-up: RETURNING on writes for an anonymous principal still echoes encrypted values (write paths don't yet thread the principal) — edge case, no encrypted-column write users today.

## Tests
Engine gating (authorized decrypts, anonymous omits, searchable-still-matches) + anonymous-detection unit. Full suite 904 pass, clippy clean.