### PR TITLE
Brand default ports (5890/5891) + Studio LUX_URL fix; reposition README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@
 <h1 align="center">Lux</h1>
 
 <p align="center">
-  <strong>An open-source application database engine.</strong><br/>
-  Tables, cache, vectors, realtime, queues, time series, auth, and Redis-compatible commands in one Rust runtime. MIT licensed forever.
+  <strong>A database that works the way your app does.</strong>
+</p>
+
+<p align="center">
+  The Application Database: one engine for tables, cache, vectors, realtime, queues, time series,<br/>
+  and auth, instead of six services glued together. Written in Rust. MIT licensed forever.
 </p>
 
 <p align="center">
@@ -33,13 +37,19 @@ Use Lux when you want one database process to cover the hot path of your applica
 
 ## Why Lux?
 
-Redis is single-threaded by design. That simplicity is part of why it became foundational infrastructure. But it also creates a ceiling: once one core is saturated, the usual answer is to shard at the client or cluster level and accept the operational complexity.
+Every app has a second data layer beyond its primary rows: cache, sessions, live UI state, semantic search, jobs, metrics, queues, leaderboards. Today you assemble it from Redis + Postgres + Pinecone + Kafka-style plumbing + BullMQ + a metrics store, each its own connection string, SDK, dashboard, bill, and thing that breaks at 3am.
 
-Lux uses a **sharded concurrent architecture** that safely uses all your cores in a single process. Each key maps to one of N shards, each protected by a `parking_lot` RwLock. Reads never block reads. Writes only block the shard they touch. Tokio handles thousands of connections across cores. The result is single-digit microsecond latency at low concurrency and throughput that keeps scaling with cores and pipeline depth.
+Lux collapses that into one engine. Tables, cache, vectors, realtime, queues, time series, and auth share one runtime, one connection surface, one durability layer, and one SDK. You add primitives as the app needs them instead of standing up another service for each one.
+
+It speaks RESP, so your existing Redis clients (ioredis, redis-py, go-redis, Jedis, redis-rb, redis-cli), BullMQ, and tooling connect unchanged. That compatibility is the on-ramp, not the ceiling; reach for the Lux SDK and CLI when you want tables, migrations, gateway auth, and app-first workflows.
+
+## Performance
+
+Redis is single-threaded by design, which caps one instance at a single core. Lux uses a **sharded concurrent architecture** that safely uses all your cores in one process. Each key maps to one of N shards, each protected by a `parking_lot` RwLock. Reads never block reads. Writes only block the shard they touch. Tokio handles thousands of connections across cores. The result is single-digit microsecond latency at low concurrency and throughput that keeps scaling with cores and pipeline depth.
 
 The concurrency model is deliberately conservative. Commands acquire a shard lock, do their work, and release it. There are no cross-shard locks in normal command execution and no lock-ordering games. MULTI/EXEC uses WATCH-based optimistic concurrency with shard versioning, matching what Redis clients rely on.
 
-**Compatibility:** ioredis, redis-py, go-redis, Jedis, redis-rb, BullMQ, redis-cli, and other RESP clients can connect directly. Use the Lux SDK and CLI when you want higher-level tables, migrations, Cloud gateway auth, and app-first workflows.
+As a drop-in for Redis workloads, it's also faster on the measured single-key command set:
 
 ### Benchmarks
 
@@ -447,58 +457,58 @@ Project clients use the Cloud/self-hosted HTTP gateway and return `{ data, error
 Lux has a built-in HTTP/JSON API. Set `LUX_HTTP_PORT` to enable it alongside the RESP protocol. Every data primitive gets its own RESTful routes.
 
 ```bash
-LUX_HTTP_PORT=8080 ./target/release/lux
+LUX_HTTP_PORT=5890 ./target/release/lux
 ```
 
 **Key-Value:**
 ```bash
-curl http://localhost:8080/v1/kv/mykey                    # GET
-curl -X PUT http://localhost:8080/v1/kv/mykey \
+curl http://localhost:5890/v1/kv/mykey                    # GET
+curl -X PUT http://localhost:5890/v1/kv/mykey \
   -d '{"value":"hello","ex":3600}'                        # SET (with optional TTL)
