### PR TITLE
release: engine v0.26.0 — encryption v2 + adversarial data-loss hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "lux"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "argon2",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lux"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "An open-source application database engine with tables, cache, vectors, auth, realtime, queues, time series, and Redis-compatible commands."
 license = "MIT"

--- a/src/cmd/bitops.rs
+++ b/src/cmd/bitops.rs
@@ -7,6 +7,20 @@ use crate::store::Store;
 use super::{arg_str, cmd_eq, parse_i64, CmdResult};
 
 const INTEGER_ERR: &str = "ERR value is not an integer or out of range";
+const ENCRYPTED_BITOP_ERR: &str =
+    "ERR bit operations are not supported on encrypted values (they would operate on ciphertext)";
+
+/// Reject a bit operation touching an encrypted string. Bit ops read/write the
+/// raw stored bytes, which for an encrypted value are the ciphertext envelope:
+/// a write corrupts it irrecoverably and a read returns meaningless answers.
+fn reject_encrypted_bitop(store: &Store, key: &[u8], now: Instant, out: &mut BytesMut) -> bool {
+    if store.kv_string_is_encrypted(key, now) {
+        resp::write_error(out, ENCRYPTED_BITOP_ERR);
+        true
+    } else {
+        false
+    }
+}
 
 fn parse_i64_arg(arg: &[u8], out: &mut BytesMut) -> Option<i64> {
     match parse_i64(arg) {
@@ -21,6 +35,9 @@ fn parse_i64_arg(arg: &[u8], out: &mut BytesMut) -> Option<i64> {
 pub fn cmd_setbit(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     if args.len() != 4 {
         resp::write_error(out, "ERR wrong number of arguments for 'setbit' command");
+        return CmdResult::Written;
+    }
+    if reject_encrypted_bitop(store, args[1], now, out) {
         return CmdResult::Written;
     }
     let offset = match parse_i64(args[2]) {
@@ -56,6 +73,9 @@ pub fn cmd_getbit(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, "ERR wrong number of arguments for 'getbit' command");
         return CmdResult::Written;
     }
+    if reject_encrypted_bitop(store, args[1], now, out) {
+        return CmdResult::Written;
+    }
     let offset = match parse_i64(args[2]) {
         Ok(o) if o >= 0 => o as u64,
         _ => {
@@ -71,6 +91,9 @@ pub fn cmd_getbit(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
 }
 
 pub fn cmd_bitcount(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() >= 2 && reject_encrypted_bitop(store, args[1], now, out) {
+        return CmdResult::Written;
+    }
     if args.len() < 2 {
         resp::write_error(out, "ERR wrong number of arguments for 'bitcount' command");
         return CmdResult::Written;
@@ -119,6 +142,9 @@ pub fn cmd_bitcount(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Inst
 pub fn cmd_bitpos(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     if args.len() < 3 {
         resp::write_error(out, "ERR wrong number of arguments for 'bitpos' command");
+        return CmdResult::Written;
+    }
+    if reject_encrypted_bitop(store, args[1], now, out) {
         return CmdResult::Written;
     }
     let bit = match args[2] {
@@ -180,6 +206,17 @@ pub fn cmd_bitop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
     }
     let dest = args[2];
     let src_keys: Vec<&[u8]> = args[3..].to_vec();
+    // Refuse if the destination or any source is encrypted: BITOP would either
+    // overwrite an encrypted key with a plaintext result or compute over an
+    // envelope. Guard before any mutation.
+    if reject_encrypted_bitop(store, dest, now, out) {
+        return CmdResult::Written;
+    }
+    for key in &src_keys {
+        if reject_encrypted_bitop(store, key, now, out) {
+            return CmdResult::Written;
+        }
+    }
     for key in &src_keys {
         store.try_promote(key, now);
     }

--- a/src/cmd/encryption.rs
+++ b/src/cmd/encryption.rs
@@ -137,6 +137,30 @@ fn cmd_rawset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -
             };
             ttl = Some(Duration::from_millis(ms));
             i += 2;
+        } else if cmd_eq(args[i], b"EXAT") && i + 1 < args.len() {
+            // Absolute epoch-seconds deadline -> remaining duration (0 if past,
+            // so the value replays as already-expired, matching SET ... EXAT).
+            let Ok(secs) = parse_u64(args[i + 1]) else {
+                resp::write_error(out, "ERR value is not an integer or out of range");
+                return CmdResult::Written;
+            };
+            let now_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            ttl = Some(Duration::from_secs(secs.saturating_sub(now_secs)));
+            i += 2;
+        } else if cmd_eq(args[i], b"PXAT") && i + 1 < args.len() {
+            let Ok(ms) = parse_u64(args[i + 1]) else {
+                resp::write_error(out, "ERR value is not an integer or out of range");
+                return CmdResult::Written;
+            };
+            let now_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64;
+            ttl = Some(Duration::from_millis(ms.saturating_sub(now_ms)));
+            i += 2;
         } else if cmd_eq(args[i], b"NX")
             || cmd_eq(args[i], b"XX")
             || cmd_eq(args[i], b"KEEPTTL")

--- a/src/cmd/encryption.rs
+++ b/src/cmd/encryption.rs
@@ -88,6 +88,9 @@ pub fn cmd_enc(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
     if cmd_eq(args[1], b"RAWHSET") {
         return cmd_rawhset(args, store, out, now);
     }
+    if cmd_eq(args[1], b"RAWVSET") {
+        return cmd_rawvset(args, store, out, now);
+    }
     resp::write_error(out, "ERR unknown ENC subcommand");
     CmdResult::Written
 }
@@ -156,5 +159,44 @@ fn cmd_rawhset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
         Ok(_) => resp::write_ok(out),
         Err(err) => resp::write_error(out, &err),
     }
+    CmdResult::Written
+}
+
+/// Replay form of an encrypted VSET: decrypts the sealed payload back to f32 and
+/// re-inserts (rebuilding the in-memory index), preserving the encrypted flag.
+fn cmd_rawvset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
+    if args.len() < 4 {
+        resp::write_error(
+            out,
+            "ERR usage: ENC RAWVSET <key> <ciphertext> [META <m>] [EX <s>]",
+        );
+        return CmdResult::Written;
+    }
+    let key = args[2];
+    let data = match store.decrypt_vector(key, args[3]) {
+        Ok(d) => d,
+        Err(err) => {
+            resp::write_error(out, &err);
+            return CmdResult::Written;
+        }
+    };
+    let mut metadata = None;
+    let mut ttl = None;
+    let mut i = 4;
+    while i < args.len() {
+        if cmd_eq(args[i], b"META") && i + 1 < args.len() {
+            metadata = Some(String::from_utf8_lossy(args[i + 1]).to_string());
+            i += 2;
+        } else if cmd_eq(args[i], b"EX") && i + 1 < args.len() {
+            if let Ok(s) = parse_u64(args[i + 1]) {
+                ttl = Some(Duration::from_secs(s));
+            }
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    store.vset(key, data, metadata, ttl, true, now);
+    resp::write_ok(out);
     CmdResult::Written
 }

--- a/src/cmd/encryption.rs
+++ b/src/cmd/encryption.rs
@@ -88,6 +88,12 @@ pub fn cmd_enc(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
     if cmd_eq(args[1], b"RAWHSET") {
         return cmd_rawhset(args, store, out, now);
     }
+    if cmd_eq(args[1], b"RAWLPUSH") {
+        return cmd_rawlpush(args, store, out, now, true);
+    }
+    if cmd_eq(args[1], b"RAWRPUSH") {
+        return cmd_rawlpush(args, store, out, now, false);
+    }
     resp::write_error(out, "ERR unknown ENC subcommand");
     CmdResult::Written
 }
@@ -153,6 +159,31 @@ fn cmd_rawhset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
     }
     let pairs: Vec<(&[u8], &[u8])> = args[3..].chunks(2).map(|c| (c[0], c[1])).collect();
     match store.hset(args[2], &pairs, now) {
+        Ok(_) => resp::write_ok(out),
+        Err(err) => resp::write_error(out, &err),
+    }
+    CmdResult::Written
+}
+
+/// Replay form of an encrypted LPUSH/RPUSH: stores the already-sealed envelope
+/// elements verbatim (no re-encryption). `front` selects LPUSH vs RPUSH.
+fn cmd_rawlpush(
+    args: &[&[u8]],
+    store: &Store,
+    out: &mut BytesMut,
+    now: Instant,
+    front: bool,
+) -> CmdResult {
+    if args.len() < 4 {
+        resp::write_error(out, "ERR usage: ENC RAWLPUSH|RAWRPUSH <key> <element> ...");
+        return CmdResult::Written;
+    }
+    let res = if front {
+        store.lpush(args[2], &args[3..], now)
+    } else {
+        store.rpush(args[2], &args[3..], now)
+    };
+    match res {
         Ok(_) => resp::write_ok(out),
         Err(err) => resp::write_error(out, &err),
     }

--- a/src/cmd/lists.rs
+++ b/src/cmd/lists.rs
@@ -56,25 +56,78 @@ fn parse_block_timeout(arg: &[u8], out: &mut BytesMut) -> Option<Duration> {
     }
 }
 
-pub fn cmd_lpush(
+/// Decrypt a list element for output, passing plaintext (and, defensively, any
+/// value we cannot decrypt) through unchanged.
+fn decrypt_out(store: &Store, raw: Bytes) -> Bytes {
+    store.decrypt_list_element(raw.clone()).unwrap_or(raw)
+}
+
+/// Shared LPUSH/RPUSH body. Supports a trailing `ENCRYPTED` flag (mirrors
+/// `SET ... ENCRYPTED`): each pushed element is sealed as an envelope and the
+/// resolved ciphertext is self-logged to the WAL as `ENC RAWLPUSH/RAWRPUSH` so
+/// replay is deterministic (envelopes carry random nonces).
+fn push_list(
     args: &[&[u8]],
     store: &Store,
-    _broker: &Broker,
+    broker: &Broker,
     out: &mut BytesMut,
     now: Instant,
+    front: bool,
 ) -> CmdResult {
-    if args.len() < 3 {
-        resp::write_error(out, "ERR wrong number of arguments for 'lpush' command");
+    let name = if front { "lpush" } else { "rpush" };
+    let encrypted = args.last().is_some_and(|a| cmd_eq(a, b"ENCRYPTED"));
+    let end = if encrypted {
+        args.len() - 1
+    } else {
+        args.len()
+    };
+    if end < 3 {
+        resp::write_error(
+            out,
+            &format!("ERR wrong number of arguments for '{name}' command"),
+        );
         return CmdResult::Written;
     }
-    match store.lpush(args[1], &args[2..], now) {
+    let stored: Vec<Vec<u8>> = if encrypted {
+        match args[2..end]
+            .iter()
+            .map(|v| store.encrypt_list_element(v))
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(s) => s,
+            Err(e) => {
+                resp::write_error(out, &e);
+                return CmdResult::Written;
+            }
+        }
+    } else {
+        args[2..end].iter().map(|v| v.to_vec()).collect()
+    };
+    let refs: Vec<&[u8]> = stored.iter().map(Vec::as_slice).collect();
+    let res = if front {
+        store.lpush(args[1], &refs, now)
+    } else {
+        store.rpush(args[1], &refs, now)
+    };
+    match res {
         Ok(n) => {
+            if encrypted && store.wal_enabled() {
+                let raw_cmd: &[u8] = if front { b"RAWLPUSH" } else { b"RAWRPUSH" };
+                let mut owned: Vec<Vec<u8>> =
+                    vec![b"ENC".to_vec(), raw_cmd.to_vec(), args[1].to_vec()];
+                owned.extend(stored.iter().cloned());
+                let log_refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+                if let Err(e) = store.wal_log_command(&log_refs) {
+                    resp::write_error(out, &format!("ERR WAL append failed: {e}"));
+                    return CmdResult::Written;
+                }
+            }
             resp::write_integer(out, n);
             let key_s = arg_str(args[1]);
-            if _broker.has_list_waiters(key_s) {
+            if broker.has_list_waiters(key_s) {
                 let shard_idx = store.shard_for_key(args[1]);
                 let mut shard = store.lock_write_shard(shard_idx);
-                _broker.drain_list_waiters(key_s, &mut shard.data, now);
+                broker.drain_list_waiters(key_s, &mut shard.data, store, now);
             }
         }
         Err(e) => resp::write_error(out, &e),
@@ -82,10 +135,24 @@ pub fn cmd_lpush(
     CmdResult::Written
 }
 
+pub fn cmd_lpush(
+    args: &[&[u8]],
+    store: &Store,
+    broker: &Broker,
+    out: &mut BytesMut,
+    now: Instant,
+) -> CmdResult {
+    if args.len() < 3 {
+        resp::write_error(out, "ERR wrong number of arguments for 'lpush' command");
+        return CmdResult::Written;
+    }
+    push_list(args, store, broker, out, now, true)
+}
+
 pub fn cmd_rpush(
     args: &[&[u8]],
     store: &Store,
-    _broker: &Broker,
+    broker: &Broker,
     out: &mut BytesMut,
     now: Instant,
 ) -> CmdResult {
@@ -93,19 +160,7 @@ pub fn cmd_rpush(
         resp::write_error(out, "ERR wrong number of arguments for 'rpush' command");
         return CmdResult::Written;
     }
-    match store.rpush(args[1], &args[2..], now) {
-        Ok(n) => {
-            resp::write_integer(out, n);
-            let key_s = arg_str(args[1]);
-            if _broker.has_list_waiters(key_s) {
-                let shard_idx = store.shard_for_key(args[1]);
-                let mut shard = store.lock_write_shard(shard_idx);
-                _broker.drain_list_waiters(key_s, &mut shard.data, now);
-            }
-        }
-        Err(e) => resp::write_error(out, &e),
-    }
-    CmdResult::Written
+    push_list(args, store, broker, out, now, false)
 }
 
 pub fn cmd_lpushx(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
@@ -157,7 +212,7 @@ pub fn cmd_lpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
                         let items: Vec<Bytes> = (0..n).filter_map(|_| list.pop_front()).collect();
                         resp::write_array_header(out, items.len());
                         for item in &items {
-                            resp::write_bulk_raw(out, item);
+                            resp::write_bulk_raw(out, &decrypt_out(store, item.clone()));
                         }
                     }
                 } else {
@@ -170,7 +225,10 @@ pub fn cmd_lpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
             _ => resp::write_null_array(out),
         }
     } else {
-        resp::write_optional_bulk_raw(out, &store.lpop(args[1], now));
+        resp::write_optional_bulk_raw(
+            out,
+            &store.lpop(args[1], now).map(|b| decrypt_out(store, b)),
+        );
     }
     CmdResult::Written
 }
@@ -206,7 +264,7 @@ pub fn cmd_rpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
                         let items: Vec<Bytes> = (0..n).filter_map(|_| list.pop_back()).collect();
                         resp::write_array_header(out, items.len());
                         for item in &items {
-                            resp::write_bulk_raw(out, item);
+                            resp::write_bulk_raw(out, &decrypt_out(store, item.clone()));
                         }
                     }
                 } else {
@@ -219,7 +277,10 @@ pub fn cmd_rpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
             _ => resp::write_null_array(out),
         }
     } else {
-        resp::write_optional_bulk_raw(out, &store.rpop(args[1], now));
+        resp::write_optional_bulk_raw(
+            out,
+            &store.rpop(args[1], now).map(|b| decrypt_out(store, b)),
+        );
     }
     CmdResult::Written
 }
@@ -250,7 +311,10 @@ pub fn cmd_lrange(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         None => return CmdResult::Written,
     };
     match store.lrange(args[1], start, stop, now) {
-        Ok(items) => resp::write_bulk_array_raw(out, &items),
+        Ok(items) => {
+            let dec: Vec<Bytes> = items.into_iter().map(|b| decrypt_out(store, b)).collect();
+            resp::write_bulk_array_raw(out, &dec);
+        }
         Err(e) => resp::write_error(out, &e),
     }
     CmdResult::Written
@@ -265,7 +329,12 @@ pub fn cmd_lindex(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         Some(n) => n,
         None => return CmdResult::Written,
     };
-    resp::write_optional_bulk_raw(out, &store.lindex(args[1], index, now));
+    resp::write_optional_bulk_raw(
+        out,
+        &store
+            .lindex(args[1], index, now)
+            .map(|b| decrypt_out(store, b)),
+    );
     CmdResult::Written
 }
 
@@ -479,7 +548,12 @@ pub fn cmd_lmove(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         Some(side) => side,
         None => return CmdResult::Written,
     };
-    resp::write_optional_bulk_raw(out, &store.lmove(args[1], args[2], src_left, dst_left, now));
+    resp::write_optional_bulk_raw(
+        out,
+        &store
+            .lmove(args[1], args[2], src_left, dst_left, now)
+            .map(|b| decrypt_out(store, b)),
+    );
     CmdResult::Written
 }
 
@@ -488,7 +562,12 @@ pub fn cmd_rpoplpush(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Ins
         resp::write_error(out, "ERR wrong number of arguments for 'rpoplpush' command");
         return CmdResult::Written;
     }
-    resp::write_optional_bulk_raw(out, &store.lmove(args[1], args[2], false, true, now));
+    resp::write_optional_bulk_raw(
+        out,
+        &store
+            .lmove(args[1], args[2], false, true, now)
+            .map(|b| decrypt_out(store, b)),
+    );
     CmdResult::Written
 }
 
