### PR TITLE
feat(enc): encrypt list elements and stream field values

### DIFF
--- a/src/cmd/encryption.rs
+++ b/src/cmd/encryption.rs
@@ -88,6 +88,12 @@ pub fn cmd_enc(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
     if cmd_eq(args[1], b"RAWHSET") {
         return cmd_rawhset(args, store, out, now);
     }
+    if cmd_eq(args[1], b"RAWLPUSH") {
+        return cmd_rawlpush(args, store, out, now, true);
+    }
+    if cmd_eq(args[1], b"RAWRPUSH") {
+        return cmd_rawlpush(args, store, out, now, false);
+    }
     resp::write_error(out, "ERR unknown ENC subcommand");
     CmdResult::Written
 }
@@ -153,6 +159,31 @@ fn cmd_rawhset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
     }
     let pairs: Vec<(&[u8], &[u8])> = args[3..].chunks(2).map(|c| (c[0], c[1])).collect();
     match store.hset(args[2], &pairs, now) {
+        Ok(_) => resp::write_ok(out),
+        Err(err) => resp::write_error(out, &err),
+    }
+    CmdResult::Written
+}
+
+/// Replay form of an encrypted LPUSH/RPUSH: stores the already-sealed envelope
+/// elements verbatim (no re-encryption). `front` selects LPUSH vs RPUSH.
+fn cmd_rawlpush(
+    args: &[&[u8]],
+    store: &Store,
+    out: &mut BytesMut,
+    now: Instant,
+    front: bool,
+) -> CmdResult {
+    if args.len() < 4 {
+        resp::write_error(out, "ERR usage: ENC RAWLPUSH|RAWRPUSH <key> <element> ...");
+        return CmdResult::Written;
+    }
+    let res = if front {
+        store.lpush(args[2], &args[3..], now)
+    } else {
+        store.rpush(args[2], &args[3..], now)
+    };
+    match res {
         Ok(_) => resp::write_ok(out),
         Err(err) => resp::write_error(out, &err),
     }

--- a/src/cmd/lists.rs
+++ b/src/cmd/lists.rs
@@ -56,25 +56,78 @@ fn parse_block_timeout(arg: &[u8], out: &mut BytesMut) -> Option<Duration> {
     }
 }
 