-curl -X DELETE http://localhost:8080/v1/kv/mykey           # DEL
-curl -X POST http://localhost:8080/v1/kv/counter/incr      # INCR
-curl http://localhost:8080/v1/kv/myhash/hash               # HGETALL
-curl http://localhost:8080/v1/kv/mylist/list                # LRANGE
-curl http://localhost:8080/v1/kv/myset/set                 # SMEMBERS
-curl http://localhost:8080/v1/kv/myzset/zset               # ZRANGEBYSCORE
+curl -X DELETE http://localhost:5890/v1/kv/mykey           # DEL
+curl -X POST http://localhost:5890/v1/kv/counter/incr      # INCR
+curl http://localhost:5890/v1/kv/myhash/hash               # HGETALL
+curl http://localhost:5890/v1/kv/mylist/list                # LRANGE
+curl http://localhost:5890/v1/kv/myset/set                 # SMEMBERS
+curl http://localhost:5890/v1/kv/myzset/zset               # ZRANGEBYSCORE
 ```
 
 **Tables:**
 ```bash
-curl -X POST http://localhost:8080/v1/tables \
+curl -X POST http://localhost:5890/v1/tables \
   -d '{"name":"users","columns":["id INT PRIMARY KEY","name STR","age INT"]}'   # TCREATE
-curl http://localhost:8080/v1/tables                        # TLIST
-curl -X POST http://localhost:8080/v1/tables/users \
+curl http://localhost:5890/v1/tables                        # TLIST
+curl -X POST http://localhost:5890/v1/tables/users \
   -d '{"name":"Alice","age":"28"}'                          # TINSERT
-curl 'http://localhost:8080/v1/tables/users?where=age>25&order=name&limit=10'  # TSELECT
-curl http://localhost:8080/v1/tables/users/1                # row lookup endpoint
-curl -X PUT http://localhost:8080/v1/tables/users/1 \
+curl 'http://localhost:5890/v1/tables/users?where=age>25&order=name&limit=10'  # TSELECT
+curl http://localhost:5890/v1/tables/users/1                # row lookup endpoint
+curl -X PUT http://localhost:5890/v1/tables/users/1 \
   -d '{"name":"Alicia"}'                                    # TUPDATE ... WHERE id = 1
-curl -X DELETE http://localhost:8080/v1/tables/users/1      # TDELETE FROM ... WHERE id = 1
+curl -X DELETE http://localhost:5890/v1/tables/users/1      # TDELETE FROM ... WHERE id = 1
 ```
 
 **Time Series:**
 ```bash
-curl -X POST http://localhost:8080/v1/ts/cpu:host1 \
+curl -X POST http://localhost:5890/v1/ts/cpu:host1 \
   -d '{"value":72.5,"labels":{"host":"server1"}}'          # TSADD
-curl http://localhost:8080/v1/ts/cpu:host1/latest           # TSGET
-curl 'http://localhost:8080/v1/ts/cpu:host1?from=-&to=+&agg=avg&bucket=3600000'  # TSRANGE
-curl http://localhost:8080/v1/ts/cpu:host1/info             # TSINFO
+curl http://localhost:5890/v1/ts/cpu:host1/latest           # TSGET
+curl 'http://localhost:5890/v1/ts/cpu:host1?from=-&to=+&agg=avg&bucket=3600000'  # TSRANGE
+curl http://localhost:5890/v1/ts/cpu:host1/info             # TSINFO
 ```
 
 **Vectors:**
 ```bash
-curl -X POST http://localhost:8080/v1/vectors/doc:1 \
+curl -X POST http://localhost:5890/v1/vectors/doc:1 \
   -d '{"vector":[0.1,0.2,0.3],"metadata":{"title":"hello"}}'  # VSET
-curl http://localhost:8080/v1/vectors/doc:1                     # VGET
-curl -X POST http://localhost:8080/v1/vectors/search \
+curl http://localhost:5890/v1/vectors/doc:1                     # VGET
+curl -X POST http://localhost:5890/v1/vectors/search \
   -d '{"vector":[0.1,0.2,0.3],"k":5}'                         # VSEARCH
-curl http://localhost:8080/v1/vectors                            # VCARD
+curl http://localhost:5890/v1/vectors                            # VCARD
 ```
 
 **Exec (any command):**
 ```bash
-curl -X POST http://localhost:8080/v1/exec \
+curl -X POST http://localhost:5890/v1/exec \
   -d '{"command":["HSET","user:1","name","alice"]}'
 ```
 
@@ -514,7 +524,7 @@ Lux can also expose a Supabase-style app auth surface. This is optional and is s
 - `LUX_AUTH_SECRET_KEY` is for trusted servers and admin auth operations.
 
 ```bash
-LUX_HTTP_PORT=8080 \
+LUX_HTTP_PORT=5890 \
 LUX_AUTH_ENABLED=true \
 LUX_AUTH_PUBLISHABLE_KEY=lux_pub_local \
 LUX_AUTH_SECRET_KEY=lux_sec_local \