@@ -522,7 +601,7 @@ pub fn cmd_blpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         if let Some(v) = val {
             resp::write_array_header(out, 2);
             resp::write_bulk(out, key);
-            resp::write_bulk_raw(out, &v);
+            resp::write_bulk_raw(out, &decrypt_out(store, v));
             return CmdResult::Written;
         }
     }
@@ -555,7 +634,7 @@ pub fn cmd_blmove(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
     };
 
     if let Some(v) = store.lmove(args[1], args[2], src_left, dst_left, now) {
-        resp::write_bulk_raw(out, &v);
+        resp::write_bulk_raw(out, &decrypt_out(store, v));
         return CmdResult::Written;
     }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -3831,6 +3831,47 @@ mod tests {
     }
 
     #[test]
+    fn rotate_rewrap_retire_preserves_vector_across_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(
+            &store,
+            &[
+                b"VSET",
+                b"emb:1",
+                b"3",
+                b"1.5",
+                b"2.5",
+                b"3.5",
+                b"ENCRYPTED",
+            ],
+        );
+        exec(&store, &[b"ENC", b"ROTATE", b"KEYID", b"k2"]);
+        assert!(!exec_str(&store, &[b"ENC", b"REWRAP"]).contains("ERR"));
+        assert!(exec_str(&store, &[b"ENC", b"RETIRE", b"k1"]).contains("OK"));
+
+        // Restart from disk: the vector's snapshot envelope must have been
+        // re-sealed under k2 (old key retired), else decrypt-on-load fails.
+        let restored = Store::new_with_config(config);
+        let _ = crate::snapshot::load(&restored);
+        restored.replay_wal(&Broker::new());
+        let got = exec_str(&restored, &[b"VGET", b"emb:1"]);
+        assert!(
+            got.contains("1.5") && got.contains("2.5") && got.contains("3.5"),
+            "vector after rotate/retire/restart: {got}"
+        );
+    }
+
+    #[test]
     fn enc_rotate_rewrap_then_retire_preserves_existing_data() {
         let dir = tempfile::tempdir().unwrap();
         let config = Arc::new(ServerConfig {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -4017,6 +4017,76 @@ mod tests {
     }
 
     #[test]
+    fn encrypted_string_rejects_bit_operations() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::new_with_config(Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        }));
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(&store, &[b"SET", b"bk", b"topsecret", b"ENCRYPTED"]);
+        // SETBIT must be rejected and must NOT corrupt the envelope.
+        assert!(exec_str(&store, &[b"SETBIT", b"bk", b"0", b"1"]).contains("ERR"));
+        assert!(
+            exec_str(&store, &[b"GET", b"bk"]).contains("topsecret"),
+            "value must survive a rejected SETBIT"
+        );
+        // BITOP with an encrypted operand is rejected and leaves it intact.
+        exec(&store, &[b"SET", b"plain", b"AAAA"]);
+        assert!(exec_str(&store, &[b"BITOP", b"AND", b"bk", b"bk", b"plain"]).contains("ERR"));
+        assert!(
+            exec_str(&store, &[b"GET", b"bk"]).contains("topsecret"),
+            "value must survive a rejected BITOP"
+        );
+        // Reads over the envelope are refused rather than returning ciphertext-based answers.
+        assert!(exec_str(&store, &[b"GETBIT", b"bk", b"0"]).contains("ERR"));
+        assert!(exec_str(&store, &[b"BITCOUNT", b"bk"]).contains("ERR"));
+    }
+
+    #[test]
+    fn encrypted_key_relocation_is_rejected_but_data_survives() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::new_with_config(Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        }));
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(&store, &[b"SET", b"a", b"rename-secret", b"ENCRYPTED"]);
+        // RENAME / COPY of an encrypted key must be refused, leaving the source intact.
+        assert!(exec_str(&store, &[b"RENAME", b"a", b"b"]).contains("ERR"));
+        assert!(
+            exec_str(&store, &[b"GET", b"a"]).contains("rename-secret"),
+            "source must survive a rejected RENAME"
+        );
+        assert!(exec_str(&store, &[b"COPY", b"a", b"c"]).contains("ERR"));
+        assert!(exec_str(&store, &[b"GET", b"a"]).contains("rename-secret"));
+        // Non-encrypted keys still rename normally (the guard must not over-block).
+        exec(&store, &[b"SET", b"plain", b"hello"]);
+        assert!(exec_str(&store, &[b"RENAME", b"plain", b"plain2"]).contains("OK"));
+        assert!(exec_str(&store, &[b"GET", b"plain2"]).contains("hello"));
+    }
+
+    #[test]
+    fn vset_encryption_is_sticky() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::new_with_config(Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        }));
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(&store, &[b"VSET", b"v", b"2", b"1.0", b"2.0", b"ENCRYPTED"]);
+        // Re-set WITHOUT the flag, using a distinctive value, must stay encrypted.
+        exec(&store, &[b"VSET", b"v", b"2", b"111222.5", b"0.0"]);
+        crate::snapshot::save_and_truncate_wal_consistent(&store).unwrap();
+        let dat = std::fs::read(dir.path().join("lux.dat")).unwrap();
+        let needle = 111222.5f32.to_le_bytes();
+        assert!(
+            !dat.windows(4).any(|w| w == needle),
+            "re-set vector silently downgraded to plaintext-at-rest"
+        );
+    }
+
+    #[test]
     fn enc_rotate_rewrap_then_retire_preserves_existing_data() {
         let dir = tempfile::tempdir().unwrap();
         let config = Arc::new(ServerConfig {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -4157,6 +4157,37 @@ mod tests {
     }
 
     #[test]
+    fn encrypted_overwrite_to_expiry_does_not_resurrect_after_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec_wal(&store, &[b"SET", b"ek", b"orig-secret", b"ENCRYPTED"]);
+        // Overwrite with an already-past absolute expiry: live, the key is gone.
+        exec_wal(
+            &store,
+            &[b"SET", b"ek", b"new-secret", b"EXAT", b"1", b"ENCRYPTED"],
+        );
+        store.fsync_wal();
+
+        // Replay from WAL: the prior encrypted value must NOT come back.
+        let restored = Store::new_with_config(config);
+        restored.replay_wal(&Broker::new());
+        let got = exec_str(&restored, &[b"GET", b"ek"]);
+        assert!(
+            !got.contains("orig-secret"),
+            "stale encrypted value resurrected after replay: {got}"
+        );
+    }
+
+    #[test]
     fn enc_rotate_rewrap_then_retire_preserves_existing_data() {
         let dir = tempfile::tempdir().unwrap();
         let config = Arc::new(ServerConfig {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -4120,6 +4120,43 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_load_fails_loudly_when_encrypted_vector_cant_decrypt() {
+        // Store A: encrypt a vector and snapshot it.
+        let dir_a = tempfile::tempdir().unwrap();
+        let store_a = Store::new_with_config(Arc::new(ServerConfig {
+            data_dir: dir_a.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        }));
+        exec(&store_a, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(
+            &store_a,
+            &[b"VSET", b"v", b"2", b"1.0", b"2.0", b"ENCRYPTED"],
+        );
+        crate::snapshot::save_and_truncate_wal_consistent(&store_a).unwrap();
+        let dat = std::fs::read(dir_a.path().join("lux.dat")).unwrap();
+
+        // Store B has its own (different) keyring. Drop A's snapshot in and load.
+        let dir_b = tempfile::tempdir().unwrap();
+        let store_b = Store::new_with_config(Arc::new(ServerConfig {
+            data_dir: dir_b.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        }));
+        exec(&store_b, &[b"ENC", b"INIT", b"KEYID", b"other"]);
+        std::fs::write(dir_b.path().join("lux.dat"), &dat).unwrap();
+        // Must fail loudly (startup then refuses), not silently drop the vector
+        // and cascade — and the on-disk snapshot is left intact for recovery.
+        assert!(
+            crate::snapshot::load(&store_b).is_err(),
+            "load must error on an undecryptable encrypted vector"
+        );
+        assert_eq!(
+            std::fs::read(dir_b.path().join("lux.dat")).unwrap(),
+            dat,
+            "load must not modify the on-disk snapshot"
+        );
+    }
+
+    #[test]
     fn enc_rotate_rewrap_then_retire_preserves_existing_data() {
         let dir = tempfile::tempdir().unwrap();
         let config = Arc::new(ServerConfig {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2315,6 +2315,10 @@ fn command_self_logs_wal_args(args: &[&[u8]], store: &Store, now: Instant) -> bo
             return encrypted || store.hash_fields_need_encryption(args[1], &fields, now);
         }
     }
+    if cmd_eq(cmd, b"VSET") {
+        // Encrypted VSET self-logs ENC RAWVSET with the sealed payload.
+        return args.iter().any(|arg| cmd_eq(arg, b"ENCRYPTED"));
+    }
     false
 }
 
@@ -3750,6 +3754,80 @@ mod tests {
         assert!(got.contains("hash-secret-value"), "{got}");
         let scan = exec_str(&restored, &[b"HSCAN", b"profile:1", b"0"]);
         assert!(scan.contains("hash-secret-value"), "{scan}");
+    }
+
+    #[test]
+    fn encrypted_vset_self_logs_ciphertext_and_replays() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        let out = String::from_utf8_lossy(&exec_wal(
+            &store,
+            &[
+                b"VSET",
+                b"emb:1",
+                b"3",
+                b"1.5",
+                b"2.5",
+                b"3.5",
+                b"ENCRYPTED",
+            ],
+        ))
+        .to_string();
+        assert!(out.contains("OK"), "{out}");
+        store.fsync_wal();
+        let wal = read_wal_bytes(dir.path());
+        assert!(
+            wal.windows(b"RAWVSET".len()).any(|w| w == b"RAWVSET"),
+            "encrypted VSET must self-log ENC RAWVSET"
+        );
+        assert!(
+            !wal.windows(b"2.5".len()).any(|w| w == b"2.5"),
+            "WAL must not contain the plaintext vector components"
+        );
+
+        let restored = Store::new_with_config(config);
+        restored.replay_wal(&Broker::new());
+        let got = exec_str(&restored, &[b"VGET", b"emb:1"]);
+        assert!(
+            got.contains("1.5") && got.contains("2.5") && got.contains("3.5"),
+            "{got}"
+        );
+    }
+
+    #[test]
+    fn encrypt_vector_roundtrips_and_hides_plaintext() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::new_with_config(Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        }));
+        store.encryption().init(Some("k1")).unwrap();
+        let v = vec![1.5f32, -2.25, 3.0, 0.125];
+        let sealed = store.encrypt_vector(b"emb:1", &v).unwrap();
+
+        // The raw little-endian f32 bytes must not appear in the envelope.
+        let mut plain = Vec::new();
+        for f in &v {
+            plain.extend_from_slice(&f.to_le_bytes());
+        }
+        assert!(
+            !sealed.windows(plain.len()).any(|w| w == plain.as_slice()),
+            "plaintext vector bytes leaked into the envelope"
+        );
+
+        // Round-trips under the same key context.
+        assert_eq!(store.decrypt_vector(b"emb:1", &sealed).unwrap(), v);
+        // AAD binds the storage key: a different key must not decrypt.
+        assert!(store.decrypt_vector(b"other:key", &sealed).is_err());
     }
 
     #[test]

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -3852,6 +3852,59 @@ mod tests {
     }
 
     #[test]
+    fn rotate_rewrap_retire_preserves_list_and_stream_across_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(
+            &store,
+            &[b"RPUSH", b"l", b"list-rotate-secret", b"ENCRYPTED"],
+        );
+        exec(
+            &store,
+            &[
+                b"XADD",
+                b"s",
+                b"*",
+                b"f",
+                b"stream-rotate-secret",
+                b"ENCRYPTED",
+            ],
+        );
+        exec(&store, &[b"ENC", b"ROTATE", b"KEYID", b"k2"]);
+        let rewrap = exec_str(&store, &[b"ENC", b"REWRAP"]);
+        assert!(!rewrap.contains("ERR"), "rewrap: {rewrap}");
+        assert!(
+            exec_str(&store, &[b"ENC", b"RETIRE", b"k1"]).contains("OK"),
+            "retire k1 should succeed once list/stream are rewrapped"
+        );
+
+        // Restart from disk (snapshot re-sealed under k2, WAL truncated): the old
+        // key is gone, so this fails if REWRAP didn't cover list/stream + persist.
+        let restored = Store::new_with_config(config);
+        let _ = crate::snapshot::load(&restored);
+        restored.replay_wal(&Broker::new());
+        let l = exec_str(&restored, &[b"LRANGE", b"l", b"0", b"-1"]);
+        assert!(
+            l.contains("list-rotate-secret"),
+            "list after rotate/retire/restart: {l}"
+        );
+        let s = exec_str(&restored, &[b"XRANGE", b"s", b"-", b"+"]);
+        assert!(
+            s.contains("stream-rotate-secret"),
+            "stream after rotate/retire/restart: {s}"
+        );
+    }
+
+    #[test]
     fn enc_rotate_rewrap_then_retire_preserves_existing_data() {
         let dir = tempfile::tempdir().unwrap();
         let config = Arc::new(ServerConfig {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -4087,6 +4087,39 @@ mod tests {
     }
 
     #[test]
+    fn cold_tiered_encrypted_value_survives_rotate_rewrap_retire() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config);
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(&store, &[b"SET", b"cold", b"cold-secret", b"ENCRYPTED"]);
+        // Force it onto the cold tier (where the rewrap/retire guard was blind).
+        let idx = store.shard_for_key(b"cold");
+        assert!(
+            store.evict_key(idx, b"cold"),
+            "value should evict to cold tier"
+        );
+        exec(&store, &[b"ENC", b"ROTATE", b"KEYID", b"k2"]);
+        assert!(!exec_str(&store, &[b"ENC", b"REWRAP"]).contains("ERR"));
+        // Retire must succeed (cold value rewrapped) and the value must survive.
+        assert!(
+            exec_str(&store, &[b"ENC", b"RETIRE", b"k1"]).contains("OK"),
+            "retire should succeed once the cold value is rewrapped"
+        );
+        assert!(
+            exec_str(&store, &[b"GET", b"cold"]).contains("cold-secret"),
+            "cold-tiered encrypted value must survive rotate+rewrap+retire"
+        );
+    }
+
+    #[test]
     fn enc_rotate_rewrap_then_retire_preserves_existing_data() {
         let dir = tempfile::tempdir().unwrap();
         let config = Arc::new(ServerConfig {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2303,6 +2303,11 @@ fn command_self_logs_wal_args(args: &[&[u8]], store: &Store, now: Instant) -> bo
         return args[3..].iter().any(|arg| cmd_eq(arg, b"ENCRYPTED"))
             || store.kv_string_is_encrypted(args[1], now);
     }
+    if (cmd_eq(cmd, b"LPUSH") || cmd_eq(cmd, b"RPUSH")) && args.len() >= 4 {
+        // Encrypted pushes self-log ENC RAWLPUSH/RAWRPUSH with the resolved
+        // ciphertext; plaintext pushes take the normal WAL path.
+        return args.last().is_some_and(|arg| cmd_eq(arg, b"ENCRYPTED"));
+    }
     if (cmd_eq(cmd, b"HSET") || cmd_eq(cmd, b"HMSET")) && args.len() >= 4 {
         let encrypted = args.last().is_some_and(|arg| cmd_eq(arg, b"ENCRYPTED"));
         let end = if encrypted {
@@ -3750,6 +3755,100 @@ mod tests {
         assert!(got.contains("hash-secret-value"), "{got}");
         let scan = exec_str(&restored, &[b"HSCAN", b"profile:1", b"0"]);
         assert!(scan.contains("hash-secret-value"), "{scan}");
+    }
+
+    #[test]
+    fn encrypted_lpush_self_logs_ciphertext_and_replays() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        let out = String::from_utf8_lossy(&exec_wal(
+            &store,
+            &[
+                b"RPUSH",
+                b"events",
+                b"list-secret-one",
+                b"list-secret-two",
+                b"ENCRYPTED",
+            ],
+        ))
+        .to_string();
+        assert!(out.contains(":2"), "{out}");
+        store.fsync_wal();
+        let wal = read_wal_bytes(dir.path());
+        assert!(!wal
+            .windows(b"list-secret-one".len())
+            .any(|w| w == b"list-secret-one"));
+        assert!(wal.windows(b"RAWRPUSH".len()).any(|w| w == b"RAWRPUSH"));
+
+        let restored = Store::new_with_config(config);
+        restored.replay_wal(&Broker::new());
+        let got = exec_str(&restored, &[b"LRANGE", b"events", b"0", b"-1"]);
+        assert!(got.contains("list-secret-one"), "{got}");
+        assert!(got.contains("list-secret-two"), "{got}");
+    }
+
+    #[test]
+    fn encrypted_list_element_survives_lmove_across_keys() {
+        // List AAD is key-independent, so an encrypted element stays decryptable
+        // after LMOVE relocates it to a different list.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::new_with_config(Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        }));
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        exec(&store, &[b"RPUSH", b"src", b"move-me-secret", b"ENCRYPTED"]);
+        exec(&store, &[b"LMOVE", b"src", b"dst", b"LEFT", b"RIGHT"]);
+        let got = exec_str(&store, &[b"LRANGE", b"dst", b"0", b"-1"]);
+        assert!(got.contains("move-me-secret"), "{got}");
+    }
+
+    #[test]
+    fn encrypted_xadd_self_logs_ciphertext_and_replays() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            storage: StorageConfig {
+                mode: StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config.clone());
+        exec(&store, &[b"ENC", b"INIT", b"KEYID", b"k1"]);
+        let out = String::from_utf8_lossy(&exec_wal(
+            &store,
+            &[
+                b"XADD",
+                b"stream:1",
+                b"*",
+                b"payload",
+                b"stream-secret-value",
+                b"ENCRYPTED",
+            ],
+        ))
+        .to_string();
+        assert!(out.contains('-'), "{out}"); // resolved stream id like <ms>-<seq>
+        store.fsync_wal();
+        let wal = read_wal_bytes(dir.path());
+        assert!(!wal
+            .windows(b"stream-secret-value".len())
+            .any(|w| w == b"stream-secret-value"));
+
+        let restored = Store::new_with_config(config);
+        restored.replay_wal(&Broker::new());
+        let got = exec_str(&restored, &[b"XRANGE", b"stream:1", b"-", b"+"]);
+        assert!(got.contains("stream-secret-value"), "{got}");
+        assert!(got.contains("payload"), "{got}");
     }
 
     #[test]

--- a/src/cmd/streams.rs
+++ b/src/cmd/streams.rs
@@ -72,6 +72,41 @@ fn log_resolved_xadd(store: &Store, args: &[&[u8]], id: StreamId, out: &mut Byte
     }
 }
 
+/// Self-log an encrypted XADD as a normal XADD carrying the resolved id and the
+/// sealed ciphertext values (the ENCRYPTED flag is dropped). On replay the
+/// envelope bytes are stored verbatim (no ENCRYPTED flag => no re-encryption),
+/// and reads decrypt them via the envelope magic prefix.
+fn log_encrypted_xadd(
+    store: &Store,
+    args: &[&[u8]],
+    id: StreamId,
+    fields: &[(String, Bytes)],
+    out: &mut BytesMut,
+) -> bool {
+    if !store.wal_enabled() {
+        return true;
+    }
+    let Some(id_idx) = xadd_id_arg_index(args) else {
+        return true;
+    };
+    let mut owned: Vec<Vec<u8>> = vec![b"XADD".to_vec(), args[1].to_vec()];
+    // Preserve trimming options (MAXLEN/MINID/NOMKSTREAM) that sit before the id.
+    owned.extend(args[2..id_idx].iter().map(|a| a.to_vec()));
+    owned.push(id.to_string().into_bytes());
+    for (name, val) in fields {
+        owned.push(name.as_bytes().to_vec());
+        owned.push(val.to_vec());
+    }
+    let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+    match store.wal_log_command(&refs) {
+        Ok(()) => true,
+        Err(e) => {
+            resp::write_error(out, &format!("ERR WAL append failed: {e}"));
+            false
+        }
+    }
+}
+
 pub fn cmd_xadd(
     args: &[&[u8]],
     store: &Store,
@@ -83,6 +118,9 @@ pub fn cmd_xadd(
         resp::write_error(out, "ERR wrong number of arguments for 'xadd' command");
         return CmdResult::Written;
     }
+    // Trailing ENCRYPTED flag (mirrors SET/HSET): seal each field value.
+    let encrypted = args.last().is_some_and(|a| cmd_eq(a, b"ENCRYPTED"));
+    let arg_end = args.len() - encrypted as usize;
     let mut i = 2;
     let mut maxlen: Option<usize> = None;
     while i < args.len() {
@@ -101,27 +139,40 @@ pub fn cmd_xadd(
             break;
         }
     }
-    if i >= args.len() {
+    if i >= arg_end {
         resp::write_error(out, "ERR wrong number of arguments for 'xadd' command");
         return CmdResult::Written;
     }
     let id_input = arg_str(args[i]);
     i += 1;
-    if (args.len() - i) < 2 || !(args.len() - i).is_multiple_of(2) {
+    if (arg_end - i) < 2 || !(arg_end - i).is_multiple_of(2) {
         resp::write_error(out, "ERR wrong number of arguments for 'xadd' command");
         return CmdResult::Written;
     }
     let mut fields = Vec::new();
-    while i + 1 < args.len() {
-        fields.push((
-            arg_str(args[i]).to_string(),
-            Bytes::copy_from_slice(args[i + 1]),
-        ));
+    while i + 1 < arg_end {
+        let value = if encrypted {
+            match store.encrypt_stream_value(args[1], args[i], args[i + 1]) {
+                Ok(ct) => Bytes::from(ct),
+                Err(e) => {
+                    resp::write_error(out, &e);
+                    return CmdResult::Written;
+                }
+            }
+        } else {
+            Bytes::copy_from_slice(args[i + 1])
+        };
+        fields.push((arg_str(args[i]).to_string(), value));
         i += 2;
     }
-    match store.xadd(args[1], id_input, fields, maxlen, now) {
+    match store.xadd(args[1], id_input, fields.clone(), maxlen, now) {
         Ok(id) => {
-            if !log_resolved_xadd(store, args, id, out) {
+            let logged = if encrypted {
+                log_encrypted_xadd(store, args, id, &fields, out)
+            } else {
+                log_resolved_xadd(store, args, id, out)
+            };
+            if !logged {
                 return CmdResult::Written;
             }
             resp::write_bulk(out, &id.to_string());

--- a/src/cmd/strings.rs
+++ b/src/cmd/strings.rs
@@ -196,6 +196,9 @@ pub fn cmd_set(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) 
         Ok((set, old)) => {
             if set && should_self_log && store.wal_enabled() {
                 if let Some(raw) = store.get_raw_string(args[1], now) {
+                    // Self-log the resolved ciphertext plus the original SET
+                    // options (minus ENCRYPTED), incl. EX/PX/EXAT/PXAT, which
+                    // ENC RAWSET replays faithfully so expiry survives a restart.
                     let mut owned: Vec<Vec<u8>> = Vec::with_capacity(args.len());
                     owned.push(b"ENC".to_vec());
                     owned.push(b"RAWSET".to_vec());

--- a/src/cmd/vectors.rs
+++ b/src/cmd/vectors.rs
@@ -40,8 +40,12 @@ pub fn cmd_vset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
     let mut i = 3 + dims;
     let mut metadata = None;
     let mut ttl = None;
+    let mut encrypted = false;
     while i < args.len() {
-        if cmd_eq(args[i], b"META") {
+        if cmd_eq(args[i], b"ENCRYPTED") {
+            encrypted = true;
+            i += 1;
+        } else if cmd_eq(args[i], b"META") {
             if i + 1 >= args.len() {
                 resp::write_error(out, "ERR syntax error");
                 return CmdResult::Written;
@@ -79,7 +83,39 @@ pub fn cmd_vset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
             return CmdResult::Written;
         }
     }
-    store.vset(key, data, metadata, ttl, now);
+    // Encrypted vectors keep plaintext in RAM but self-log the sealed payload as
+    // ENC RAWVSET so the WAL carries no plaintext f32 (mirrors SET ... ENCRYPTED).
+    let sealed = if encrypted {
+        match store.encrypt_vector(key, &data) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                resp::write_error(out, &e);
+                return CmdResult::Written;
+            }
+        }
+    } else {
+        None
+    };
+    store.vset(key, data, metadata.clone(), ttl, encrypted, now);
+    if let Some(ct) = sealed {
+        if store.wal_enabled() {
+            let mut owned: Vec<Vec<u8>> =
+                vec![b"ENC".to_vec(), b"RAWVSET".to_vec(), key.to_vec(), ct];
+            if let Some(m) = &metadata {
+                owned.push(b"META".to_vec());
+                owned.push(m.as_bytes().to_vec());
+            }
+            if let Some(d) = ttl {
+                owned.push(b"EX".to_vec());
+                owned.push(d.as_secs().to_string().into_bytes());
+            }
+            let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+            if let Err(e) = store.wal_log_command(&refs) {
+                resp::write_error(out, &format!("ERR WAL append failed: {e}"));
+                return CmdResult::Written;
+            }
+        }
+    }
     resp::write_ok(out);
     CmdResult::Written
 }

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -951,7 +951,10 @@ pub fn write_single_entry(w: &mut impl Write, entry: &DumpEntry) -> io::Result<(
             }
             write_stream_groups(w, groups)?;
         }
-        DumpValue::Vector(data, metadata) => {
+        // Vectors are pinned to the hot tier (eviction skips them), so an
+        // encrypted vector never reaches cold-tier disk; the flag is not
+        // persisted here and reads back as plaintext.
+        DumpValue::Vector(data, metadata, _) => {
             write_u32(w, data.len() as u32)?;
             for f in data {
                 w.write_all(&f.to_le_bytes())?;
@@ -1063,7 +1066,7 @@ pub fn read_single_entry(r: &mut impl Read) -> io::Result<(String, DumpValue, i6
             } else {
                 None
             };
-            DumpValue::Vector(data, metadata)
+            DumpValue::Vector(data, metadata, false)
         }
         b'P' => {
             let len = read_u32(r)? as usize;
@@ -1449,7 +1452,7 @@ mod tests {
                 prop::collection::vec(-1e6f32..1e6f32, 0..64),
                 prop::option::of(arb_string())
             )
-                .prop_map(|(data, meta)| DumpValue::Vector(data, meta)),
+                .prop_map(|(data, meta)| DumpValue::Vector(data, meta, false)),
             prop::collection::vec(any::<u8>(), 0..256).prop_map(|regs| {
                 let cached = crate::hll::hll_count(&regs);
                 DumpValue::HyperLogLog(regs, cached)
@@ -1497,7 +1500,9 @@ mod tests {
             (DumpValue::Stream(ae, al, ag), DumpValue::Stream(be, bl, bg)) => {
                 ae == be && al == bl && ag == bg
             }
-            (DumpValue::Vector(ad, am), DumpValue::Vector(bd, bm)) => ad == bd && am == bm,
+            (DumpValue::Vector(ad, am, ae), DumpValue::Vector(bd, bm, be)) => {
+                ad == bd && am == bm && ae == be
+            }
             (DumpValue::HyperLogLog(ar, _), DumpValue::HyperLogLog(br, _)) => ar == br,
             (DumpValue::TimeSeries(as_, ar, al), DumpValue::TimeSeries(bs, br, bl)) => {
                 as_ == bs && ar == br && al == bl

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1746,9 +1746,12 @@ impl EmbeddedClient {
         }
         let key_s = std::str::from_utf8(key).unwrap_or("");
         if self.runtime.broker.has_list_waiters(key_s) {
-            self.runtime
-                .broker
-                .drain_list_waiters(key_s, &mut shard.data, now);
+            self.runtime.broker.drain_list_waiters(
+                key_s,
+                &mut shard.data,
+                &self.runtime.store,
+                now,
+            );
         }
     }
 
@@ -3643,7 +3646,10 @@ impl CommandExecutor {
 
         if !cmd::is_pipeline_special_command(args[0]) {
             let access = cmd::pipeline_access_for_args(args);
-            if access == cmd::PipelineAccess::Read {
+            // The shard-local read fast-path reads stored bytes directly and has
+            // no keyring, so it cannot decrypt. When encryption is active, fall
+            // through to the slow path (cmd::execute) which decrypts on read.
+            if access == cmd::PipelineAccess::Read && !self.store.encryption().has_active_key() {
                 let command = [ShardPipelineCommand { args, access }];
                 let shard_idx = self.store.shard_for_key(args[1]);
                 if let Err(err) = self
@@ -3766,7 +3772,10 @@ impl CommandExecutor {
             }
         }
 
-        if has_special || !all_single_key_rw {
+        // When encryption is active, the shard-local fast batch path can neither
+        // encrypt writes nor decrypt reads (no keyring there), so force every
+        // command onto the slow path (cmd::execute) which handles both.
+        if has_special || !all_single_key_rw || self.store.encryption().has_active_key() {
             for command in commands {
                 let args = command.argv();
                 if !session.authenticated && !is_public_without_auth_cmd(args[0]) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3044,12 +3044,29 @@ impl Runtime {
         match snapshot::load(&runtime.store) {
             Ok(0) => emit_info(&runtime.config, ServerInfoEvent::NoSnapshotFound),
             Ok(n) => emit_info(&runtime.config, ServerInfoEvent::SnapshotLoaded { keys: n }),
-            Err(e) => emit_error(
-                &runtime.config,
-                ServerErrorEvent::SnapshotLoadFailed {
-                    error: e.to_string(),
-                },
-            ),
+            Err(e) => {
+                // Refuse to start on a load failure (e.g. an encrypted value the
+                // current keyring can't decrypt) rather than coming up with a
+                // truncated dataset that the background save would then overwrite.
+                // The on-disk snapshot is left intact and recoverable; supply the
+                // correct keyring/seal and restart.
+                runtime
+                    .store
+                    .wal_suppress
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
+                emit_error(
+                    &runtime.config,
+                    ServerErrorEvent::SnapshotLoadFailed {
+                        error: e.to_string(),
+                    },
+                );
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "refusing to start: snapshot load failed, on-disk data preserved (not overwritten): {e}"
+                    ),
+                ));
+            }
         }
         runtime
             .store

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -155,6 +155,7 @@ impl Broker {
         &self,
         key: &str,
         shard_data: &mut crate::store::ShardData,
+        store: &crate::store::Store,
         now: std::time::Instant,
     ) {
         let mut waiters = self.list_waiters.lock();
@@ -181,6 +182,9 @@ impl Broker {
                 list.pop_back()
             };
             if let Some(v) = val {
+                // Decrypt encrypted list elements before handing them to the
+                // blocked waiter (deferred BLPOP/BRPOP resolution).
+                let v = store.decrypt_list_element(v.clone()).unwrap_or(v);
                 let _ = req.tx.try_send((key.to_string(), v));
             }
         }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -133,7 +133,7 @@ fn save_entries(store: &Store, entries: &[crate::store::DumpEntry]) -> io::Resul
     let tmp = format!("{path}.{}.tmp", std::process::id());
     let file = fs::File::create(&tmp)?;
     let mut w = BufWriter::new(file);
-    save_binary(&mut w, entries)?;
+    save_binary(&mut w, entries, store)?;
     w.into_inner().map_err(io::Error::other)?.sync_all()?;
     fs::rename(&tmp, &path)?;
     Ok(entries.len())
@@ -221,7 +221,11 @@ fn purge_lux_storage_shards(storage_dir: &Path) -> io::Result<()> {
     Ok(())
 }
 
-fn save_binary(w: &mut impl Write, entries: &[crate::store::DumpEntry]) -> io::Result<()> {
+fn save_binary(
+    w: &mut impl Write,
+    entries: &[crate::store::DumpEntry],
+    store: &Store,
+) -> io::Result<()> {
     w.write_all(HEADER)?;
     for entry in entries {
         let type_byte: u8 = match &entry.value {
@@ -231,7 +235,8 @@ fn save_binary(w: &mut impl Write, entries: &[crate::store::DumpEntry]) -> io::R
             DumpValue::Set(_) => b'T',
             DumpValue::SortedSet(_) => b'Z',
             DumpValue::Stream(..) => b'X',
-            DumpValue::Vector(..) => b'V',
+            DumpValue::Vector(_, _, true) => b'W',
+            DumpValue::Vector(_, _, false) => b'V',
             DumpValue::HyperLogLog(..) => b'P',
             DumpValue::TimeSeries(..) => b'I',
         };
@@ -308,10 +313,18 @@ fn save_binary(w: &mut impl Write, entries: &[crate::store::DumpEntry]) -> io::R
                     }
                 }
             }
-            DumpValue::Vector(data, metadata) => {
-                write_u32(w, data.len() as u32)?;
-                for f in data {
-                    w.write_all(&f.to_le_bytes())?;
+            DumpValue::Vector(data, metadata, encrypted) => {
+                if *encrypted {
+                    // Seal the f32 payload; the 'W' type byte marks it encrypted.
+                    let sealed = store
+                        .encrypt_vector(entry.key.as_bytes(), data)
+                        .map_err(io::Error::other)?;
+                    write_bytes(w, &sealed)?;
+                } else {
+                    write_u32(w, data.len() as u32)?;
+                    for f in data {
+                        w.write_all(&f.to_le_bytes())?;
+                    }
                 }
                 match metadata {
                     Some(m) => {
@@ -507,7 +520,22 @@ pub(crate) fn load_binary(
                 } else {
                     None
                 };
-                DumpValue::Vector(data, metadata)
+                DumpValue::Vector(data, metadata, false)
+            }
+            b'W' => {
+                // Encrypted vector: sealed f32 payload, decrypted with the key.
+                let sealed = read_bytes(r)?;
+                let mut flag = [0u8; 1];
+                r.read_exact(&mut flag)?;
+                let metadata = if flag[0] == 1 {
+                    Some(read_string(r)?)
+                } else {
+                    None
+                };
+                let data = store
+                    .decrypt_vector(key.as_bytes(), &sealed)
+                    .map_err(io::Error::other)?;
+                DumpValue::Vector(data, metadata, true)
             }
             b'P' => {
                 let len = read_sized_count(r, "hyperloglog register", 1)?;
@@ -731,7 +759,7 @@ fn save_to_path(store: &Store, path: &str) -> io::Result<usize> {
     let tmp = format!("{path}.tmp");
     let file = fs::File::create(&tmp)?;
     let mut w = BufWriter::new(file);
-    save_binary(&mut w, &entries)?;
+    save_binary(&mut w, &entries, store)?;
     w.into_inner().map_err(io::Error::other)?.sync_all()?;
     fs::rename(&tmp, path)?;
     Ok(entries.len())

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1288,6 +1288,73 @@ impl Store {
             .encrypt("__lux_kv", "value", &key_name, value)
     }
 
+    /// Encrypt a list element. AAD is intentionally key-independent so an
+    /// envelope stays decryptable after LMOVE/RPOPLPUSH move it to another list
+    /// (no re-keying). Per-value random DEK + nonce still protects each element.
+    pub(crate) fn encrypt_list_element(&self, value: &[u8]) -> Result<Vec<u8>, String> {
+        self.encryption()
+            .encrypt("__lux_list", "element", "", value)
+    }
+
+    /// Decrypt a list element if it is an encryption envelope; pass plaintext
+    /// through untouched so encrypted and plaintext elements can coexist.
+    pub(crate) fn decrypt_list_element(&self, value: Bytes) -> Result<Bytes, String> {
+        if !crate::encryption::EncryptionKeyring::is_encrypted_value(&value) {
+            return Ok(value);
+        }
+        self.encryption()
+            .decrypt("__lux_list", "element", "", &value)
+            .map(Bytes::from)
+    }
+
+    /// Encrypt a stream entry field value. AAD binds the stream key + field.
+    pub(crate) fn encrypt_stream_value(
+        &self,
+        key: &[u8],
+        field: &[u8],
+        value: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        let key_name = Self::user_kv_key(key);
+        let field_name = Self::user_hash_field(field);
+        self.encryption()
+            .encrypt("__lux_stream", &field_name, &key_name, value)
+    }
+
+    /// Decrypt a stream entry field value if it is an envelope.
+    pub(crate) fn decrypt_stream_value(
+        &self,
+        key: &[u8],
+        field: &[u8],
+        value: Bytes,
+    ) -> Result<Bytes, String> {
+        if !crate::encryption::EncryptionKeyring::is_encrypted_value(&value) {
+            return Ok(value);
+        }
+        let key_name = Self::user_kv_key(key);
+        let field_name = Self::user_hash_field(field);
+        self.encryption()
+            .decrypt("__lux_stream", &field_name, &key_name, &value)
+            .map(Bytes::from)
+    }
+
+    /// Decrypt all field values of one stream entry for output. Plaintext (and,
+    /// defensively, undecryptable) values pass through unchanged.
+    pub(crate) fn decrypt_stream_fields(
+        &self,
+        key: &[u8],
+        fields: &[(String, Bytes)],
+    ) -> Vec<(String, Bytes)> {
+        fields
+            .iter()
+            .map(|(f, v)| {
+                let dv = self
+                    .decrypt_stream_value(key, f.as_bytes(), v.clone())
+                    .unwrap_or_else(|_| v.clone());
+                (f.clone(), dv)
+            })
+            .collect()
+    }
+
     pub(crate) fn decrypt_hash_field_value(
         &self,
         key: &[u8],

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -634,6 +634,11 @@ impl Store {
                 self.remove_from_disk(&key);
             }
         }
+        // Encrypted vectors keep plaintext in RAM (nothing to rewrap in place),
+        // but their at-rest envelope must be re-sealed under the current keyset;
+        // a consistent save rewrites it and truncates the WAL.
+        crate::snapshot::save_and_truncate_wal_consistent(self)
+            .map_err(|e| format!("ERR rewrap persist failed: {e}"))?;
         Ok(count)
     }
 
@@ -673,6 +678,11 @@ impl Store {
                 }
             }
         }
+        // Re-seal at-rest data (including plaintext-in-RAM vectors, whose disk
+        // envelope is rewritten under the current keyset) and truncate the WAL
+        // before removing the key, so nothing persisted still references it.
+        crate::snapshot::save_and_truncate_wal_consistent(self)
+            .map_err(|e| format!("ERR retire persist failed: {e}"))?;
         self.encryption().retire(key_id)
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -611,6 +611,43 @@ impl Store {
                             disk_remove.push(key.clone());
                         }
                     }
+                    StoreValue::List(list) => {
+                        for elem in list.iter_mut() {
+                            if !crate::encryption::EncryptionKeyring::is_encrypted_value(elem) {
+                                continue;
+                            }
+                            let new_value =
+                                self.encryption()
+                                    .reencrypt("__lux_list", "element", "", elem)?;
+                            mem_delta += new_value.len() as isize - elem.len() as isize;
+                            *elem = Bytes::from(new_value);
+                            count += 1;
+                            shard_changed = true;
+                            disk_remove.push(key.clone());
+                        }
+                    }
+                    StoreValue::Stream(stream) => {
+                        let key_name = key_string(key);
+                        for fields in stream.entries.values_mut() {
+                            for (field, value) in fields.iter_mut() {
+                                if !crate::encryption::EncryptionKeyring::is_encrypted_value(value)
+                                {
+                                    continue;
+                                }
+                                let new_value = self.encryption().reencrypt(
+                                    "__lux_stream",
+                                    field,
+                                    &key_name,
+                                    value,
+                                )?;
+                                mem_delta += new_value.len() as isize - value.len() as isize;
+                                *value = Bytes::from(new_value);
+                                count += 1;
+                                shard_changed = true;
+                                disk_remove.push(key.clone());
+                            }
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -630,6 +667,11 @@ impl Store {
                 self.remove_from_disk(&key);
             }
         }
+        // Make the rewrap durable: persist the re-wrapped in-memory values and
+        // truncate the WAL so a restart cannot replay the pre-rewrap (old-key)
+        // ciphertext.
+        crate::snapshot::save_and_truncate_wal_consistent(self)
+            .map_err(|e| format!("ERR rewrap persist failed: {e}"))?;
         Ok(count)
     }
 
@@ -665,10 +707,33 @@ impl Store {
                             }
                         }
                     }
+                    StoreValue::List(list) => {
+                        for elem in list.iter() {
+                            if encrypted_value_would_be_orphaned(elem, &remaining) {
+                                return Err(
+                                    "ERR ENC key is still required by encrypted data".to_string()
+                                );
+                            }
+                        }
+                    }
+                    StoreValue::Stream(stream) => {
+                        for fields in stream.entries.values() {
+                            for (_field, value) in fields {
+                                if encrypted_value_would_be_orphaned(value, &remaining) {
+                                    return Err("ERR ENC key is still required by encrypted data"
+                                        .to_string());
+                                }
+                            }
+                        }
+                    }
                     _ => {}
                 }
             }
         }
+        // Persist the re-wrapped values and truncate the WAL before removing the
+        // key, so no stored value or WAL entry still references it.
+        crate::snapshot::save_and_truncate_wal_consistent(self)
+            .map_err(|e| format!("ERR retire persist failed: {e}"))?;
         self.encryption().retire(key_id)
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -554,6 +554,72 @@ impl Store {
         &self.encryption
     }
 
+    /// Rewrap any encrypted values inside a cold-tier `DumpValue` under the
+    /// current keyset. Returns true if anything was re-encrypted. Mirrors the
+    /// in-memory rewrap AAD slots. Vectors never cold-tier (pinned hot).
+    fn reencrypt_cold_dump_value(&self, key: &str, value: &mut DumpValue) -> Result<bool, String> {
+        use crate::encryption::EncryptionKeyring as E;
+        let mut changed = false;
+        match value {
+            DumpValue::Str(v) => {
+                if E::is_encrypted_value(v) {
+                    *v = self.encryption().reencrypt("__lux_kv", "value", key, v)?;
+                    changed = true;
+                }
+            }
+            DumpValue::Hash(pairs) => {
+                for (field, v) in pairs.iter_mut() {
+                    if E::is_encrypted_value(v) {
+                        *v = self.encryption().reencrypt("__lux_hash", field, key, v)?;
+                        changed = true;
+                    }
+                }
+            }
+            DumpValue::List(items) => {
+                for v in items.iter_mut() {
+                    if E::is_encrypted_value(v) {
+                        *v = self
+                            .encryption()
+                            .reencrypt("__lux_list", "element", "", v)?;
+                        changed = true;
+                    }
+                }
+            }
+            DumpValue::Stream(entries, _, _) => {
+                for (_id, fields) in entries.iter_mut() {
+                    for (field, v) in fields.iter_mut() {
+                        if E::is_encrypted_value(v) {
+                            *v = self.encryption().reencrypt("__lux_stream", field, key, v)?;
+                            changed = true;
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(changed)
+    }
+
+    /// True if any encrypted value in a cold-tier `DumpValue` would become
+    /// undecryptable without the retiring key.
+    fn dump_value_would_orphan(value: &DumpValue, remaining: &HashSet<String>) -> bool {
+        match value {
+            DumpValue::Str(v) => encrypted_value_would_be_orphaned(v, remaining),
+            DumpValue::Hash(pairs) => pairs
+                .iter()
+                .any(|(_, v)| encrypted_value_would_be_orphaned(v, remaining)),
+            DumpValue::List(items) => items
+                .iter()
+                .any(|v| encrypted_value_would_be_orphaned(v, remaining)),
+            DumpValue::Stream(entries, _, _) => entries.iter().any(|(_, fields)| {
+                fields
+                    .iter()
+                    .any(|(_, v)| encrypted_value_would_be_orphaned(v, remaining))
+            }),
+            _ => false,
+        }
+    }
+
     pub(crate) fn enc_rewrap_all(&self) -> Result<usize, String> {
         let mut count = 0usize;
         for idx in 0..self.shards.len() {
@@ -673,6 +739,23 @@ impl Store {
                 self.remove_from_disk(&key);
             }
         }
+        // Cold-tiered encrypted values live on disk, invisible to the in-RAM
+        // pass above; rewrap them in place too so a later RETIRE can't orphan them.
+        if let Some(disk_shards) = &self.disk_shards {
+            for ds in disk_shards.iter() {
+                let mut disk = ds.lock();
+                let entries = disk
+                    .dump_all(Instant::now())
+                    .map_err(|e| format!("ERR rewrap cold read failed: {e}"))?;
+                for mut entry in entries {
+                    if self.reencrypt_cold_dump_value(&entry.key, &mut entry.value)? {
+                        disk.put(&entry.key, &entry)
+                            .map_err(|e| format!("ERR rewrap cold write failed: {e}"))?;
+                        count += 1;
+                    }
+                }
+            }
+        }
         // Make the rewrap durable: persist re-wrapped in-memory values, re-seal
         // encrypted vectors (plaintext in RAM) under the current keyset, and
         // truncate the WAL so a restart can't replay pre-rewrap (old-key) bytes.
@@ -733,6 +816,21 @@ impl Store {
                         }
                     }
                     _ => {}
+                }
+            }
+        }
+        // Cold-tiered encrypted values are invisible to the in-RAM scan above;
+        // scan the disk tier too so we never retire a key they still need.
+        if let Some(disk_shards) = &self.disk_shards {
+            for ds in disk_shards.iter() {
+                let mut disk = ds.lock();
+                let entries = disk
+                    .dump_all(Instant::now())
+                    .map_err(|e| format!("ERR retire cold scan failed: {e}"))?;
+                for entry in &entries {
+                    if Self::dump_value_would_orphan(&entry.value, &remaining) {
+                        return Err("ERR ENC key is still required by encrypted data".to_string());
+                    }
                 }
             }
         }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -111,6 +111,8 @@ impl Hasher for FxHasher {
 #[allow(dead_code)]
 pub const MAX_SHARDS: usize = 1024;
 const WRONGTYPE: &str = "WRONGTYPE Operation against a key holding the wrong kind of value";
+const RENAME_ENCRYPTED_ERR: &str =
+    "ERR cannot relocate an encrypted key: its ciphertext is bound to the key name and would be unrecoverable at the destination; decrypt and re-set under the new key instead";
 
 pub struct VectorData {
     #[allow(dead_code)]
@@ -1425,6 +1427,24 @@ impl Store {
             .collect()
     }
 
+    /// True if relocating this value to a different key would orphan encrypted
+    /// data, because its AEAD AAD is bound to the key name. Lists use a
+    /// key-independent AAD and vectors stay plaintext in RAM (re-sealed on the
+    /// next write), so both self-heal on a move and are not blocked.
+    pub(crate) fn value_has_key_bound_encryption(value: &StoreValue) -> bool {
+        use crate::encryption::EncryptionKeyring as E;
+        match value {
+            StoreValue::Str(v) => E::is_encrypted_value(v),
+            StoreValue::StrBuf(v) => E::is_encrypted_value(v),
+            StoreValue::Hash(map) => map.values().any(|v| E::is_encrypted_value(v)),
+            StoreValue::Stream(s) => s
+                .entries
+                .values()
+                .any(|fields| fields.iter().any(|(_, v)| E::is_encrypted_value(v))),
+            _ => false,
+        }
+    }
+
     /// Seal a vector (as little-endian f32 bytes) for at-rest storage. AAD binds
     /// the vector's storage key so envelopes can't be swapped between slots.
     pub(crate) fn encrypt_vector(&self, key: &[u8], data: &[f32]) -> Result<Vec<u8>, String> {
@@ -2457,6 +2477,16 @@ impl Store {
 
     pub fn rename(&self, key: &[u8], new_key: &[u8], now: Instant) -> Result<(), String> {
         let old_idx = self.shard_index(key);
+        {
+            // A value whose AEAD AAD is bound to the key name can't be decrypted
+            // at a new key; moving it would orphan it. Refuse rather than lose it.
+            let shard = self.shards[old_idx].read();
+            if let Some(e) = shard.data.get(key) {
+                if !e.is_expired_at(now) && Self::value_has_key_bound_encryption(&e.value) {
+                    return Err(RENAME_ENCRYPTED_ERR.to_string());
+                }
+            }
+        }
         let entry = {
             let mut shard = self.shards[old_idx].write();
             shard.version += 1;
@@ -2499,6 +2529,9 @@ impl Store {
             let ks = src;
             match shard.data.get(ks) {
                 Some(entry) if !entry.is_expired_at(now) => {
+                    if Self::value_has_key_bound_encryption(&entry.value) {
+                        return Err(RENAME_ENCRYPTED_ERR.to_string());
+                    }
                     let ttl = entry.expires_at.map(|exp| exp.duration_since(now));
                     let dv = store_value_to_dump_value(&entry.value);
                     (dv, ttl)

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -117,6 +117,10 @@ pub struct VectorData {
     pub dims: u32,
     pub data: Vec<f32>,
     pub metadata: Option<String>,
+    /// When true this vector is encrypted at rest: the in-memory `data` stays
+    /// plaintext (HNSW/search need it), but it is sealed when written to the
+    /// snapshot and self-logged as ciphertext in the WAL.
+    pub encrypted: bool,
 }
 
 pub struct TimeSeriesData {
@@ -1286,6 +1290,33 @@ impl Store {
         let key_name = Self::user_kv_key(key);
         self.encryption()
             .encrypt("__lux_kv", "value", &key_name, value)
+    }
+
+    /// Seal a vector (as little-endian f32 bytes) for at-rest storage. AAD binds
+    /// the vector's storage key so envelopes can't be swapped between slots.
+    pub(crate) fn encrypt_vector(&self, key: &[u8], data: &[f32]) -> Result<Vec<u8>, String> {
+        let key_name = Self::user_kv_key(key);
+        let mut bytes = Vec::with_capacity(data.len() * 4);
+        for f in data {
+            bytes.extend_from_slice(&f.to_le_bytes());
+        }
+        self.encryption()
+            .encrypt("__lux_vec", "data", &key_name, &bytes)
+    }
+
+    /// Decrypt a sealed vector back into f32 values.
+    pub(crate) fn decrypt_vector(&self, key: &[u8], envelope: &[u8]) -> Result<Vec<f32>, String> {
+        let key_name = Self::user_kv_key(key);
+        let bytes = self
+            .encryption()
+            .decrypt("__lux_vec", "data", &key_name, envelope)?;
+        if !bytes.len().is_multiple_of(4) {
+            return Err("ERR corrupt encrypted vector payload".to_string());
+        }
+        Ok(bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect())
     }
 
     pub(crate) fn decrypt_hash_field_value(
@@ -3210,7 +3241,7 @@ impl Store {
                     groups,
                 })
             }
-            DumpValue::Vector(data, metadata) => {
+            DumpValue::Vector(data, metadata, encrypted) => {
                 let dims = data.len() as u32;
                 let index_data = data.clone();
                 let key_clone = key.clone();
@@ -3218,6 +3249,7 @@ impl Store {
                     dims,
                     data,
                     metadata,
+                    encrypted,
                 });
                 let expires_at = ttl.map(|d| Instant::now() + d);
                 let mem = estimate_entry_memory(&key, &sv);
@@ -4716,7 +4748,7 @@ fn store_value_to_dump_value(value: &StoreValue) -> DumpValue {
                 .collect();
             DumpValue::Stream(entries, s.last_id.to_string(), groups)
         }
-        StoreValue::Vector(v) => DumpValue::Vector(v.data.clone(), v.metadata.clone()),
+        StoreValue::Vector(v) => DumpValue::Vector(v.data.clone(), v.metadata.clone(), v.encrypted),
         StoreValue::HyperLogLog(regs, cached) => DumpValue::HyperLogLog(regs.clone(), *cached),
         StoreValue::TimeSeries(ts) => {
             DumpValue::TimeSeries(ts.samples.clone(), ts.retention, ts.labels.clone())
@@ -4742,7 +4774,9 @@ pub enum DumpValue {
     Set(Vec<String>),
     SortedSet(Vec<(String, f64)>),
     Stream(Vec<StreamDumpEntry>, String, Vec<StreamGroupDump>),
-    Vector(Vec<f32>, Option<String>),
+    /// f32 data, metadata, and whether it is encrypted-at-rest (sealed in the
+    /// snapshot; the in-memory copy is plaintext).
+    Vector(Vec<f32>, Option<String>, bool),
     HyperLogLog(Vec<u8>, u64),
     TimeSeries(Vec<(i64, f64)>, u64, Vec<(String, String)>),
 }
@@ -5965,8 +5999,8 @@ mod tests {
     fn vector_search_indexes_are_dimension_scoped() {
         let store = Store::new();
         let n = now();
-        store.vset(b"two_dim", vec![1.0, 0.0], None, None, n);
-        store.vset(b"three_dim", vec![0.0, 1.0, 0.0], None, None, n);
+        store.vset(b"two_dim", vec![1.0, 0.0], None, None, false, n);
+        store.vset(b"three_dim", vec![0.0, 1.0, 0.0], None, None, false, n);
 
         let two_dim = store.vsearch(&[1.0, 0.0], 1, None, None, n);
         assert_eq!(

--- a/src/store/streams.rs
+++ b/src/store/streams.rs
@@ -157,7 +157,7 @@ impl Store {
                 StoreValue::Stream(s) => {
                     let mut result = Vec::new();
                     for (id, fields) in s.entries.range(start..=end) {
-                        result.push((*id, fields.clone()));
+                        result.push((*id, self.decrypt_stream_fields(key, fields)));
                         if let Some(c) = count {
                             if result.len() >= c {
                                 break;
@@ -188,7 +188,7 @@ impl Store {
                 StoreValue::Stream(s) => {
                     let mut result = Vec::new();
                     for (id, fields) in s.entries.range(start..=end).rev() {
-                        result.push((*id, fields.clone()));
+                        result.push((*id, self.decrypt_stream_fields(key, fields)));
                         if let Some(c) = count {
                             if result.len() >= c {
                                 break;
@@ -225,7 +225,7 @@ impl Store {
                         };
                         let mut entries = Vec::new();
                         for (id, fields) in s.entries.range(start..) {
-                            entries.push((*id, fields.clone()));
+                            entries.push((*id, self.decrypt_stream_fields(key.as_bytes(), fields)));
                             if let Some(c) = count {
                                 if entries.len() >= c {
                                     break;
@@ -387,7 +387,10 @@ impl Store {
                             };
                             let mut entries = Vec::new();
                             for (id, fields) in s.entries.range(start..) {
-                                entries.push((*id, fields.clone()));
+                                entries.push((
+                                    *id,
+                                    self.decrypt_stream_fields(key.as_bytes(), fields),
+                                ));
                                 if !noack {
                                     cg.pel.insert(
                                         *id,
@@ -432,7 +435,10 @@ impl Store {
                             sorted.sort();
                             for id in sorted {
                                 if let Some(fields) = s.entries.get(&id) {
-                                    entries.push((id, fields.clone()));
+                                    entries.push((
+                                        id,
+                                        self.decrypt_stream_fields(key.as_bytes(), fields),
+                                    ));
                                     if let Some(cnt) = count {
                                         if entries.len() >= cnt {
                                             break;
@@ -627,7 +633,7 @@ impl Store {
                                 c.pel.insert(*id);
                                 c.seen_time = inst_now;
                                 if let Some(fields) = s.entries.get(id) {
-                                    result.push((*id, fields.clone()));
+                                    result.push((*id, self.decrypt_stream_fields(key, fields)));
                                 }
                             }
                         }
@@ -706,7 +712,7 @@ impl Store {
                                 c.pel.insert(id);
                                 c.seen_time = inst_now;
                                 if let Some(fields) = s.entries.get(&id) {
-                                    claimed.push((id, fields.clone()));
+                                    claimed.push((id, self.decrypt_stream_fields(key, fields)));
                                 } else {
                                     deleted_ids.push(id);
                                 }

--- a/src/store/vectors.rs
+++ b/src/store/vectors.rs
@@ -1,12 +1,14 @@
 use super::*;
 
 impl Store {
+    #[allow(clippy::too_many_arguments)]
     pub fn vset(
         &self,
         key: &[u8],
         data: Vec<f32>,
         metadata: Option<String>,
         ttl: Option<Duration>,
+        encrypted: bool,
         now: Instant,
     ) {
         let idx = self.shard_index(key);
@@ -21,6 +23,7 @@ impl Store {
             dims,
             data,
             metadata,
+            encrypted,
         });
         let new_mem = estimate_entry_memory(&ks, &new_value);
         let expires_at = ttl.map(|d| now + d);

--- a/src/store/vectors.rs
+++ b/src/store/vectors.rs
@@ -19,6 +19,13 @@ impl Store {
         let dims = data.len() as u32;
         let index_data = data.clone();
         let mut old_vector_dims = None;
+        // Sticky encryption: overwriting an encrypted vector without the flag
+        // must not silently downgrade it to plaintext-at-rest (mirrors SET).
+        let encrypted = encrypted
+            || matches!(
+                shard.data.get(&ks).map(|e| &e.value),
+                Some(StoreValue::Vector(v)) if v.encrypted
+            );
         let new_value = StoreValue::Vector(VectorData {
             dims,
             data,

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -799,9 +799,9 @@ fn field_supports_encryption(field: &FieldDef) -> Result<(), String> {
             field.name
         ));
     }
-    if matches!(field.field_type, FieldType::Vector(_)) {
+    if field.searchable && matches!(field.field_type, FieldType::Vector(_)) {
         return Err(format!(
-            "ERR encrypted column '{}' cannot use VECTOR type",
+            "ERR encrypted VECTOR column '{}' cannot be SEARCHABLE (similarity search uses the in-memory index, not a blind index)",
             field.name
         ));
     }
@@ -2024,7 +2024,14 @@ fn add_to_index(
                 })
                 .to_string();
                 let vkey = table_vector_key(table, &field.name, pk_str);
-                store.vset(vkey.as_bytes(), vector, Some(metadata), None, now);
+                store.vset(
+                    vkey.as_bytes(),
+                    vector,
+                    Some(metadata),
+                    None,
+                    field.encrypted,
+                    now,
+                );
             }
         }
         // JSON/ARRAY columns are not auto-indexed; only declared path indexes apply.
@@ -4033,7 +4040,10 @@ mod tests {
     fn encrypted_field_rejects_invalid_combinations() {
         assert!(parse_field_def("id UUID PRIMARY KEY ENCRYPTED").is_err());
         assert!(parse_field_def("owner UUID REFERENCES users(id) ENCRYPTED").is_err());
-        assert!(parse_field_def("embedding VECTOR(3) ENCRYPTED").is_err());
+        // Encrypted VECTOR columns are allowed (at-rest); only SEARCHABLE on an
+        // encrypted vector is rejected (no blind index for similarity search).
+        assert!(parse_field_def("embedding VECTOR(3) ENCRYPTED").is_ok());
+        assert!(parse_field_def("embedding VECTOR(3) ENCRYPTED SEARCHABLE").is_err());
         assert!(parse_field_def("token STR SEARCHABLE").is_err());
         assert!(parse_field_def("token STR ENCRYPTED UNIQUE").is_err());
         assert!(parse_field_def("token STR ENCRYPTED DEFAULT seeded").is_err());

--- a/tests/encryption.rs
+++ b/tests/encryption.rs
@@ -17,11 +17,22 @@ fn resp_encrypted_values_roundtrip_over_tcp() {
         "encrypted GET must decrypt over TCP"
     );
 
+    // STRLEN must report the plaintext length, not the ciphertext envelope size.
+    assert!(
+        send_and_read(&mut c, &["STRLEN", "tok"]).contains("13"),
+        "encrypted STRLEN must report plaintext length over TCP"
+    );
+
     // Hash field.
     send_and_read(&mut c, &["HSET", "h", "f", "hash-secret", "ENCRYPTED"]);
     assert!(
         send_and_read(&mut c, &["HGET", "h", "f"]).contains("hash-secret"),
         "encrypted HGET must decrypt over TCP"
+    );
+    let hgetall = send_and_read(&mut c, &["HGETALL", "h"]);
+    assert!(
+        hgetall.contains("hash-secret"),
+        "encrypted HGETALL must decrypt over TCP: {hgetall}"
     );
 
     // List elements: LRANGE/LINDEX go through the read fast-path.

--- a/tests/encryption.rs
+++ b/tests/encryption.rs
@@ -1,0 +1,58 @@
+//! RESP-over-TCP encryption round-trips. These exercise the real server read
+//! dispatch (including the shard-local read fast-path), which the in-crate unit
+//! tests bypass by going through the slow executor directly.
+
+mod common;
+use common::{send_and_read, LuxServer};
+
+#[test]
+fn resp_encrypted_values_roundtrip_over_tcp() {
+    let server = LuxServer::builder().env("LUX_ENC_AUTO_INIT", "1").start();
+    let mut c = server.conn();
+
+    // String: regression for the fast read path decrypting GET.
+    send_and_read(&mut c, &["SET", "tok", "string-secret", "ENCRYPTED"]);
+    assert!(
+        send_and_read(&mut c, &["GET", "tok"]).contains("string-secret"),
+        "encrypted GET must decrypt over TCP"
+    );
+
+    // Hash field.
+    send_and_read(&mut c, &["HSET", "h", "f", "hash-secret", "ENCRYPTED"]);
+    assert!(
+        send_and_read(&mut c, &["HGET", "h", "f"]).contains("hash-secret"),
+        "encrypted HGET must decrypt over TCP"
+    );
+
+    // List elements: LRANGE/LINDEX go through the read fast-path.
+    send_and_read(
+        &mut c,
+        &["RPUSH", "l", "list-secret-a", "list-secret-b", "ENCRYPTED"],
+    );
+    let lr = send_and_read(&mut c, &["LRANGE", "l", "0", "-1"]);
+    assert!(
+        lr.contains("list-secret-a") && lr.contains("list-secret-b"),
+        "encrypted LRANGE must decrypt over TCP: {lr}"
+    );
+    assert!(send_and_read(&mut c, &["LINDEX", "l", "0"]).contains("list-secret-a"));
+    // LPOP (write path) also decrypts.
+    assert!(send_and_read(&mut c, &["LPOP", "l"]).contains("list-secret-a"));
+
+    // LMOVE relocates an encrypted element to another key and it still decrypts.
+    send_and_read(&mut c, &["RPUSH", "src", "move-secret", "ENCRYPTED"]);
+    send_and_read(&mut c, &["LMOVE", "src", "dst", "LEFT", "RIGHT"]);
+    assert!(
+        send_and_read(&mut c, &["LRANGE", "dst", "0", "-1"]).contains("move-secret"),
+        "encrypted element must survive LMOVE across keys"
+    );
+
+    // Stream field values: XRANGE goes through the read fast-path.
+    send_and_read(
+        &mut c,
+        &["XADD", "s", "*", "payload", "stream-secret", "ENCRYPTED"],
+    );
+    assert!(
+        send_and_read(&mut c, &["XRANGE", "s", "-", "+"]).contains("stream-secret"),
+        "encrypted XRANGE must decrypt over TCP"
+    );
+}


### PR DESCRIPTION
Consolidates the Encryption v2 features (grant-gated decryption already on main; **lists/streams** #35; **vectors** #36) and fixes every data-loss/integrity hole found by the adversarial audit, so v0.26.0 can ship without dangerous encryption behavior. Full suite **919 pass**, clippy clean, adversarial deep-e2e **37/37**.

## Data-loss holes fixed (each with a regression test that reproduces the loss then proves the fix)

- **C1 — cold-tier rotation orphaning** (shipped): `ENC REWRAP`/`RETIRE` only scanned in-RAM shards, so an encrypted value evicted to disk was orphaned by rotate+retire. Both now iterate `disk_shards` (rewrap in place; retire refuses if a cold value still needs the key).
- **C2 + M1 — snapshot-load cascade + autosave truncation** (vectors/general): an undecryptable entry aborted the load, came up "healthy," and autosave then permanently truncated `lux.dat`. Load failure is now **fatal** — the on-disk snapshot is left intact and recoverable; supply the keyring and restart.
- **C3 / H3 — bit ops corrupting envelopes** (shipped): `SETBIT`/`BITOP`/`GETBIT`/`BITCOUNT`/`BITPOS` operated on ciphertext bytes; now refused on encrypted strings.
- **H1 — RENAME/RENAMENX/COPY orphaning** (shipped): moved ciphertext without re-encrypting; AAD binds the key name. Now refused for key-bound encrypted values (str/hash/stream); lists/vectors self-heal and are still allowed.
- **H4 — encrypted-value resurrection after crash** (shipped): overwrite-with-past-`EXAT` self-logged a RAWSET that replay couldn't parse, resurrecting the prior value. `ENC RAWSET` now honors `EXAT`/`PXAT`.
- **M2 — vectors not sticky**: re-`VSET` without the flag no longer downgrades an encrypted vector to plaintext-at-rest.
- **M3 — encrypted reads over RESP**: `GET`/`HGET`/`HGETALL`/`STRLEN` now decrypt (via the read-fast-path gate); pinned by a TCP integration test.

## Not in this release (tracked follow-up)
- **H2 — self-sufficient backup**: `GET /v1/snapshot` still doesn't bundle the keyring. The *data-loss* risk is neutralized by C2/M1 (restore-without-key now refuses to start, non-destructive). Making the app-level backup carry the (re-wrapped) keyring is a coordinated cloud-repo change and a fast-follow.

## Verification
- Adversarial deep e2e (all primitives, grant-gating, rotate/rewrap/retire, WAL-only replay, snapshot restart, on-disk plaintext scan, negative cases): 37/37.
- Full engine suite 919 pass; clippy clean.

Supersedes #35 and #36 (folded in here).