-pub fn cmd_lpush(
+/// Decrypt a list element for output, passing plaintext (and, defensively, any
+/// value we cannot decrypt) through unchanged.
+fn decrypt_out(store: &Store, raw: Bytes) -> Bytes {
+    store.decrypt_list_element(raw.clone()).unwrap_or(raw)
+}
+
+/// Shared LPUSH/RPUSH body. Supports a trailing `ENCRYPTED` flag (mirrors
+/// `SET ... ENCRYPTED`): each pushed element is sealed as an envelope and the
+/// resolved ciphertext is self-logged to the WAL as `ENC RAWLPUSH/RAWRPUSH` so
+/// replay is deterministic (envelopes carry random nonces).
+fn push_list(
     args: &[&[u8]],
     store: &Store,
-    _broker: &Broker,
+    broker: &Broker,
     out: &mut BytesMut,
     now: Instant,
+    front: bool,
 ) -> CmdResult {
-    if args.len() < 3 {
-        resp::write_error(out, "ERR wrong number of arguments for 'lpush' command");
+    let name = if front { "lpush" } else { "rpush" };
+    let encrypted = args.last().is_some_and(|a| cmd_eq(a, b"ENCRYPTED"));
+    let end = if encrypted {
+        args.len() - 1
+    } else {
+        args.len()
+    };
+    if end < 3 {
+        resp::write_error(
+            out,
+            &format!("ERR wrong number of arguments for '{name}' command"),
+        );
         return CmdResult::Written;
     }
-    match store.lpush(args[1], &args[2..], now) {
+    let stored: Vec<Vec<u8>> = if encrypted {
+        match args[2..end]
+            .iter()
+            .map(|v| store.encrypt_list_element(v))
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(s) => s,
+            Err(e) => {
+                resp::write_error(out, &e);
+                return CmdResult::Written;
+            }
+        }
+    } else {
+        args[2..end].iter().map(|v| v.to_vec()).collect()
+    };
+    let refs: Vec<&[u8]> = stored.iter().map(Vec::as_slice).collect();
+    let res = if front {
+        store.lpush(args[1], &refs, now)
+    } else {
+        store.rpush(args[1], &refs, now)
+    };
+    match res {
         Ok(n) => {
+            if encrypted && store.wal_enabled() {
+                let raw_cmd: &[u8] = if front { b"RAWLPUSH" } else { b"RAWRPUSH" };
+                let mut owned: Vec<Vec<u8>> =
+                    vec![b"ENC".to_vec(), raw_cmd.to_vec(), args[1].to_vec()];
+                owned.extend(stored.iter().cloned());
+                let log_refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+                if let Err(e) = store.wal_log_command(&log_refs) {
+                    resp::write_error(out, &format!("ERR WAL append failed: {e}"));
+                    return CmdResult::Written;
+                }
+            }
             resp::write_integer(out, n);
             let key_s = arg_str(args[1]);
-            if _broker.has_list_waiters(key_s) {
+            if broker.has_list_waiters(key_s) {
                 let shard_idx = store.shard_for_key(args[1]);
                 let mut shard = store.lock_write_shard(shard_idx);
-                _broker.drain_list_waiters(key_s, &mut shard.data, now);
+                broker.drain_list_waiters(key_s, &mut shard.data, store, now);
             }
         }
         Err(e) => resp::write_error(out, &e),
@@ -82,10 +135,24 @@ pub fn cmd_lpush(
     CmdResult::Written
 }
 
+pub fn cmd_lpush(
+    args: &[&[u8]],
+    store: &Store,
+    broker: &Broker,
+    out: &mut BytesMut,
+    now: Instant,
+) -> CmdResult {
+    if args.len() < 3 {
+        resp::write_error(out, "ERR wrong number of arguments for 'lpush' command");
+        return CmdResult::Written;
+    }
+    push_list(args, store, broker, out, now, true)
+}
+
 pub fn cmd_rpush(
     args: &[&[u8]],
     store: &Store,
-    _broker: &Broker,
+    broker: &Broker,
     out: &mut BytesMut,
     now: Instant,
 ) -> CmdResult {
@@ -93,19 +160,7 @@ pub fn cmd_rpush(
         resp::write_error(out, "ERR wrong number of arguments for 'rpush' command");
         return CmdResult::Written;
     }
-    match store.rpush(args[1], &args[2..], now) {
-        Ok(n) => {
-            resp::write_integer(out, n);
-            let key_s = arg_str(args[1]);
-            if _broker.has_list_waiters(key_s) {
-                let shard_idx = store.shard_for_key(args[1]);
-                let mut shard = store.lock_write_shard(shard_idx);
-                _broker.drain_list_waiters(key_s, &mut shard.data, now);
-            }
-        }
-        Err(e) => resp::write_error(out, &e),
-    }
-    CmdResult::Written
+    push_list(args, store, broker, out, now, false)
 }
 
 pub fn cmd_lpushx(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
@@ -157,7 +212,7 @@ pub fn cmd_lpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
                         let items: Vec<Bytes> = (0..n).filter_map(|_| list.pop_front()).collect();
                         resp::write_array_header(out, items.len());
                         for item in &items {
-                            resp::write_bulk_raw(out, item);
+                            resp::write_bulk_raw(out, &decrypt_out(store, item.clone()));
                         }
                     }
                 } else {
@@ -170,7 +225,10 @@ pub fn cmd_lpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
             _ => resp::write_null_array(out),
         }
     } else {
-        resp::write_optional_bulk_raw(out, &store.lpop(args[1], now));
+        resp::write_optional_bulk_raw(
+            out,
+            &store.lpop(args[1], now).map(|b| decrypt_out(store, b)),
+        );
     }
     CmdResult::Written
 }
@@ -206,7 +264,7 @@ pub fn cmd_rpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
                         let items: Vec<Bytes> = (0..n).filter_map(|_| list.pop_back()).collect();
                         resp::write_array_header(out, items.len());
                         for item in &items {
-                            resp::write_bulk_raw(out, item);
+                            resp::write_bulk_raw(out, &decrypt_out(store, item.clone()));
                         }
                     }
                 } else {
@@ -219,7 +277,10 @@ pub fn cmd_rpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
             _ => resp::write_null_array(out),
         }
     } else {
-        resp::write_optional_bulk_raw(out, &store.rpop(args[1], now));
+        resp::write_optional_bulk_raw(
+            out,
+            &store.rpop(args[1], now).map(|b| decrypt_out(store, b)),
+        );
     }
     CmdResult::Written
 }
@@ -250,7 +311,10 @@ pub fn cmd_lrange(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         None => return CmdResult::Written,
     };
     match store.lrange(args[1], start, stop, now) {
-        Ok(items) => resp::write_bulk_array_raw(out, &items),
+        Ok(items) => {
+            let dec: Vec<Bytes> = items.into_iter().map(|b| decrypt_out(store, b)).collect();
+            resp::write_bulk_array_raw(out, &dec);
+        }
         Err(e) => resp::write_error(out, &e),
     }
     CmdResult::Written
@@ -265,7 +329,12 @@ pub fn cmd_lindex(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         Some(n) => n,
         None => return CmdResult::Written,
     };