@@ -545,14 +555,14 @@ GET  /auth/v1/authorize?provider=google&redirect_to=http://localhost:5173/callba
 OAuth providers are configured through admin routes with a secret key:
 
 ```bash
-curl -X PUT http://localhost:8080/auth/v1/admin/providers/google \
+curl -X PUT http://localhost:5890/auth/v1/admin/providers/google \
   -H "Authorization: Bearer lux_sec_local" \
   -H "Content-Type: application/json" \
   -d '{
     "enabled": true,
     "client_id": "GOOGLE_CLIENT_ID",
     "client_secret": "GOOGLE_CLIENT_SECRET",
-    "redirect_uri": "http://localhost:8080/auth/v1/callback/google",
+    "redirect_uri": "http://localhost:5890/auth/v1/callback/google",
     "scopes": "openid email profile"
   }'
 ```
@@ -581,8 +591,8 @@ redis-cli GRANT read, write ON messages WHERE workspace_id IN ( SELECT workspace
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LUX_PORT` | `6379` | TCP port |
-| `LUX_HTTP_PORT` | (disabled) | HTTP API port (set to enable) |
+| `LUX_PORT` | `6379` | RESP (Redis-compatible) TCP port |
+| `LUX_HTTP_PORT` | (disabled) | HTTP API port (set to enable; `lux start` defaults it to `5890`) |
 | `LUX_PASSWORD` | (none) | Enable AUTH (applies to both RESP and HTTP) |
 | `LUX_DATA_DIR` | `.` | Snapshot directory |
 | `LUX_SAVE_INTERVAL` | `60` | Snapshot interval in seconds (0 to disable) |

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -698,7 +698,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lux-cli"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lux-cli"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "CLI for Lux"
 license = "MIT"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -39,7 +39,7 @@ enum Commands {
         #[arg(
             long,
             value_name = "PORT",
-            help = "Host port for the HTTP API (default 8080, auto-bumps if taken)"
+            help = "Host port for the HTTP API (default 5890, auto-bumps if taken)"
         )]
         http_port: Option<u16>,
     },
@@ -343,7 +343,7 @@ fn local_engine_env(state: &LocalState) -> Vec<String> {
         format!("LUX_AUTH_PUBLISHABLE_KEY={}", state.publishable_key),
         format!("LUX_AUTH_SECRET_KEY={}", state.secret_key),
         "LUX_PORT=6379".to_string(),
-        "LUX_HTTP_PORT=8080".to_string(),
+        "LUX_HTTP_PORT=5890".to_string(),
         "LUX_BIND_HOST=0.0.0.0".to_string(),
         "LUX_DATA_DIR=/data".to_string(),
         // Tiered (WAL) storage so local-dev data survives a crash/restart;
@@ -370,7 +370,7 @@ struct Config {
 struct LocalConfig {
     project_id: Option<String>,
     project_name: Option<String>,
-    /// Optional host port overrides for `lux start` (engine listens on 6379/8080
+    /// Optional host port overrides for `lux start` (engine listens on 6379/5890
     /// inside the container; these map to the host).
     local_http_port: Option<u16>,
     local_resp_port: Option<u16>,
@@ -392,15 +392,16 @@ fn desired_engine_image(config: Option<&LocalConfig>) -> String {
 /// release) and `lux start` does an explicit `docker pull` each run, so local
 /// dev follows the newest engine without the CLI needing a release per bump.
 const LOCAL_ENGINE_IMAGE: &str = "ghcr.io/lux-db/lux:latest";
-const DEFAULT_HTTP_PORT: u16 = 8080;
+const DEFAULT_HTTP_PORT: u16 = 5890;
 const DEFAULT_RESP_PORT: u16 = 6379;
 
 /// Lux Studio image `lux studio` runs (tracks `:latest`, pulled each run, like
 /// the engine image). Serves the local web UI; talks to the engine from the
 /// browser over the engine's CORS-`*` HTTP API.
 const STUDIO_IMAGE: &str = "ghcr.io/lux-db/studio:latest";
-/// Default host port for Studio (Supabase Studio uses 54323; we follow suit).
-const DEFAULT_STUDIO_PORT: u16 = 54323;
+/// Default host port for Studio. Lux owns the 5890 block: 5890 = HTTP API,
+/// 5891 = Studio (RESP stays on 6379 for Redis drop-in compatibility).
+const DEFAULT_STUDIO_PORT: u16 = 5891;
 
 fn default_studio_port() -> u16 {
     DEFAULT_STUDIO_PORT
@@ -751,8 +752,9 @@ fn studio_project_name() -> String {
 /// Ensure the Lux Studio container is running against `state`'s engine, then
 /// print its URL (and optionally open a browser). Assumes the engine is up.
 /// Non-fatal: warns and returns on failure so callers like `lux start` keep
-/// going. The SPA runs in the browser, so LUX_URL is host-visible localhost;
-/// LUX_KEY is the operator secret and never leaves the machine.
+/// going. The SPA runs in the browser, so LUX_URL must be reachable from the
+/// browser: defaults to host-visible localhost, but honors an explicit LUX_URL
+/// for remote/sandbox setups. LUX_KEY is the operator secret and stays local.
 fn ensure_studio(state: &mut LocalState, open_browser: bool) {
     if docker_container_state(&state.studio_container).as_deref() == Some("running") {
         let url = format!("http://localhost:{}", state.studio_port);
@@ -777,7 +779,16 @@ fn ensure_studio(state: &mut LocalState, open_browser: bool) {
         .status();
 
     let port_map = format!("{studio_port}:80");
-    let e_url = format!("LUX_URL=http://localhost:{}", state.http_port);
+    // The Studio SPA runs in the browser and calls the engine directly. Normally
+    // that's the host-visible localhost, but in a remote/sandbox context (e2b,
+    // a dev container, an SSH port-forward) the browser can't reach the engine
+    // at localhost. Honor an explicit LUX_URL so Studio points at whatever URL
+    // is actually reachable from the browser; fall back to localhost otherwise.
+    let engine_url = match std::env::var("LUX_URL") {
+        Ok(u) if !u.trim().is_empty() => u.trim().to_string(),
+        _ => format!("http://localhost:{}", state.http_port),
+    };
+    let e_url = format!("LUX_URL={engine_url}");
     let e_key = format!("LUX_KEY={}", state.secret_key);
     let e_pub = format!("LUX_PUBLISHABLE_KEY={}", state.publishable_key);
     let e_direct = format!("LUX_DIRECT_URL={}", state.direct_url());
@@ -831,6 +842,7 @@ fn ensure_studio(state: &mut LocalState, open_browser: bool) {
 
     let url = format!("http://localhost:{studio_port}");
     println!("{} {}", "Lux Studio:".bold(), url.cyan());
+    println!("{} {}", "  → engine:".dimmed(), engine_url.dimmed());
     if open_browser {
         let _ = open::that(&url);
     }
@@ -1331,7 +1343,7 @@ pub async fn run() {
                 .status();
 
             let resp_map = format!("{}:6379", state.resp_port);
-            let http_map = format!("{}:8080", state.http_port);
+            let http_map = format!("{}:5890", state.http_port);
             let vol_map = format!("{}:/data", state.volume);
             let engine_env = local_engine_env(&state);
 
@@ -4248,7 +4260,7 @@ mod tests {
             password: "lux_sec_local_deadbeef".to_string(),
             publishable_key: "lux_pub_local_cafef00d".to_string(),
             secret_key: "lux_sec_local_deadbeef".to_string(),
-            http_port: 8080,
+            http_port: 5890,
             resp_port: 6379,
             container: "lux-sample-abc123".to_string(),
             volume: "lux-sample-abc123-data".to_string(),
@@ -4261,13 +4273,13 @@ mod tests {
     #[test]
     fn local_state_urls_and_env_lines() {
         let s = sample_state();
-        assert_eq!(s.lux_url(), "http://localhost:8080");
+        assert_eq!(s.lux_url(), "http://localhost:5890");
         assert_eq!(
             s.direct_url(),
             "lux://:lux_sec_local_deadbeef@localhost:6379"
         );
         let env = s.env_lines();
-        assert_eq!(env[0], "LUX_URL=http://localhost:8080");
+        assert_eq!(env[0], "LUX_URL=http://localhost:5890");
         assert_eq!(
             env[1],
             "LUX_DIRECT_URL=lux://:lux_sec_local_deadbeef@localhost:6379"


### PR DESCRIPTION
## What
- **CLI v0.26.0**: brand the local default ports — HTTP API **8080 → 5890**, Studio **54323 → 5891**. RESP stays **6379** (Redis drop-in on-ramp).
- **Studio fix**: `lux start` now honors an explicit `LUX_URL` instead of hardcoding `http://localhost:<port>`, so Studio works in remote/sandbox setups (e2b, dev containers) where the browser can't reach the host's localhost. Falls back to localhost when unset. Prints the engine URL Studio targets.
- **README**: repositioned as "The Application Database" (tagline + sprawl-first "Why Lux"; Redis/benchmarks demoted to a supporting Performance section). Port examples → 5890.

## Notes
- Engine binary unchanged (its HTTP default is `0`/disabled; it just reads `LUX_HTTP_PORT`). This is a CLI + docs change.
- 38 CLI tests + clippy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)