### PR TITLE
Fix/multiple grant conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "lux"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "argon2",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lux"
-version = "0.26.1"
+version = "0.26.2"
 edition = "2021"
 description = "An open-source application database engine with tables, cache, vectors, auth, realtime, queues, time series, and Redis-compatible commands."
 license = "MIT"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4707,25 +4707,88 @@ fn render_enforced_clause(conds: &[crate::grants::EnforcedCondition]) -> String 
     parts.join(" AND ")
 }
 
-fn collapse_or_clauses(
+fn render_enforced_or_clauses(
     clauses: &[Vec<crate::grants::EnforcedCondition>],
-) -> Result<Option<crate::grants::EnforcedCondition>, String> {
+) -> Result<String, String> {
     use crate::grants::EnforcedCondition;
-    let mut column: Option<String> = None;
-    let mut values: Vec<String> = Vec::new();
+    if let Some(cond) = collapse_same_column_or_clauses(clauses) {
+        return Ok(render_enforced_clause(&[cond]));
+    }
+    let mut branches = Vec::new();
     for clause in clauses {
         if clause.is_empty() {
-            return Ok(None);
+            return Ok(String::new());
         }
-        if clause.len() != 1 {
+        let mut parts = Vec::new();
+        let mut branch_is_false = false;
+        for condition in clause {
+            match condition {
+                EnforcedCondition::Cmp(rc) => {
+                    parts.push(format!("{} {} {}", rc.column, rc.op, rc.value));
+                }
+                EnforcedCondition::InSet {
+                    column,
+                    negated,
+                    values,
+                } => {
+                    if values.is_empty() {
+                        if *negated {
+                            continue;
+                        }
+                        branch_is_false = true;
+                        break;
+                    }
+                    let kw = if *negated { "NOT IN" } else { "IN" };
+                    parts.push(format!("{column} {kw} ( {} )", values.join(" ")));
+                }
+            }
+        }
+        if branch_is_false {
+            continue;
+        }
+        if parts.is_empty() {
+            return Ok(String::new());
+        }
+        if parts.len() != 1 {
             return Err(
                 "OR grants with multi-condition branches are not supported yet".to_string(),
             );
         }
+        branches.push(parts.remove(0));
+    }
+    if branches.is_empty() {
+        let Some(first_column) = clauses
+            .iter()
+            .flat_map(|clause| clause.iter())
+            .map(|condition| match condition {
+                EnforcedCondition::Cmp(rc) => rc.column.as_str(),
+                EnforcedCondition::InSet { column, .. } => column.as_str(),
+            })
+            .next()
+        else {
+            return Ok(String::new());
+        };
+        return Ok(format!(
+            "{first_column} IS NULL AND {first_column} IS NOT NULL"
+        ));
+    }
+    Ok(branches.join(" OR "))
+}
+
+fn collapse_same_column_or_clauses(
+    clauses: &[Vec<crate::grants::EnforcedCondition>],
+) -> Option<crate::grants::EnforcedCondition> {
+    use crate::grants::EnforcedCondition;
+    let mut column: Option<String> = None;
+    let mut values: Vec<String> = Vec::new();
+    for clause in clauses {
+        if clause.len() != 1 {
+            return None;
+        }
         match &clause[0] {
             EnforcedCondition::Cmp(rc) if rc.op == "=" => {
                 if column.as_deref().is_some_and(|c| c != rc.column) {
-                    return Err("OR grants must target the same column".to_string());
+                    return None;
                 }
                 column.get_or_insert_with(|| rc.column.clone());
                 if !values.iter().any(|value| value == &rc.value) {
@@ -4738,7 +4801,7 @@ fn collapse_or_clauses(
                 values: set,
             } => {
                 if column.as_deref().is_some_and(|column| column != c) {
-                    return Err("OR grants must target the same column".to_string());
+                    return None;
                 }
                 column.get_or_insert_with(|| c.clone());
                 for value in set {
@@ -4747,22 +4810,14 @@ fn collapse_or_clauses(
                     }
                 }
             }
-            _ => {
-                return Err(
-                    "OR grants only support '=' and positive IN branches on the same column"
-                        .to_string(),
-                );
-            }
+            _ => return None,
         }
     }
-    let Some(column) = column else {
-        return Ok(None);
-    };
-    Ok(Some(EnforcedCondition::InSet {
-        column,
+    Some(EnforcedCondition::InSet {
+        column: column?,
         negated: false,
         values,
-    }))
+    })
 }
 
 fn render_enforced_clauses(
@@ -4771,10 +4826,7 @@ fn render_enforced_clauses(
     if clauses.len() == 1 {
         return Ok(render_enforced_clause(&clauses[0]));
     }
-    match collapse_or_clauses(clauses)? {
-        Some(cond) => Ok(render_enforced_clause(&[cond])),
-        None => Ok(String::new()),
-    }
+    render_enforced_or_clauses(clauses)
 }
 
 /// Resolve + execute the grant for `(table, scope)` into enforced conditions.
@@ -4824,6 +4876,7 @@ pub(crate) fn read_filter(
 /// (column, op, value) instead of a rendered string. Used by the `.live()` path,
 /// which merges them into the subscription's own `where_conditions` so both the
 /// initial snapshot and streamed events are scoped to the grant.
+#[cfg(test)]
 pub(crate) fn read_filter_conds(
     store: &Store,
     cache: &SharedSchemaCache,
@@ -4842,13 +4895,12 @@ pub(crate) fn read_filter_conds(
     else {
         return Err(format!("no read access to '{table}'"));
     };
-    if conds.len() == 1 {
-        return Ok(conds.into_iter().next().unwrap_or_default());
+    if conds.len() != 1 {
+        return Err(
+            "read grant has OR alternatives; use read_filter for expression rendering".to_string(),
+        );
     }
-    match collapse_or_clauses(&conds)? {
-        Some(cond) => Ok(vec![cond]),
-        None => Ok(Vec::new()),
-    }
+    Ok(conds.into_iter().next().unwrap_or_default())
 }
 
 /// Return tables consulted by READ-grant membership subqueries. Live queries
@@ -5642,6 +5694,74 @@ mod tests {
         );
         assert!(teamed_filter.contains("alice"), "got: {teamed_filter}");
         assert!(teamed_filter.contains("bob"), "got: {teamed_filter}");
+    }
+
+    #[test]
+    fn repeated_read_grants_on_different_columns_render_or_alternatives() {
+        let store = Store::new();
+        let cache = Arc::new(RwLock::new(SchemaCache::new()));
+        let now = Instant::now();
+        crate::tables::table_create(
+            &store,
+            &cache,
+            "invites",
+            &[
+                "id", "STR", "PRIMARY", "KEY,", "team_id", "STR,", "email", "STR",
+            ],
+            now,
+        )
+        .unwrap();
+        crate::tables::table_create(
+            &store,
+            &cache,
+            "members",
+            &[
+                "id", "STR", "PRIMARY", "KEY,", "user_id", "STR,", "team_id", "STR",
+            ],
+            now,
+        )
+        .unwrap();
+        crate::tables::table_insert(
+            &store,
+            &cache,
+            "members",
+            &[("id", "1"), ("user_id", "alice"), ("team_id", "team-a")],
+            now,
+        )
+        .unwrap();
+
+        grant(
+            &store,
+            &cache,
+            &[
+                "read",
+                "ON",
+                "invites",
+                "WHERE",
+                "team_id",
+                "IN",
+                "(",
+                "SELECT",
+                "team_id",
+                "FROM",
+                "members",
+                "WHERE",
+                "user_id",
+                "=",
+                "auth.uid()",
+                ")",
+            ],
+            now,
+        );
+        grant(
+            &store,
+            &cache,
+            &["read", "ON", "invites", "WHERE", "email", "=", "auth.email"],
+            now,
+        );
+
+        let filter = read_filter(&store, &cache, &principal("alice"), "invites", now).unwrap();
+        assert_eq!(filter, "team_id IN ( team-a ) OR email = u@x.dev");
     }
 
     // ── RLS auto-filter (USING) coverage ──

--- a/src/http.rs
+++ b/src/http.rs
@@ -1340,7 +1340,7 @@ async fn build_live_subscription(
                 // Validate access at subscribe time, but do not freeze the
                 // resolved conditions here: membership subqueries can change
                 // while the socket remains open.
-                crate::auth::read_filter_conds(store, cache, p, &table_spec.table, Instant::now())
+                crate::auth::read_filter(store, cache, p, &table_spec.table, Instant::now())
                     .map_err(|e| live_error("FORBIDDEN", &e))?;
                 table_spec.auth_dependencies = crate::auth::read_filter_dependencies(
                     store,
@@ -1714,7 +1714,7 @@ fn fetch_live_table_rows(
     if spec.deny_all {
         return Ok(Vec::new());
     }
-    let Some(where_conditions) = live_table_where_conditions(store, cache, spec)? else {
+    let Some(where_tokens) = live_table_where_tokens(store, cache, spec)? else {
         return Ok(Vec::new());
     };
     let mut tokens = vec![spec.select.clone(), "FROM".to_string(), spec.table.clone()];
@@ -1736,40 +1736,9 @@ fn fetch_live_table_rows(
             },
         ]);
     }
-    if !where_conditions.is_empty() {
+    if !where_tokens.is_empty() {
         tokens.push("WHERE".to_string());
-        for (index, (field, op, value)) in where_conditions.iter().enumerate() {
-            if index > 0 {
-                tokens.push("AND".to_string());
-            }
-            tokens.push(field.clone());
-            let op_upper = op.to_ascii_uppercase();
-            if op_upper == "IN" || op_upper == "NOT IN" {
-                if op_upper == "NOT IN" {
-                    tokens.push("NOT".to_string());
-                }
-                tokens.push("IN".to_string());
-                tokens.push("(".to_string());
-                match value.as_array() {
-                    Some(arr) => {
-                        for v in arr {
-                            tokens.push(live_value_to_token(v));
-                        }
-                    }
-                    None => tokens.push(live_value_to_token(value)),
-                }
-                tokens.push(")".to_string());
-            } else if op_upper == "IS VALID" || op_upper == "IS NOT VALID" {
-                tokens.push("IS".to_string());
-                if op_upper == "IS NOT VALID" {
-                    tokens.push("NOT".to_string());
-                }
-                tokens.push("VALID".to_string());
-            } else {
-                tokens.push(op.clone());
-                tokens.push(live_value_to_token(value));
-            }
-        }
+        tokens.extend(where_tokens);
     }
     if let Some(near) = &spec.near {
         tokens.push("NEAR".to_string());
@@ -1822,43 +1791,60 @@ fn fetch_live_table_rows(
     }
 }
 
-fn live_table_where_conditions(
+fn live_table_where_tokens(
     store: &Arc<Store>,
     cache: &SharedSchemaCache,
     spec: &LiveTableSpec,
-) -> Result<Option<LiveTableWhereConditions>, Value> {
-    let mut conditions = spec.where_conditions.clone();
-    let Some(principal) = &spec.principal else {
-        return Ok(Some(conditions));
-    };
-    let grant_conds =
-        crate::auth::read_filter_conds(store, cache, principal, &spec.table, Instant::now())
+) -> Result<Option<Vec<String>>, Value> {
+    let mut tokens = live_where_conditions_to_tokens(&spec.where_conditions);
+    if let Some(principal) = &spec.principal {
+        let grant = crate::auth::read_filter(store, cache, principal, &spec.table, Instant::now())
             .map_err(|e| live_error("FORBIDDEN", &e))?;
-    for condition in grant_conds {
-        match condition {
-            crate::grants::EnforcedCondition::Cmp(rc) => {
-                conditions.push((rc.column, rc.op, Value::String(rc.value)));
+        if !grant.trim().is_empty() {
+            if !tokens.is_empty() {
+                tokens.push("AND".to_string());
             }
-            crate::grants::EnforcedCondition::InSet {
-                column,
-                negated,
-                values,
-            } => {
-                if values.is_empty() {
-                    if !negated {
-                        return Ok(None);
-                    }
-                } else {
-                    conditions.push((
-                        column,
-                        if negated { "NOT IN" } else { "IN" }.to_string(),
-                        Value::Array(values.into_iter().map(Value::String).collect()),
-                    ));
-                }
-            }
+            tokens.extend(tokenize_where(&grant).map_err(|e| live_error("FORBIDDEN", &e))?);
         }
     }
-    Ok(Some(conditions))
+    Ok(Some(tokens))
+}
+
+fn live_where_conditions_to_tokens(conditions: &LiveTableWhereConditions) -> Vec<String> {
+    let mut tokens = Vec::new();
+    for (index, (field, op, value)) in conditions.iter().enumerate() {
+        if index > 0 {
+            tokens.push("AND".to_string());
+        }
+        tokens.push(field.clone());
+        let op_upper = op.to_ascii_uppercase();
+        if op_upper == "IN" || op_upper == "NOT IN" {
+            if op_upper == "NOT IN" {
+                tokens.push("NOT".to_string());
+            }
+            tokens.push("IN".to_string());
+            tokens.push("(".to_string());
+            match value.as_array() {
+                Some(arr) => {
+                    for v in arr {
+                        tokens.push(live_value_to_token(v));
+                    }
+                }
+                None => tokens.push(live_value_to_token(value)),
+            }
+            tokens.push(")".to_string());
+        } else if op_upper == "IS VALID" || op_upper == "IS NOT VALID" {
+            tokens.push("IS".to_string());
+            if op_upper == "IS NOT VALID" {
+                tokens.push("NOT".to_string());
+            }
+            tokens.push("VALID".to_string());
+        } else {
+            tokens.push(op.clone());
+            tokens.push(live_value_to_token(value));
+        }
+    }
+    tokens
 }
 
 fn live_table_dependencies(spec: &LiveTableSpec) -> Vec<String> {
@@ -4880,6 +4866,129 @@ mod tests {
             Some("members"),
             "grant dependency changes must wake the live query"
         );
+    }
+
+    #[test]
+    fn live_table_allows_or_read_grants_on_different_columns() {
+        let config = std::sync::Arc::new(crate::ServerConfig {
+            auth: crate::AuthConfig {
+                enabled: true,
+                ..crate::AuthConfig::default()
+            },
+            ..crate::ServerConfig::default()
+        });
+        let store = Arc::new(Store::new_with_config(config));
+        let cache: SharedSchemaCache =
+            Arc::new(parking_lot::RwLock::new(crate::tables::SchemaCache::new()));
+        let now = Instant::now();
+        crate::tables::table_create(
+            &store,
+            &cache,
+            "invites",
+            &[
+                "id", "STR", "PRIMARY", "KEY,", "team_id", "STR,", "email", "STR",
+            ],
+            now,
+        )
+        .unwrap();
+        crate::tables::table_create(
+            &store,
+            &cache,
+            "members",
+            &[
+                "id", "STR", "PRIMARY", "KEY,", "user_id", "STR,", "team_id", "STR",
+            ],
+            now,
+        )
+        .unwrap();
+        crate::tables::table_insert(
+            &store,
+            &cache,
+            "members",
+            &[("id", "m1"), ("user_id", "alice"), ("team_id", "team-a")],
+            now,
+        )
+        .unwrap();
+        for (id, team_id, email) in [
+            ("team", "team-a", "other@x.dev"),
+            ("email", "team-b", "alice@x.dev"),
+            ("hidden", "team-b", "other@x.dev"),
+        ] {
+            crate::tables::table_insert(
+                &store,
+                &cache,
+                "invites",
+                &[("id", id), ("team_id", team_id), ("email", email)],
+                now,
+            )
+            .unwrap();
+        }
+        for grant in [
+            crate::grants::parse_grant(&[
+                "read",
+                "ON",
+                "invites",
+                "WHERE",
+                "team_id",
+                "IN",
+                "(",
+                "SELECT",
+                "team_id",
+                "FROM",
+                "members",
+                "WHERE",
+                "user_id",
+                "=",
+                "auth.uid()",
+                ")",
+            ])
+            .unwrap(),
+            crate::grants::parse_grant(&[
+                "read",
+                "ON",
+                "invites",
+                "WHERE",
+                "email",
+                "=",
+                "auth.email",
+            ])
+            .unwrap(),
+        ] {
+            crate::auth::put_grant(&store, &cache, &grant, now).unwrap();
+        }
+        let principal = match user_ctx("alice") {
+            HttpAuthContext::User(principal) => principal,
+            _ => unreachable!(),
+        };
+        let spec = LiveTableSpec {
+            table: "invites".to_string(),
+            select: "*".to_string(),
+            where_conditions: vec![],
+            joins: vec![],
+            principal: Some(principal),
+            auth_dependencies: vec!["members".to_string()],
+            near: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            deny_all: false,
+        };
+
+        crate::auth::read_filter(
+            &store,
+            &cache,
+            spec.principal.as_ref().unwrap(),
+            "invites",
+            now,
+        )
+        .unwrap();
+        let body =
+            serde_json::to_string(&fetch_live_table_rows(&store, &cache, &spec).unwrap()).unwrap();
+        assert!(
+            body.contains("\"team\"") && body.contains("\"email\""),
+            "{body}"
+        );
+        assert!(!body.contains("\"hidden\""), "{body}");
     }
 
     #[test]


### PR DESCRIPTION
**Summary**

Fixes live/table read grants with repeated `GRANT read` policies that produce `OR` alternatives across different columns.

Previously, repeated read grants were only supported when all alternatives targeted the same column, because the grant filter was collapsed into a single `IN (...)` condition. A policy like:

```sql
GRANT read ON invites WHERE team_id IN ( SELECT team_id FROM members WHERE user_id = auth.uid() )
GRANT read ON invites WHERE email = auth.email
```

failed during live subscribe with:

```text
FORBIDDEN: OR grants must target the same column
```

This PR allows those single-condition OR alternatives to render as a real OR expression, while preserving the existing same-column collapse behavior.

**Changes**

- Render different-column grant alternatives as `OR` filters, e.g.:
  ```sql
  team_id IN ( team-a ) OR email = user@example.com
  ```
- Preserve existing same-column behavior by collapsing alternatives into `IN (...)`, e.g.:
  ```sql
  id IN ( alice bob )
  ```
- Update live table subscriptions to validate and reapply the full read filter expression instead of the older structured condition helper.
- Add regression coverage for:
  - repeated read grants across different columns
  - live table snapshots using invite-style grants
  - existing same-column repeated grants

**Notes**

Composite OR branches with multiple conditions are still intentionally unsupported, because they require grouped boolean semantics such as:

```sql
(team_id IN (...) AND role = admin) OR email = auth.email
```

The current table `WHERE` grammar does not preserve parentheses/grouping yet, so this PR avoids widening access accidentally.

**Verification**

- `cargo fmt`
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`