-    resp::write_optional_bulk_raw(out, &store.lindex(args[1], index, now));
+    resp::write_optional_bulk_raw(
+        out,
+        &store
+            .lindex(args[1], index, now)
+            .map(|b| decrypt_out(store, b)),
+    );
     CmdResult::Written
 }
 
@@ -479,7 +548,12 @@ pub fn cmd_lmove(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         Some(side) => side,
         None => return CmdResult::Written,
     };
-    resp::write_optional_bulk_raw(out, &store.lmove(args[1], args[2], src_left, dst_left, now));
+    resp::write_optional_bulk_raw(
+        out,
+        &store
+            .lmove(args[1], args[2], src_left, dst_left, now)
+            .map(|b| decrypt_out(store, b)),
+    );
     CmdResult::Written
 }
 
@@ -488,7 +562,12 @@ pub fn cmd_rpoplpush(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Ins
         resp::write_error(out, "ERR wrong number of arguments for 'rpoplpush' command");
         return CmdResult::Written;
     }
-    resp::write_optional_bulk_raw(out, &store.lmove(args[1], args[2], false, true, now));
+    resp::write_optional_bulk_raw(
+        out,
+        &store
+            .lmove(args[1], args[2], false, true, now)
+            .map(|b| decrypt_out(store, b)),
+    );
     CmdResult::Written
 }
 
@@ -522,7 +601,7 @@ pub fn cmd_blpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         if let Some(v) = val {
             resp::write_array_header(out, 2);
             resp::write_bulk(out, key);
-            resp::write_bulk_raw(out, &v);
+            resp::write_bulk_raw(out, &decrypt_out(store, v));
             return CmdResult::Written;
         }
     }
@@ -555,7 +634,7 @@ pub fn cmd_blmove(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
     };
 
     if let Some(v) = store.lmove(args[1], args[2], src_left, dst_left, now) {
-        resp::write_bulk_raw(out, &v);
+        resp::write_bulk_raw(out, &decrypt_out(store, v));
         return CmdResult::Written;
     }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -3852,6 +3852,59 @@ mod tests {
     }
 
     #[test]
