### PR TITLE
feat(enc): encrypt vectors at rest (table columns + standalone VSET)

### DIFF
--- a/src/cmd/encryption.rs
+++ b/src/cmd/encryption.rs
@@ -88,6 +88,9 @@ pub fn cmd_enc(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
     if cmd_eq(args[1], b"RAWHSET") {
         return cmd_rawhset(args, store, out, now);
     }
+    if cmd_eq(args[1], b"RAWVSET") {
+        return cmd_rawvset(args, store, out, now);
+    }
     resp::write_error(out, "ERR unknown ENC subcommand");
     CmdResult::Written
 }
@@ -156,5 +159,44 @@ fn cmd_rawhset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
         Ok(_) => resp::write_ok(out),
         Err(err) => resp::write_error(out, &err),
     }
+    CmdResult::Written
+}
+
+/// Replay form of an encrypted VSET: decrypts the sealed payload back to f32 and
+/// re-inserts (rebuilding the in-memory index), preserving the encrypted flag.
+fn cmd_rawvset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() < 4 {
+        resp::write_error(
+            out,
+            "ERR usage: ENC RAWVSET <key> <ciphertext> [META <m>] [EX <s>]",
+        );
+        return CmdResult::Written;
+    }
+    let key = args[2];
+    let data = match store.decrypt_vector(key, args[3]) {
+        Ok(d) => d,
+        Err(err) => {
+            resp::write_error(out, &err);
+            return CmdResult::Written;
+        }
+    };
+    let mut metadata = None;
+    let mut ttl = None;
+    let mut i = 4;
+    while i < args.len() {
+        if cmd_eq(args[i], b"META") && i + 1 < args.len() {
+            metadata = Some(String::from_utf8_lossy(args[i + 1]).to_string());
+            i += 2;
+        } else if cmd_eq(args[i], b"EX") && i + 1 < args.len() {
+            if let Ok(s) = parse_u64(args[i + 1]) {
+                ttl = Some(Duration::from_secs(s));
+            }
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    store.vset(key, data, metadata, ttl, true, now);
+    resp::write_ok(out);
     CmdResult::Written
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -3831,6 +3831,47 @@ mod tests {
     }
 
     #[test]
+    fn rotate_rewrap_retire_preserves_vector_across_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(
+            &store,
+            &[
+                b"VSET",
+                b"emb:1",
+                b"3",
+                b"1.5",
+                b"2.5",
+                b"3.5",
+                b"ENCRYPTED",
+            ],
+        );
+        exec(&store, &[b"ENC", b"ROTATE", b"KEYID", b"k2"]);
+        assert!(!exec_str(&store, &[b"ENC", b"REWRAP"]).contains("ERR"));
+        assert!(exec_str(&store, &[b"ENC", b"RETIRE", b"k1"]).contains("OK"));
+
+        // Restart from disk: the vector's snapshot envelope must have been
+        // re-sealed under k2 (old key retired), else decrypt-on-load fails.
+        let restored = Store::new_with_config(config);
+        let _ = crate::snapshot::load(&restored);
+        restored.replay_wal(&Broker::new());
+        let got = exec_str(&restored, &[b"VGET", b"emb:1"]);
+        assert!(
+            got.contains("1.5") && got.contains("2.5") && got.contains("3.5"),
+            "vector after rotate/retire/restart: {got}"
+        );
+    }
+
+    #[test]
     fn enc_rotate_rewrap_then_retire_preserves_existing_data() {
         let dir = tempfile::tempdir().unwrap();
         let config = Arc::new(ServerConfig {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2315,6 +2315,10 @@ fn command_self_logs_wal_args(args: &[&[u8]], store: &Store, now: Instant) -> bo
             return encrypted || store.hash_fields_need_encryption(args[1], &fields, now);
         }
     }
+    if cmd_eq(cmd, b"VSET") {
+        // Encrypted VSET self-logs ENC RAWVSET with the sealed payload.
+        return args.iter().any(|arg| cmd_eq(arg, b"ENCRYPTED"));
+    }
     false
 }
 
@@ -3750,6 +3754,80 @@ mod tests {
         assert!(got.contains("hash-secret-value"), "{got}");
         let scan = exec_str(&restored, &[b"HSCAN", b"profile:1", b"0"]);
         assert!(scan.contains("hash-secret-value"), "{scan}");
+    }
+
+    #[test]
+    fn encrypted_vset_self_logs_ciphertext_and_replays() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        let out = String::from_utf8_lossy(&exec_wal(
+            &store,
+            &[
+                b"VSET",
+                b"emb:1",
+                b"3",
+                b"1.5",
+                b"2.5",
+                b"3.5",
+                b"ENCRYPTED",
+            ],
+        ))
+        .to_string();
+        assert!(out.contains("OK"), "{out}");
+        store.fsync_wal();
+        let wal = read_wal_bytes(dir.path());
+        assert!(
+            wal.windows(b"RAWVSET".len()).any(|w| w == b"RAWVSET"),
+            "encrypted VSET must self-log ENC RAWVSET"
+        );
+        assert!(
+            !wal.windows(b"2.5".len()).any(|w| w == b"2.5"),
+            "WAL must not contain the plaintext vector components"
+        );
+
+        let restored = Store::new_with_config(config);
+        restored.replay_wal(&Broker::new());
+        let got = exec_str(&restored, &[b"VGET", b"emb:1"]);
+        assert!(
+            got.contains("1.5") && got.contains("2.5") && got.contains("3.5"),
+            "{got}"
+        );
+    }
+
+    #[test]
+    fn encrypt_vector_roundtrips_and_hides_plaintext() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::new_with_config(Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        }));
+        store.encryption().init(Some("k1")).unwrap();
+        let v = vec![1.5f32, -2.25, 3.0, 0.125];
+        let sealed = store.encrypt_vector(b"emb:1", &v).unwrap();
+
+        // The raw little-endian f32 bytes must not appear in the envelope.
+        let mut plain = Vec::new();
+        for f in &v {
+            plain.extend_from_slice(&f.to_le_bytes());
+        }
+        assert!(
+            !sealed.windows(plain.len()).any(|w| w == plain.as_slice()),
+            "plaintext vector bytes leaked into the envelope"
+        );
+
+        // Round-trips under the same key context.
+        assert_eq!(store.decrypt_vector(b"emb:1", &sealed).unwrap(), v);
+        // AAD binds the storage key: a different key must not decrypt.
+        assert!(store.decrypt_vector(b"other:key", &sealed).is_err());
     }
 
     #[test]

--- a/src/cmd/vectors.rs
+++ b/src/cmd/vectors.rs
@@ -40,8 +40,12 @@ pub fn cmd_vset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
     let mut i = 3 + dims;
     let mut metadata = None;
     let mut ttl = None;
+    let mut encrypted = false;
     while i < args.len() {
-        if cmd_eq(args[i], b"META") {
+        if cmd_eq(args[i], b"ENCRYPTED") {
+            encrypted = true;
+            i += 1;
+        } else if cmd_eq(args[i], b"META") {
             if i + 1 >= args.len() {
                 resp::write_error(out, "ERR syntax error");
                 return CmdResult::Written;
@@ -79,7 +83,39 @@ pub fn cmd_vset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
             return CmdResult::Written;
         }
     }
-    store.vset(key, data, metadata, ttl, now);
+    // Encrypted vectors keep plaintext in RAM but self-log the sealed payload as
+    // ENC RAWVSET so the WAL carries no plaintext f32 (mirrors SET ... ENCRYPTED).
+    let sealed = if encrypted {
+        match store.encrypt_vector(key, &data) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                resp::write_error(out, &e);
+                return CmdResult::Written;
+            }
+        }
+    } else {
+        None
+    };
+    store.vset(key, data, metadata.clone(), ttl, encrypted, now);
+    if let Some(ct) = sealed {
+        if store.wal_enabled() {
+            let mut owned: Vec<Vec<u8>> =
+                vec![b"ENC".to_vec(), b"RAWVSET".to_vec(), key.to_vec(), ct];
+            if let Some(m) = &metadata {
+                owned.push(b"META".to_vec());
+                owned.push(m.as_bytes().to_vec());
+            }
+            if let Some(d) = ttl {
+                owned.push(b"EX".to_vec());
+                owned.push(d.as_secs().to_string().into_bytes());
+            }
+            let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+            if let Err(e) = store.wal_log_command(&refs) {
+                resp::write_error(out, &format!("ERR WAL append failed: {e}"));
+                return CmdResult::Written;
+            }
+        }
+    }
     resp::write_ok(out);
     CmdResult::Written
 }

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -951,7 +951,10 @@ pub fn write_single_entry(w: &mut impl Write, entry: &DumpEntry) -> io::Result<(
             }
             write_stream_groups(w, groups)?;
         }