+    fn rotate_rewrap_retire_preserves_list_and_stream_across_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(
+            &store,
+            &[b"RPUSH", b"l", b"list-rotate-secret", b"ENCRYPTED"],
+        );
+        exec(
+            &store,
+            &[
+                b"XADD",
+                b"s",
+                b"*",
+                b"f",
+                b"stream-rotate-secret",
+                b"ENCRYPTED",
+            ],
+        );
+        exec(&store, &[b"ENC", b"ROTATE", b"KEYID", b"k2"]);
+        let rewrap = exec_str(&store, &[b"ENC", b"REWRAP"]);
+        assert!(!rewrap.contains("ERR"), "rewrap: {rewrap}");
+        assert!(
+            exec_str(&store, &[b"ENC", b"RETIRE", b"k1"]).contains("OK"),
+            "retire k1 should succeed once list/stream are rewrapped"
+        );
+
+        // Restart from disk (snapshot re-sealed under k2, WAL truncated): the old
+        // key is gone, so this fails if REWRAP didn't cover list/stream + persist.
+        let restored = Store::new_with_config(config);
+        let _ = crate::snapshot::load(&restored);
+        restored.replay_wal(&Broker::new());
+        let l = exec_str(&restored, &[b"LRANGE", b"l", b"0", b"-1"]);
+        assert!(
+            l.contains("list-rotate-secret"),
+            "list after rotate/retire/restart: {l}"
+        );
+        let s = exec_str(&restored, &[b"XRANGE", b"s", b"-", b"+"]);
+        assert!(
+            s.contains("stream-rotate-secret"),
+            "stream after rotate/retire/restart: {s}"
+        );
+    }
+
+    #[test]
     fn enc_rotate_rewrap_then_retire_preserves_existing_data() {
         let dir = tempfile::tempdir().unwrap();
         let config = Arc::new(ServerConfig {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2303,6 +2303,11 @@ fn command_self_logs_wal_args(args: &[&[u8]], store: &Store, now: Instant) -> bo
         return args[3..].iter().any(|arg| cmd_eq(arg, b"ENCRYPTED"))
             || store.kv_string_is_encrypted(args[1], now);
     }
+    if (cmd_eq(cmd, b"LPUSH") || cmd_eq(cmd, b"RPUSH")) && args.len() >= 4 {
+        // Encrypted pushes self-log ENC RAWLPUSH/RAWRPUSH with the resolved
+        // ciphertext; plaintext pushes take the normal WAL path.
+        return args.last().is_some_and(|arg| cmd_eq(arg, b"ENCRYPTED"));
+    }
     if (cmd_eq(cmd, b"HSET") || cmd_eq(cmd, b"HMSET")) && args.len() >= 4 {
         let encrypted = args.last().is_some_and(|arg| cmd_eq(arg, b"ENCRYPTED"));
         let end = if encrypted {
@@ -3750,6 +3755,100 @@ mod tests {
         assert!(got.contains("hash-secret-value"), "{got}");
         let scan = exec_str(&restored, &[b"HSCAN", b"profile:1", b"0"]);
         assert!(scan.contains("hash-secret-value"), "{scan}");
+    }
+
+    #[test]
+    fn encrypted_lpush_self_logs_ciphertext_and_replays() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        let out = String::from_utf8_lossy(&exec_wal(
+            &store,
+            &[
+                b"RPUSH",
+                b"events",
+                b"list-secret-one",
+                b"list-secret-two",
+                b"ENCRYPTED",
+            ],
+        ))
+        .to_string();
+        assert!(out.contains(":2"), "{out}");
+        store.fsync_wal();
+        let wal = read_wal_bytes(dir.path());
+        assert!(!wal
+            .windows(b"list-secret-one".len())
+            .any(|w| w == b"list-secret-one"));
+        assert!(wal.windows(b"RAWRPUSH".len()).any(|w| w == b"RAWRPUSH"));
+
+        let restored = Store::new_with_config(config);
+        restored.replay_wal(&Broker::new());
+        let got = exec_str(&restored, &[b"LRANGE", b"events", b"0", b"-1"]);
+        assert!(got.contains("list-secret-one"), "{got}");
+        assert!(got.contains("list-secret-two"), "{got}");
+    }
+
+    #[test]
+    fn encrypted_list_element_survives_lmove_across_keys() {
+        // List AAD is key-independent, so an encrypted element stays decryptable
+        // after LMOVE relocates it to a different list.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::new_with_config(Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        }));
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(&store, &[b"RPUSH", b"src", b"move-me-secret", b"ENCRYPTED"]);
+        exec(&store, &[b"LMOVE", b"src", b"dst", b"LEFT", b"RIGHT"]);
+        let got = exec_str(&store, &[b"LRANGE", b"dst", b"0", b"-1"]);
+        assert!(got.contains("move-me-secret"), "{got}");
+    }
+
+    #[test]
+    fn encrypted_xadd_self_logs_ciphertext_and_replays() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        let out = String::from_utf8_lossy(&exec_wal(
+            &store,
+            &[
+                b"XADD",
+                b"stream:1",
+                b"*",
+                b"payload",
+                b"stream-secret-value",
+                b"ENCRYPTED",
+            ],
+        ))
+        .to_string();
+        assert!(out.contains('-'), "{out}"); // resolved stream id like <ms>-<seq>
+        store.fsync_wal();
+        let wal = read_wal_bytes(dir.path());
+        assert!(!wal
+            .windows(b"stream-secret-value".len())
+            .any(|w| w == b"stream-secret-value"));
+
+        let restored = Store::new_with_config(config);
+        restored.replay_wal(&Broker::new());
+        let got = exec_str(&restored, &[b"XRANGE", b"stream:1", b"-", b"+"]);
+        assert!(got.contains("stream-secret-value"), "{got}");
+        assert!(got.contains("payload"), "{got}");
     }
 
     #[test]

--- a/src/cmd/streams.rs
+++ b/src/cmd/streams.rs
@@ -72,6 +72,41 @@ fn log_resolved_xadd(store: &Store, args: &[&[u8]], id: StreamId, out: &mut Byte
     }
 }
 
+/// Self-log an encrypted XADD as a normal XADD carrying the resolved id and the
+/// sealed ciphertext values (the ENCRYPTED flag is dropped). On replay the
+/// envelope bytes are stored verbatim (no ENCRYPTED flag => no re-encryption),
+/// and reads decrypt them via the envelope magic prefix.
+fn log_encrypted_xadd(
+    store: &Store,
+    args: &[&[u8]],
+    id: StreamId,
+    fields: &[(String, Bytes)],
+    out: &mut BytesMut,
+) -> bool {
+    if !store.wal_enabled() {
+        return true;
+    }
+    let Some(id_idx) = xadd_id_arg_index(args) else {
+        return true;
+    };
+    let mut owned: Vec<Vec<u8>> = vec![b"XADD".to_vec(), args[1].to_vec()];
+    // Preserve trimming options (MAXLEN/MINID/NOMKSTREAM) that sit before the id.
+    owned.extend(args[2..id_idx].iter().map(|a| a.to_vec()));
+    owned.push(id.to_string().into_bytes());
+    for (name, val) in fields {
+        owned.push(name.as_bytes().to_vec());
+        owned.push(val.to_vec());
+    }
+    let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+    match store.wal_log_command(&refs) {
+        Ok(()) => true,
+        Err(e) => {
+            resp::write_error(out, &format!("ERR WAL append failed: {e}"));
+            false
+        }
+    }
+}
+
 pub fn cmd_xadd(
     args: &[&[u8]],
     store: &Store,
@@ -83,6 +118,9 @@ pub fn cmd_xadd(
         resp::write_error(out, "ERR wrong number of arguments for 'xadd' command");
         return CmdResult::Written;
     }
+    // Trailing ENCRYPTED flag (mirrors SET/HSET): seal each field value.
+    let encrypted = args.last().is_some_and(|a| cmd_eq(a, b"ENCRYPTED"));
+    let arg_end = args.len() - encrypted as usize;
     let mut i = 2;
     let mut maxlen: Option<usize> = None;
     while i < args.len() {
@@ -101,27 +139,40 @@ pub fn cmd_xadd(
             break;
         }
     }
-    if i >= args.len() {
+    if i >= arg_end {
         resp::write_error(out, "ERR wrong number of arguments for 'xadd' command");
         return CmdResult::Written;
     }
     let id_input = arg_str(args[i]);
     i += 1;
-    if (args.len() - i) < 2 || !(args.len() - i).is_multiple_of(2) {
+    if (arg_end - i) < 2 || !(arg_end - i).is_multiple_of(2) {
         resp::write_error(out, "ERR wrong number of arguments for 'xadd' command");
         return CmdResult::Written;
     }
     let mut fields = Vec::new();
-    while i + 1 < args.len() {
-        fields.push((
-            arg_str(args[i]).to_string(),
-            Bytes::copy_from_slice(args[i + 1]),
-        ));
+    while i + 1 < arg_end {
+        let value = if encrypted {
+            match store.encrypt_stream_value(args[1], args[i], args[i + 1]) {
+                Ok(ct) => Bytes::from(ct),
+                Err(e) => {
+                    resp::write_error(out, &e);
+                    return CmdResult::Written;
+                }
+            }
+        } else {
+            Bytes::copy_from_slice(args[i + 1])
+        };
+        fields.push((arg_str(args[i]).to_string(), value));
         i += 2;
     }
-    match store.xadd(args[1], id_input, fields, maxlen, now) {
+    match store.xadd(args[1], id_input, fields.clone(), maxlen, now) {
         Ok(id) => {
-            if !log_resolved_xadd(store, args, id, out) {
+            let logged = if encrypted {
+                log_encrypted_xadd(store, args, id, &fields, out)
+            } else {
+                log_resolved_xadd(store, args, id, out)
+            };
+            if !logged {
                 return CmdResult::Written;
             }
             resp::write_bulk(out, &id.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1746,9 +1746,12 @@ impl EmbeddedClient {
         }
         let key_s = std::str::from_utf8(key).unwrap_or("");
         if self.runtime.broker.has_list_waiters(key_s) {
-            self.runtime
-                .broker
-                .drain_list_waiters(key_s, &mut shard.data, now);
+            self.runtime.broker.drain_list_waiters(
+                key_s,
+                &mut shard.data,
+                &self.runtime.store,
+                now,
+            );
         }
     }
 
@@ -3643,7 +3646,10 @@ impl CommandExecutor {
 
         if !cmd::is_pipeline_special_command(args[0]) {
             let access = cmd::pipeline_access_for_args(args);
-            if access == cmd::PipelineAccess::Read {
+            // The shard-local read fast-path reads stored bytes directly and has
+            // no keyring, so it cannot decrypt. When encryption is active, fall
+            // through to the slow path (cmd::execute) which decrypts on read.
+            if access == cmd::PipelineAccess::Read && !self.store.encryption().has_active_key() {
                 let command = [ShardPipelineCommand { args, access }];
                 let shard_idx = self.store.shard_for_key(args[1]);
                 if let Err(err) = self
@@ -3766,7 +3772,10 @@ impl CommandExecutor {
             }
         }
 
-        if has_special || !all_single_key_rw {
+        // When encryption is active, the shard-local fast batch path can neither
+        // encrypt writes nor decrypt reads (no keyring there), so force every
+        // command onto the slow path (cmd::execute) which handles both.
+        if has_special || !all_single_key_rw || self.store.encryption().has_active_key() {
             for command in commands {
                 let args = command.argv();
                 if !session.authenticated && !is_public_without_auth_cmd(args[0]) {

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -155,6 +155,7 @@ impl Broker {
         &self,
         key: &str,
         shard_data: &mut crate::store::ShardData,
+        store: &crate::store::Store,
         now: std::time::Instant,
     ) {
         let mut waiters = self.list_waiters.lock();
@@ -181,6 +182,9 @@ impl Broker {
                 list.pop_back()
             };
             if let Some(v) = val {
+                // Decrypt encrypted list elements before handing them to the
+                // blocked waiter (deferred BLPOP/BRPOP resolution).
+                let v = store.decrypt_list_element(v.clone()).unwrap_or(v);
                 let _ = req.tx.try_send((key.to_string(), v));
             }
         }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1288,6 +1288,73 @@ impl Store {
             .encrypt("__lux_kv", "value", &key_name, value)
     }
 
+    /// Encrypt a list element. AAD is intentionally key-independent so an
+    /// envelope stays decryptable after LMOVE/RPOPLPUSH move it to another list
+    /// (no re-keying). Per-value random DEK + nonce still protects each element.
+    pub(crate) fn encrypt_list_element(&self, value: &[u8]) -> Result<Vec<u8>, String> {
+        self.encryption()
+            .encrypt("__lux_list", "element", "", value)
+    }
+
+    /// Decrypt a list element if it is an encryption envelope; pass plaintext
+    /// through untouched so encrypted and plaintext elements can coexist.
+    pub(crate) fn decrypt_list_element(&self, value: Bytes) -> Result<Bytes, String> {
+        if !crate::encryption::EncryptionKeyring::is_encrypted_value(&value) {
+            return Ok(value);
+        }
+        self.encryption()
+            .decrypt("__lux_list", "element", "", &value)
+            .map(Bytes::from)
+    }
+
+    /// Encrypt a stream entry field value. AAD binds the stream key + field.
+    pub(crate) fn encrypt_stream_value(
+        &self,
+        key: &[u8],
+        field: &[u8],
+        value: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        let key_name = Self::user_kv_key(key);
+        let field_name = Self::user_hash_field(field);
+        self.encryption()
+            .encrypt("__lux_stream", &field_name, &key_name, value)
+    }
+
+    /// Decrypt a stream entry field value if it is an envelope.
+    pub(crate) fn decrypt_stream_value(
+        &self,
+        key: &[u8],
+        field: &[u8],
+        value: Bytes,
+    ) -> Result<Bytes, String> {
+        if !crate::encryption::EncryptionKeyring::is_encrypted_value(&value) {
+            return Ok(value);
+        }
+        let key_name = Self::user_kv_key(key);
+        let field_name = Self::user_hash_field(field);
+        self.encryption()
+            .decrypt("__lux_stream", &field_name, &key_name, &value)
+            .map(Bytes::from)
+    }
+
+    /// Decrypt all field values of one stream entry for output. Plaintext (and,
+    /// defensively, undecryptable) values pass through unchanged.
+    pub(crate) fn decrypt_stream_fields(
+        &self,
+        key: &[u8],
+        fields: &[(String, Bytes)],
+    ) -> Vec<(String, Bytes)> {
+        fields
+            .iter()
+            .map(|(f, v)| {
+                let dv = self
+                    .decrypt_stream_value(key, f.as_bytes(), v.clone())
+                    .unwrap_or_else(|_| v.clone());
+                (f.clone(), dv)
+            })
+            .collect()
+    }
+
     pub(crate) fn decrypt_hash_field_value(
         &self,
         key: &[u8],

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -611,6 +611,43 @@ impl Store {
                             disk_remove.push(key.clone());
                         }
                     }
+                    StoreValue::List(list) => {
+                        for elem in list.iter_mut() {
+                            if !crate::encryption::EncryptionKeyring::is_encrypted_value(elem) {
+                                continue;
+                            }
+                            let new_value =
+                                self.encryption()
+                                    .reencrypt("__lux_list", "element", "", elem)?;
+                            mem_delta += new_value.len() as isize - elem.len() as isize;
+                            *elem = Bytes::from(new_value);
+                            count += 1;
+                            shard_changed = true;
+                            disk_remove.push(key.clone());
+                        }
+                    }
+                    StoreValue::Stream(stream) => {
+                        let key_name = key_string(key);
+                        for fields in stream.entries.values_mut() {
+                            for (field, value) in fields.iter_mut() {
+                                if !crate::encryption::EncryptionKeyring::is_encrypted_value(value)
+                                {
+                                    continue;
+                                }
+                                let new_value = self.encryption().reencrypt(
+                                    "__lux_stream",
+                                    field,
+                                    &key_name,
+                                    value,
+                                )?;
+                                mem_delta += new_value.len() as isize - value.len() as isize;
+                                *value = Bytes::from(new_value);
+                                count += 1;
+                                shard_changed = true;
+                                disk_remove.push(key.clone());
+                            }
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -630,6 +667,11 @@ impl Store {
                 self.remove_from_disk(&key);
             }
         }
+        // Make the rewrap durable: persist the re-wrapped in-memory values and
+        // truncate the WAL so a restart cannot replay the pre-rewrap (old-key)
+        // ciphertext.
+        crate::snapshot::save_and_truncate_wal_consistent(self)
+            .map_err(|e| format!("ERR rewrap persist failed: {e}"))?;
         Ok(count)
     }
 
@@ -665,10 +707,33 @@ impl Store {
                             }
                         }
                     }
+                    StoreValue::List(list) => {
+                        for elem in list.iter() {
+                            if encrypted_value_would_be_orphaned(elem, &remaining) {
+                                return Err(
+                                    "ERR ENC key is still required by encrypted data".to_string()
+                                );
+                            }
+                        }
+                    }
+                    StoreValue::Stream(stream) => {
+                        for fields in stream.entries.values() {
+                            for (_field, value) in fields {
+                                if encrypted_value_would_be_orphaned(value, &remaining) {
+                                    return Err("ERR ENC key is still required by encrypted data"
+                                        .to_string());
+                                }
+                            }
+                        }
+                    }
                     _ => {}
                 }
             }
         }
+        // Persist the re-wrapped values and truncate the WAL before removing the
+        // key, so no stored value or WAL entry still references it.
+        crate::snapshot::save_and_truncate_wal_consistent(self)
+            .map_err(|e| format!("ERR retire persist failed: {e}"))?;
         self.encryption().retire(key_id)
     }
 

--- a/src/store/streams.rs
+++ b/src/store/streams.rs
@@ -157,7 +157,7 @@ impl Store {
                 StoreValue::Stream(s) => {
                     let mut result = Vec::new();
                     for (id, fields) in s.entries.range(start..=end) {
-                        result.push((*id, fields.clone()));
+                        result.push((*id, self.decrypt_stream_fields(key, fields)));
                         if let Some(c) = count {
                             if result.len() >= c {
                                 break;
@@ -188,7 +188,7 @@ impl Store {
                 StoreValue::Stream(s) => {
                     let mut result = Vec::new();
                     for (id, fields) in s.entries.range(start..=end).rev() {
-                        result.push((*id, fields.clone()));
+                        result.push((*id, self.decrypt_stream_fields(key, fields)));
                         if let Some(c) = count {
                             if result.len() >= c {
                                 break;
@@ -225,7 +225,7 @@ impl Store {
                         };
                         let mut entries = Vec::new();
                         for (id, fields) in s.entries.range(start..) {
-                            entries.push((*id, fields.clone()));
+                            entries.push((*id, self.decrypt_stream_fields(key.as_bytes(), fields)));
                             if let Some(c) = count {
                                 if entries.len() >= c {
                                     break;
@@ -387,7 +387,10 @@ impl Store {
                             };
                             let mut entries = Vec::new();
                             for (id, fields) in s.entries.range(start..) {
-                                entries.push((*id, fields.clone()));
+                                entries.push((
+                                    *id,
+                                    self.decrypt_stream_fields(key.as_bytes(), fields),
+                                ));
                                 if !noack {
                                     cg.pel.insert(
                                         *id,
@@ -432,7 +435,10 @@ impl Store {
                             sorted.sort();
                             for id in sorted {
                                 if let Some(fields) = s.entries.get(&id) {
-                                    entries.push((id, fields.clone()));
+                                    entries.push((
+                                        id,
+                                        self.decrypt_stream_fields(key.as_bytes(), fields),
+                                    ));
                                     if let Some(cnt) = count {
                                         if entries.len() >= cnt {
                                             break;
@@ -627,7 +633,7 @@ impl Store {
                                 c.pel.insert(*id);
                                 c.seen_time = inst_now;
                                 if let Some(fields) = s.entries.get(id) {
-                                    result.push((*id, fields.clone()));
+                                    result.push((*id, self.decrypt_stream_fields(key, fields)));
                                 }
                             }
                         }
@@ -706,7 +712,7 @@ impl Store {
                                 c.pel.insert(id);
                                 c.seen_time = inst_now;
                                 if let Some(fields) = s.entries.get(&id) {
-                                    claimed.push((id, fields.clone()));
+                                    claimed.push((id, self.decrypt_stream_fields(key, fields)));
                                 } else {
                                     deleted_ids.push(id);
                                 }

--- a/tests/encryption.rs
+++ b/tests/encryption.rs
@@ -1,0 +1,58 @@
+//! RESP-over-TCP encryption round-trips. These exercise the real server read
+//! dispatch (including the shard-local read fast-path), which the in-crate unit
+//! tests bypass by going through the slow executor directly.
+
+mod common;
+use common::{send_and_read, LuxServer};
+
+#[test]
+fn resp_encrypted_values_roundtrip_over_tcp() {
+    let server = LuxServer::builder().env("LUX_ENC_AUTO_INIT", "1").start();
+    let mut c = server.conn();
+
+    // String: regression for the fast read path decrypting GET.
+    send_and_read(&mut c, &["SET", "tok", "string-secret", "ENCRYPTED"]);
+    assert!(
+        send_and_read(&mut c, &["GET", "tok"]).contains("string-secret"),
+        "encrypted GET must decrypt over TCP"
+    );
+
+    // Hash field.
+    send_and_read(&mut c, &["HSET", "h", "f", "hash-secret", "ENCRYPTED"]);
+    assert!(
+        send_and_read(&mut c, &["HGET", "h", "f"]).contains("hash-secret"),
+        "encrypted HGET must decrypt over TCP"
+    );
+
+    // List elements: LRANGE/LINDEX go through the read fast-path.
+    send_and_read(
+        &mut c,
+        &["RPUSH", "l", "list-secret-a", "list-secret-b", "ENCRYPTED"],
+    );
+    let lr = send_and_read(&mut c, &["LRANGE", "l", "0", "-1"]);
+    assert!(
+        lr.contains("list-secret-a") && lr.contains("list-secret-b"),
+        "encrypted LRANGE must decrypt over TCP: {lr}"
+    );
+    assert!(send_and_read(&mut c, &["LINDEX", "l", "0"]).contains("list-secret-a"));
+    // LPOP (write path) also decrypts.
+    assert!(send_and_read(&mut c, &["LPOP", "l"]).contains("list-secret-a"));
+
+    // LMOVE relocates an encrypted element to another key and it still decrypts.
+    send_and_read(&mut c, &["RPUSH", "src", "move-secret", "ENCRYPTED"]);
+    send_and_read(&mut c, &["LMOVE", "src", "dst", "LEFT", "RIGHT"]);
+    assert!(
+        send_and_read(&mut c, &["LRANGE", "dst", "0", "-1"]).contains("move-secret"),
+        "encrypted element must survive LMOVE across keys"
+    );
+
+    // Stream field values: XRANGE goes through the read fast-path.
+    send_and_read(
+        &mut c,
+        &["XADD", "s", "*", "payload", "stream-secret", "ENCRYPTED"],
+    );
+    assert!(
+        send_and_read(&mut c, &["XRANGE", "s", "-", "+"]).contains("stream-secret"),
+        "encrypted XRANGE must decrypt over TCP"
+    );
+}


### PR DESCRIPTION
Extends value-level encryption-at-rest (already supported for strings, hashes, and table columns) to the remaining opaque-value primitives: **lists** and **streams**.

## API
- `LPUSH key v1 v2 ... ENCRYPTED` / `RPUSH ... ENCRYPTED` — seal each element.
- `XADD key [opts] id field val ... ENCRYPTED` — seal each field value.

Mirrors the existing `SET/HSET ... ENCRYPTED` convention. Encryption is per-write; reads auto-detect the envelope (`LUXENC2` magic) and decrypt, so encrypted and plaintext entries coexist.

## Design
- **List AAD is key-independent** (`__lux_list`/`element`), so `LMOVE`/`RPOPLPUSH` relocate an encrypted element to another key without re-keying and it still decrypts. Stream AAD binds key + field.
- **Decrypt on every read path**: LRANGE/LINDEX/LPOP/RPOP (+ COUNT), LMOVE/RPOPLPUSH/BLPOP/BLMOVE, and the deferred blocking-pop resolution; XRANGE/XREVRANGE/XREAD/XREADGROUP/XCLAIM/XAUTOCLAIM (decrypted in the store read fns).
- **WAL determinism**: encrypted pushes self-log `ENC RAWLPUSH/RAWRPUSH`; encrypted XADD self-logs a resolved XADD carrying the ciphertext (flag stripped). Replay stores envelopes verbatim, no re-encryption.
- No grant-gating needed: lists are operator-only over HTTP and streams have no HTTP route, so decryption only happens on the (operator-authed) RESP path.

## Bundled bug fix
The shard-local **read fast-path** reads stored bytes directly and has no keyring, so it returned **ciphertext** for encrypted `GET`/`HGET`/`LRANGE`/`XRANGE` over RESP (pre-existing; shipped in v0.25.0, but latent — the in-crate tests exercise the slow executor, and table/HTTP encryption was unaffected). Reads and pipelines now fall through to the decrypting slow path whenever encryption is active. Caught by the live e2e, not the unit tests — hence the new TCP integration test.

## Limitations (documented)
- Value-matching ops on encrypted list elements (LREM, LPOS, LINSERT pivot) compare against ciphertext and won't match — inherent to at-rest encryption. ENCRYPTED write support is on the append family (LPUSH/RPUSH) + XADD.
- Perf: when encryption is active, all reads take the slow path (the fast-path can't decrypt). Only affects instances that have run `ENC INIT`.

## Tests
Unit: LPUSH/XADD WAL-ciphertext + replay round-trips, LMOVE-across-keys. Integration (`tests/encryption.rs`): RESP-over-TCP round-trips for encrypted string/hash/list/stream + LMOVE. Live e2e confirmed plaintext round-trips, LMOVE portability, and no plaintext on disk. Full suite 909 pass, clippy clean.