-        DumpValue::Vector(data, metadata) => {
+        // Vectors are pinned to the hot tier (eviction skips them), so an
+        // encrypted vector never reaches cold-tier disk; the flag is not
+        // persisted here and reads back as plaintext.
+        DumpValue::Vector(data, metadata, _) => {
             write_u32(w, data.len() as u32)?;
             for f in data {
                 w.write_all(&f.to_le_bytes())?;
@@ -1063,7 +1066,7 @@ pub fn read_single_entry(r: &mut impl Read) -> io::Result<(String, DumpValue, i6
             } else {
                 None
             };
-            DumpValue::Vector(data, metadata)
+            DumpValue::Vector(data, metadata, false)
         }
         b'P' => {
             let len = read_u32(r)? as usize;
@@ -1449,7 +1452,7 @@ mod tests {
                 prop::collection::vec(-1e6f32..1e6f32, 0..64),
                 prop::option::of(arb_string())
             )
-                .prop_map(|(data, meta)| DumpValue::Vector(data, meta)),
+                .prop_map(|(data, meta)| DumpValue::Vector(data, meta, false)),
             prop::collection::vec(any::<u8>(), 0..256).prop_map(|regs| {
                 let cached = crate::hll::hll_count(&regs);
                 DumpValue::HyperLogLog(regs, cached)
@@ -1497,7 +1500,9 @@ mod tests {
             (DumpValue::Stream(ae, al, ag), DumpValue::Stream(be, bl, bg)) => {
                 ae == be && al == bl && ag == bg
             }
-            (DumpValue::Vector(ad, am), DumpValue::Vector(bd, bm)) => ad == bd && am == bm,
+            (DumpValue::Vector(ad, am, ae), DumpValue::Vector(bd, bm, be)) => {
+                ad == bd && am == bm && ae == be
+            }
             (DumpValue::HyperLogLog(ar, _), DumpValue::HyperLogLog(br, _)) => ar == br,
             (DumpValue::TimeSeries(as_, ar, al), DumpValue::TimeSeries(bs, br, bl)) => {
                 as_ == bs && ar == br && al == bl

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -133,7 +133,7 @@ fn save_entries(store: &Store, entries: &[crate::store::DumpEntry]) -> io::Resul
     let tmp = format!("{path}.{}.tmp", std::process::id());
     let file = fs::File::create(&tmp)?;
     let mut w = BufWriter::new(file);
-    save_binary(&mut w, entries)?;
+    save_binary(&mut w, entries, store)?;
     w.into_inner().map_err(io::Error::other)?.sync_all()?;
     fs::rename(&tmp, &path)?;
     Ok(entries.len())
@@ -221,7 +221,11 @@ fn purge_lux_storage_shards(storage_dir: &Path) -> io::Result<()> {
     Ok(())
 }
 
-fn save_binary(w: &mut impl Write, entries: &[crate::store::DumpEntry]) -> io::Result<()> {
+fn save_binary(
+    w: &mut impl Write,
+    entries: &[crate::store::DumpEntry],
+    store: &Store,
+) -> io::Result<()> {
     w.write_all(HEADER)?;
     for entry in entries {
         let type_byte: u8 = match &entry.value {
@@ -231,7 +235,8 @@ fn save_binary(w: &mut impl Write, entries: &[crate::store::DumpEntry]) -> io::R
             DumpValue::Set(_) => b'T',
             DumpValue::SortedSet(_) => b'Z',
             DumpValue::Stream(..) => b'X',
-            DumpValue::Vector(..) => b'V',
+            DumpValue::Vector(_, _, true) => b'W',
+            DumpValue::Vector(_, _, false) => b'V',
             DumpValue::HyperLogLog(..) => b'P',
             DumpValue::TimeSeries(..) => b'I',
         };
@@ -308,10 +313,18 @@ fn save_binary(w: &mut impl Write, entries: &[crate::store::DumpEntry]) -> io::R
                     }
                 }
             }
-            DumpValue::Vector(data, metadata) => {
-                write_u32(w, data.len() as u32)?;
-                for f in data {
-                    w.write_all(&f.to_le_bytes())?;
+            DumpValue::Vector(data, metadata, encrypted) => {
+                if *encrypted {
+                    // Seal the f32 payload; the 'W' type byte marks it encrypted.
+                    let sealed = store
+                        .encrypt_vector(entry.key.as_bytes(), data)
+                        .map_err(io::Error::other)?;
+                    write_bytes(w, &sealed)?;
+                } else {
+                    write_u32(w, data.len() as u32)?;
+                    for f in data {
+                        w.write_all(&f.to_le_bytes())?;
+                    }
                 }
                 match metadata {
                     Some(m) => {
@@ -507,7 +520,22 @@ pub(crate) fn load_binary(
                 } else {
                     None
                 };
-                DumpValue::Vector(data, metadata)
+                DumpValue::Vector(data, metadata, false)
+            }
+            b'W' => {
+                // Encrypted vector: sealed f32 payload, decrypted with the key.
+                let sealed = read_bytes(r)?;
+                let mut flag = [0u8; 1];
+                r.read_exact(&mut flag)?;
+                let metadata = if flag[0] == 1 {
+                    Some(read_string(r)?)
+                } else {
+                    None
+                };
+                let data = store
+                    .decrypt_vector(key.as_bytes(), &sealed)
+                    .map_err(io::Error::other)?;
+                DumpValue::Vector(data, metadata, true)
             }
             b'P' => {
                 let len = read_sized_count(r, "hyperloglog register", 1)?;
@@ -731,7 +759,7 @@ fn save_to_path(store: &Store, path: &str) -> io::Result<usize> {
     let tmp = format!("{path}.tmp");
     let file = fs::File::create(&tmp)?;
     let mut w = BufWriter::new(file);
-    save_binary(&mut w, &entries)?;
+    save_binary(&mut w, &entries, store)?;
     w.into_inner().map_err(io::Error::other)?.sync_all()?;
     fs::rename(&tmp, path)?;
     Ok(entries.len())

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -634,6 +634,11 @@ impl Store {
                 self.remove_from_disk(&key);
             }
         }
+        // Encrypted vectors keep plaintext in RAM (nothing to rewrap in place),
+        // but their at-rest envelope must be re-sealed under the current keyset;
+        // a consistent save rewrites it and truncates the WAL.
+        crate::snapshot::save_and_truncate_wal_consistent(self)
+            .map_err(|e| format!("ERR rewrap persist failed: {e}"))?;
         Ok(count)
     }
 
@@ -673,6 +678,11 @@ impl Store {
                 }
             }
         }
+        // Re-seal at-rest data (including plaintext-in-RAM vectors, whose disk
+        // envelope is rewritten under the current keyset) and truncate the WAL
+        // before removing the key, so nothing persisted still references it.
+        crate::snapshot::save_and_truncate_wal_consistent(self)
+            .map_err(|e| format!("ERR retire persist failed: {e}"))?;
         self.encryption().retire(key_id)
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -117,6 +117,10 @@ pub struct VectorData {
     pub dims: u32,
     pub data: Vec<f32>,
     pub metadata: Option<String>,
+    /// When true this vector is encrypted at rest: the in-memory `data` stays
+    /// plaintext (HNSW/search need it), but it is sealed when written to the
+    /// snapshot and self-logged as ciphertext in the WAL.
+    pub encrypted: bool,
 }
 
 pub struct TimeSeriesData {
@@ -1286,6 +1290,33 @@ impl Store {
         let key_name = Self::user_kv_key(key);
         self.encryption()
             .encrypt("__lux_kv", "value", &key_name, value)
+    }
+
+    /// Seal a vector (as little-endian f32 bytes) for at-rest storage. AAD binds
+    /// the vector's storage key so envelopes can't be swapped between slots.
+    pub(crate) fn encrypt_vector(&self, key: &[u8], data: &[f32]) -> Result<Vec<u8>, String> {
+        let key_name = Self::user_kv_key(key);
+        let mut bytes = Vec::with_capacity(data.len() * 4);
+        for f in data {
+            bytes.extend_from_slice(&f.to_le_bytes());
+        }
+        self.encryption()
+            .encrypt("__lux_vec", "data", &key_name, &bytes)
+    }
+
+    /// Decrypt a sealed vector back into f32 values.
+    pub(crate) fn decrypt_vector(&self, key: &[u8], envelope: &[u8]) -> Result<Vec<f32>, String> {
+        let key_name = Self::user_kv_key(key);
+        let bytes = self
+            .encryption()
+            .decrypt("__lux_vec", "data", &key_name, envelope)?;
+        if !bytes.len().is_multiple_of(4) {
+            return Err("ERR corrupt encrypted vector payload".to_string());
+        }
+        Ok(bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect())
     }
 
     pub(crate) fn decrypt_hash_field_value(
@@ -3210,7 +3241,7 @@ impl Store {
                     groups,
                 })
             }
-            DumpValue::Vector(data, metadata) => {
+            DumpValue::Vector(data, metadata, encrypted) => {
                 let dims = data.len() as u32;
                 let index_data = data.clone();
                 let key_clone = key.clone();
@@ -3218,6 +3249,7 @@ impl Store {
                     dims,
                     data,
                     metadata,
+                    encrypted,
                 });
                 let expires_at = ttl.map(|d| Instant::now() + d);
                 let mem = estimate_entry_memory(&key, &sv);
@@ -4716,7 +4748,7 @@ fn store_value_to_dump_value(value: &StoreValue) -> DumpValue {
                 .collect();
             DumpValue::Stream(entries, s.last_id.to_string(), groups)
         }
-        StoreValue::Vector(v) => DumpValue::Vector(v.data.clone(), v.metadata.clone()),
+        StoreValue::Vector(v) => DumpValue::Vector(v.data.clone(), v.metadata.clone(), v.encrypted),
         StoreValue::HyperLogLog(regs, cached) => DumpValue::HyperLogLog(regs.clone(), *cached),
         StoreValue::TimeSeries(ts) => {
             DumpValue::TimeSeries(ts.samples.clone(), ts.retention, ts.labels.clone())
@@ -4742,7 +4774,9 @@ pub enum DumpValue {
     Set(Vec<String>),
     SortedSet(Vec<(String, f64)>),
     Stream(Vec<StreamDumpEntry>, String, Vec<StreamGroupDump>),
-    Vector(Vec<f32>, Option<String>),
+    /// f32 data, metadata, and whether it is encrypted-at-rest (sealed in the
+    /// snapshot; the in-memory copy is plaintext).
+    Vector(Vec<f32>, Option<String>, bool),
     HyperLogLog(Vec<u8>, u64),
     TimeSeries(Vec<(i64, f64)>, u64, Vec<(String, String)>),
 }
@@ -5965,8 +5999,8 @@ mod tests {
     fn vector_search_indexes_are_dimension_scoped() {
         let store = Store::new();
         let n = now();
-        store.vset(b"two_dim", vec![1.0, 0.0], None, None, n);
-        store.vset(b"three_dim", vec![0.0, 1.0, 0.0], None, None, n);
+        store.vset(b"two_dim", vec![1.0, 0.0], None, None, false, n);
+        store.vset(b"three_dim", vec![0.0, 1.0, 0.0], None, None, false, n);
 
         let two_dim = store.vsearch(&[1.0, 0.0], 1, None, None, n);
         assert_eq!(

--- a/src/store/vectors.rs
+++ b/src/store/vectors.rs
@@ -1,12 +1,14 @@
 use super::*;
 
 impl Store {
+    #[allow(clippy::too_many_arguments)]
     pub fn vset(
         &self,
         key: &[u8],
         data: Vec<f32>,
         metadata: Option<String>,
         ttl: Option<Duration>,
+        encrypted: bool,
         now: Instant,
     ) {
         let idx = self.shard_index(key);
@@ -21,6 +23,7 @@ impl Store {
             dims,
             data,
             metadata,
+            encrypted,
         });
         let new_mem = estimate_entry_memory(&ks, &new_value);
         let expires_at = ttl.map(|d| now + d);

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -799,9 +799,9 @@ fn field_supports_encryption(field: &FieldDef) -> Result<(), String> {
             field.name
         ));
     }
-    if matches!(field.field_type, FieldType::Vector(_)) {
+    if field.searchable && matches!(field.field_type, FieldType::Vector(_)) {
         return Err(format!(
-            "ERR encrypted column '{}' cannot use VECTOR type",
+            "ERR encrypted VECTOR column '{}' cannot be SEARCHABLE (similarity search uses the in-memory index, not a blind index)",
             field.name
         ));
     }
@@ -2024,7 +2024,14 @@ fn add_to_index(
                 })
                 .to_string();
                 let vkey = table_vector_key(table, &field.name, pk_str);
-                store.vset(vkey.as_bytes(), vector, Some(metadata), None, now);
+                store.vset(
+                    vkey.as_bytes(),
+                    vector,
+                    Some(metadata),
+                    None,
+                    field.encrypted,
+                    now,
+                );
             }
         }
         // JSON/ARRAY columns are not auto-indexed; only declared path indexes apply.
@@ -4033,7 +4040,10 @@ mod tests {
     fn encrypted_field_rejects_invalid_combinations() {
         assert!(parse_field_def("id UUID PRIMARY KEY ENCRYPTED").is_err());
         assert!(parse_field_def("owner UUID REFERENCES users(id) ENCRYPTED").is_err());
-        assert!(parse_field_def("embedding VECTOR(3) ENCRYPTED").is_err());
+        // Encrypted VECTOR columns are allowed (at-rest); only SEARCHABLE on an
+        // encrypted vector is rejected (no blind index for similarity search).
+        assert!(parse_field_def("embedding VECTOR(3) ENCRYPTED").is_ok());
+        assert!(parse_field_def("embedding VECTOR(3) ENCRYPTED SEARCHABLE").is_err());
         assert!(parse_field_def("token STR SEARCHABLE").is_err());
         assert!(parse_field_def("token STR ENCRYPTED UNIQUE").is_err());
         assert!(parse_field_def("token STR ENCRYPTED DEFAULT seeded").is_err());


### PR DESCRIPTION
Closes the opaque-value encryption loop: VECTOR table columns can be `ENCRYPTED`, and standalone `VSET key dims ... ENCRYPTED` sets a per-write flag.

## Model: at-rest, search unaffected
The in-memory vector and the HNSW graph stay **plaintext**, so NEAR / VSEARCH run at full fidelity — encrypted vectors rank and return exactly like plaintext ones. Encryption happens only when a vector crosses a disk boundary. The tradeoff (confirmed): the encryption key must be loaded for the engine to rebuild the index at startup. This is the standard TDE-style "encrypt on disk, decrypt into RAM" model — not encrypted-domain search (ruled out as research-grade).

## What's sealed where
- **Snapshot**: `entry_to_dump`-time seal via a new `'W'` type byte carrying the envelope; plaintext `'V'` format is unchanged, so **existing snapshots still load**. Decrypted on load (which has the key).
- **WAL (standalone VSET)**: self-logs `ENC RAWVSET` with the sealed payload (no plaintext f32 in the WAL); replay decrypts and re-inserts, rebuilding the index.
- **Table row cell**: reuses the existing column-encryption path. `TROWSET` replay already `decode_stored_value`s (decrypts) before `add_to_index`, so the vector index rebuilds from plaintext on restart — verified.
- **Cold tier**: N/A — eviction pins vectors to the hot tier, so they never reach cold-tier disk.

## Guards
`SEARCHABLE` is rejected on encrypted vectors (blind-index equality is meaningless for ANN).

## Tests
Unit: VSET WAL self-log + replay round-trip; `encrypt_vector` round-trip + AAD binding + no-plaintext-in-envelope; updated the field-validation test (encrypted VECTOR now allowed, SEARCHABLE-encrypted-vector rejected). Live e2e: standalone + table encrypted vectors, **snapshot restart** (VGET + VSEARCH + table row all survive → decrypt-on-load and HNSW rebuild work), and a distinctive float's raw bytes confirmed **absent from every on-disk file**. Full suite 907 pass, clippy clean.