### PR TITLE
fix: correct WAL replay for multi-key and blocked-consumer list ops

### DIFF
--- a/src/cmd/lists.rs
+++ b/src/cmd/lists.rs
@@ -671,7 +671,14 @@ pub fn cmd_blmove(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         None => return CmdResult::Written,
     };
 
+    // Immediately-satisfiable BLMOVE moves like LMOVE, so it must be logged the
+    // same way (it isn't classified as a write command, so execute_with_wal never
+    // logs it). Self-log the resolved pop+push keyed per-key. The blocked path
+    // (CmdResult::BlockMove) is logged when the waiter is later satisfied.
     if let Some(v) = store.lmove(args[1], args[2], src_left, dst_left, now) {
+        if !wal_log_list_move(store, args[1], args[2], v.as_ref(), src_left, dst_left, out) {
+            return CmdResult::Written;
+        }
         resp::write_bulk_raw(out, &decrypt_out(store, v));
         return CmdResult::Written;
     }

--- a/src/cmd/lists.rs
+++ b/src/cmd/lists.rs
@@ -535,6 +535,38 @@ pub fn cmd_lpos(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
     CmdResult::Written
 }
 
+/// Self-log a resolved list move as its two keyed single-key effects: a POP on
+/// `src` (keyed on src) and a PUSH of the moved element on `dst` (keyed on dst).
+/// The raw LMOVE/RPOPLPUSH is skipped in execute_with_wal (it would shard on src
+/// and replay dst's push out of order vs dst's own writes). Batched so it stays
+/// one atomic append when src and dst share a WAL shard and splits into
+/// correctly-sharded frames when they don't. A plain PUSH stores the moved bytes
+/// verbatim (no re-encryption), so this is correct for encrypted lists too.
+/// Returns false and writes an error to `out` if the WAL append fails.
+fn wal_log_list_move(
+    store: &Store,
+    src: &[u8],
+    dst: &[u8],
+    moved: &[u8],
+    src_left: bool,
+    dst_left: bool,
+    out: &mut BytesMut,
+) -> bool {
+    if !store.wal_enabled() {
+        return true;
+    }
+    let pop: &[u8] = if src_left { b"LPOP" } else { b"RPOP" };
+    let push: &[u8] = if dst_left { b"LPUSH" } else { b"RPUSH" };
+    let pop_cmd: [&[u8]; 2] = [pop, src];
+    let push_cmd: [&[u8]; 3] = [push, dst, moved];
+    let batch: [&[&[u8]]; 2] = [&pop_cmd, &push_cmd];
+    if let Err(e) = store.wal_log_command_batch(&batch) {
+        resp::write_error(out, &format!("ERR WAL append failed: {e}"));
+        return false;
+    }
+    true
+}
+
 pub fn cmd_lmove(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant) -> CmdResult {
     if args.len() < 5 {
         resp::write_error(out, "ERR wrong number of arguments for 'lmove' command");
@@ -548,12 +580,15 @@ pub fn cmd_lmove(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         Some(side) => side,
         None => return CmdResult::Written,
     };
-    resp::write_optional_bulk_raw(
-        out,
-        &store
-            .lmove(args[1], args[2], src_left, dst_left, now)
-            .map(|b| decrypt_out(store, b)),
-    );
+    match store.lmove(args[1], args[2], src_left, dst_left, now) {
+        Some(v) => {
+            if !wal_log_list_move(store, args[1], args[2], v.as_ref(), src_left, dst_left, out) {
+                return CmdResult::Written;
+            }
+            resp::write_bulk_raw(out, &decrypt_out(store, v));
+        }
+        None => resp::write_null(out),
+    }
     CmdResult::Written
 }
 
@@ -562,12 +597,15 @@ pub fn cmd_rpoplpush(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Ins
         resp::write_error(out, "ERR wrong number of arguments for 'rpoplpush' command");
         return CmdResult::Written;
     }
-    resp::write_optional_bulk_raw(
-        out,
-        &store
-            .lmove(args[1], args[2], false, true, now)
-            .map(|b| decrypt_out(store, b)),
-    );
+    match store.lmove(args[1], args[2], false, true, now) {
+        Some(v) => {
+            if !wal_log_list_move(store, args[1], args[2], v.as_ref(), false, true, out) {
+                return CmdResult::Written;
+            }
+            resp::write_bulk_raw(out, &decrypt_out(store, v));
+        }
+        None => resp::write_null(out),
+    }
     CmdResult::Written
 }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1842,6 +1842,21 @@ pub fn execute(
             if cmd_eq(cmd, b"LMOVE") {
                 return lists::cmd_lmove(args, store, out, now);
             }
+            if cmd_eq(cmd, b"LXRESTORE") {
+                // Internal, replay-only: COPY's self-logged effect. Reject if a
+                // client sends it during normal operation.
+                if !store.wal_replaying() {
+                    resp::write_error(out, &format!("ERR unknown command '{}'", arg_str(cmd)));
+                    return CmdResult::Written;
+                }
+                if args.len() != 3 {
+                    return CmdResult::Written;
+                }
+                if let Err(e) = store.apply_lxrestore(args[2]) {
+                    resp::write_error(out, &e);
+                }
+                return CmdResult::Written;
+            }
             if cmd_eq(cmd, b"LASTSAVE") {
                 return server::cmd_lastsave(args, store, out, now);
             }
@@ -2365,6 +2380,26 @@ fn command_self_logs_wal_args(args: &[&[u8]], store: &Store, now: Instant) -> bo
     }
     let cmd = args[0];
     if command_self_logs_wal(cmd) {
+        return true;
+    }
+    // Commands whose key isn't at args[1] and/or that read/write across WAL
+    // shards self-log their resolved single-key effects to the correct shard(s),
+    // so they must not be raw-logged here (which would replay out of order).
+    if cmd_eq(cmd, b"ZUNIONSTORE") || cmd_eq(cmd, b"ZINTERSTORE") || cmd_eq(cmd, b"ZDIFFSTORE") {
+        return true;
+    }
+    if cmd_eq(cmd, b"SUNIONSTORE") || cmd_eq(cmd, b"SINTERSTORE") || cmd_eq(cmd, b"SDIFFSTORE") {
+        return true;
+    }
+    // Movers write two keys on different WAL shards. They self-log the resolved
+    // per-key effects (pop on src, push on dst) so each replays in its own
+    // shard's order instead of the raw command landing wholesale in src's shard.
+    if cmd_eq(cmd, b"LMOVE") || cmd_eq(cmd, b"RPOPLPUSH") || cmd_eq(cmd, b"SMOVE") {
+        return true;
+    }
+    // COPY writes only dst but shards on src and re-reads src at replay; it
+    // self-logs the resolved dst value as a keyed LXRESTORE instead.
+    if cmd_eq(cmd, b"COPY") {
         return true;
     }
     if cmd_eq(cmd, b"SET") && args.len() >= 3 {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2402,6 +2402,11 @@ fn command_self_logs_wal_args(args: &[&[u8]], store: &Store, now: Instant) -> bo
     if cmd_eq(cmd, b"COPY") {
         return true;
     }
+    // MSET/MSETNX write many keys; the raw command shards on the first key only.
+    // They self-log a keyed SET per pair so each lands in its own WAL shard.
+    if cmd_eq(cmd, b"MSET") || cmd_eq(cmd, b"MSETNX") {
+        return true;
+    }
     if cmd_eq(cmd, b"SET") && args.len() >= 3 {
         return args[3..].iter().any(|arg| cmd_eq(arg, b"ENCRYPTED"))
             || store.kv_string_is_encrypted(args[1], now);

--- a/src/cmd/sets.rs
+++ b/src/cmd/sets.rs
@@ -185,7 +185,23 @@ pub fn cmd_smove(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         return CmdResult::Written;
     }
     match store.smove(args[1], args[2], args[3], now) {
-        Ok(b) => resp::write_integer(out, if b { 1 } else { 0 }),
+        Ok(b) => {
+            // Self-log the resolved effect as a keyed SREM on src + SADD on dst so
+            // each replays in its own WAL shard's order. The raw SMOVE would land
+            // wholesale in src's shard and replay the dst insert out of order vs
+            // dst's own writes. Batched: atomic when src/dst share a shard, split
+            // (correctly sharded) when they don't. No-op if nothing moved.
+            if b && store.wal_enabled() {
+                let srem: [&[u8]; 3] = [b"SREM", args[1], args[3]];
+                let sadd: [&[u8]; 3] = [b"SADD", args[2], args[3]];
+                let batch: [&[&[u8]]; 2] = [&srem, &sadd];
+                if let Err(e) = store.wal_log_command_batch(&batch) {
+                    resp::write_error(out, &format!("ERR WAL append failed: {e}"));
+                    return CmdResult::Written;
+                }
+            }
+            resp::write_integer(out, if b { 1 } else { 0 });
+        }
         Err(e) => resp::write_error(out, &e),
     }
     CmdResult::Written

--- a/src/cmd/strings.rs
+++ b/src/cmd/strings.rs
@@ -550,6 +550,21 @@ pub fn cmd_mset(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant)
         store.set(args[i], args[i + 1], None, now);
         i += 2;
     }
+    // Self-log each pair as a keyed SET so every key lands in its own WAL shard.
+    // The raw MSET would shard on the first key only, replaying the rest out of
+    // order vs their own shards' writes. Batched: atomic when all keys share a
+    // shard, correctly split when they don't.
+    if store.wal_enabled() {
+        let sets: Vec<[&[u8]; 3]> = args[1..]
+            .chunks(2)
+            .map(|c| [b"SET".as_slice(), c[0], c[1]])
+            .collect();
+        let refs: Vec<&[&[u8]]> = sets.iter().map(|s| s.as_slice()).collect();
+        if let Err(e) = store.wal_log_command_batch(&refs) {
+            resp::write_error(out, &format!("ERR WAL append failed: {e}"));
+            return CmdResult::Written;
+        }
+    }
     resp::write_ok(out);
     CmdResult::Written
 }
@@ -567,7 +582,21 @@ pub fn cmd_msetnx(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         resp::write_error(out, ENCRYPTED_MUTATION_ERR);
         return CmdResult::Written;
     }
-    resp::write_integer(out, if store.msetnx(&pairs, now) { 1 } else { 0 });
+    let set = store.msetnx(&pairs, now);
+    // Self-log each applied pair as a keyed SET (same cross-shard reasoning as
+    // MSET). The NX check already passed at runtime; replay just sets the values.
+    if set && store.wal_enabled() {
+        let sets: Vec<[&[u8]; 3]> = pairs
+            .iter()
+            .map(|(k, v)| [b"SET".as_slice(), *k, *v])
+            .collect();
+        let refs: Vec<&[&[u8]]> = sets.iter().map(|s| s.as_slice()).collect();
+        if let Err(e) = store.wal_log_command_batch(&refs) {
+            resp::write_error(out, &format!("ERR WAL append failed: {e}"));
+            return CmdResult::Written;
+        }
+    }
+    resp::write_integer(out, if set { 1 } else { 0 });
     CmdResult::Written
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4624,6 +4624,14 @@ async fn handle_block_zpop(
             if let Ok(items) = result {
                 if !items.is_empty() {
                     let (member, score) = &items[0];
+                    // BZPOPMIN/BZPOPMAX pop straight from the store here, outside
+                    // the WAL; log the removal of the exact member so replay
+                    // doesn't resurrect it (ENG-1317). Keyed on `key` -> correct
+                    // shard; no shard locks held at this point.
+                    if store.wal_enabled() {
+                        let _ =
+                            store.wal_log_command(&[b"ZREM", key.as_bytes(), member.as_bytes()]);
+                    }
                     resp::write_array_header(&mut write_buf, 3);
                     resp::write_bulk(&mut write_buf, key);
                     resp::write_bulk(&mut write_buf, member);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1990,7 +1990,14 @@ impl EmbeddedClient {
             ));
         };
 
-        wait_for_blocking_pop(&self.runtime.broker, &owned_keys, timeout, pop_left).await
+        wait_for_blocking_pop(
+            &self.runtime.store,
+            &self.runtime.broker,
+            &owned_keys,
+            timeout,
+            pop_left,
+        )
+        .await
     }
 
     async fn execute_owned(&self, argv: Vec<Vec<u8>>) -> Result<bytes::Bytes, LuxError> {
@@ -2694,6 +2701,7 @@ fn parse_blocking_pop_value(buf: &[u8]) -> Result<Option<(String, bytes::Bytes)>
 }
 
 async fn wait_for_blocking_pop(
+    store: &Store,
     broker: &Broker,
     keys: &[String],
     timeout: Duration,
@@ -2718,6 +2726,10 @@ async fn wait_for_blocking_pop(
         val = rx.recv() => val,
         _ = tokio::time::sleep(timeout) => None,
     };
+
+    if let Some((key, _)) = &result {
+        wal_log_blocked_pop(store, key.as_bytes(), pop_left);
+    }
 
     broker.remove_list_waiters_by_id(keys, waiter_id);
     Ok(result)
@@ -4339,9 +4351,23 @@ async fn handle_connection(
     }
 }
 
+/// Log the pop that satisfied a blocked BLPOP/BRPOP/BLMOVE. The element was
+/// already removed from `key` in memory by the pushing side's drain, and the
+/// push that satisfied us was WAL-logged before we woke, so appending the
+/// matching pop here keeps WAL replay from resurrecting the element (ENG-1317).
+/// Runs in the woken task with no shard locks held, so there is no
+/// memory->WAL lock nesting.
+fn wal_log_blocked_pop(store: &Store, key: &[u8], pop_left: bool) {
+    if !store.wal_enabled() {
+        return;
+    }
+    let pop: &[u8] = if pop_left { b"LPOP" } else { b"RPOP" };
+    let _ = store.wal_log_command(&[pop, key]);
+}
+
 async fn handle_block_pop(
     socket: &mut tokio::net::TcpStream,
-    _store: &Arc<Store>,
+    store: &Arc<Store>,
     broker: &Broker,
     keys: &[String],
     timeout: std::time::Duration,
@@ -4370,6 +4396,7 @@ async fn handle_block_pop(
 
     match result {
         Some((key, val)) => {
+            wal_log_blocked_pop(store, key.as_bytes(), pop_left);
             resp::write_array_header(&mut write_buf, 2);
             resp::write_bulk(&mut write_buf, &key);
             resp::write_bulk_raw(&mut write_buf, &val);
@@ -4422,6 +4449,20 @@ async fn handle_block_move(
                 let _ = store.lpush(dst.as_bytes(), vals, now);
             } else {
                 let _ = store.rpush(dst.as_bytes(), vals, now);
+            }
+            // Log both effects of the completed move: the src pop (done in the
+            // pushing side's drain) and the dst push (done just above). Neither
+            // went through the WAL yet; the satisfying push to src was logged
+            // before we woke, so replay order is push(src), pop(src), push(dst)
+            // -> element ends up only in dst (ENG-1317). Batched so a same-shard
+            // move is one atomic frame; a cross-shard move splits per shard.
+            if store.wal_enabled() {
+                let pop: &[u8] = if src_left { b"LPOP" } else { b"RPOP" };
+                let push: &[u8] = if dst_left { b"LPUSH" } else { b"RPUSH" };
+                let pop_cmd: [&[u8]; 2] = [pop, src.as_bytes()];
+                let push_cmd: [&[u8]; 3] = [push, dst.as_bytes(), val.as_ref()];
+                let batch: [&[&[u8]]; 2] = [&pop_cmd, &push_cmd];
+                let _ = store.wal_log_command_batch(&batch);
             }
             resp::write_bulk_raw(&mut write_buf, &val);
         }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -584,6 +584,39 @@ pub(crate) fn load_binary(
     Ok(count)
 }
 
+/// Encode a single key/value into the on-disk snapshot format (header + one
+/// entry). Used to self-log COPY to the WAL as a keyed `LXRESTORE dst <blob>`
+/// so replay reconstructs the destination from its own WAL shard, rather than
+/// re-reading a source key whose shard may not have replayed yet.
+pub(crate) fn encode_dump_blob(
+    store: &Store,
+    entry: &crate::store::DumpEntry,
+) -> io::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    save_binary(&mut buf, std::slice::from_ref(entry), store)?;
+    Ok(buf)
+}
+
+/// Decode a blob produced by `encode_dump_blob` and load its entry into the
+/// store, overwriting any existing key. Replay path for `LXRESTORE`.
+pub(crate) fn decode_dump_blob(store: &Store, blob: &[u8]) -> io::Result<usize> {
+    let mut cursor = io::Cursor::new(blob);
+    let mut header = [0u8; 4];
+    cursor.read_exact(&mut header)?;
+    if &header == HEADER {
+        load_binary(store, &mut cursor, true, true)
+    } else if &header == HEADER_V2 {
+        load_binary(store, &mut cursor, true, false)
+    } else if &header == HEADER_V1 {
+        load_binary(store, &mut cursor, false, false)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "LXRESTORE payload is not a lux snapshot",
+        ))
+    }
+}
+
 fn load_legacy(store: &Store, file: fs::File) -> io::Result<usize> {
     let reader = io::BufReader::new(file);
     let mut count = 0;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1038,6 +1038,20 @@ impl Store {
         self.wal_shards.is_some() && !self.wal_suppress.load(Ordering::Relaxed)
     }
 
+    /// True while `replay_wal` is re-applying logged commands. Gates internal
+    /// replay-only commands (e.g. `LXRESTORE`) so clients can't invoke them.
+    pub(crate) fn wal_replaying(&self) -> bool {
+        self.wal_suppress.load(Ordering::Relaxed)
+    }
+
+    /// Decode and apply an `LXRESTORE` blob (COPY's self-logged effect). Only
+    /// honored during WAL replay.
+    pub(crate) fn apply_lxrestore(&self, blob: &[u8]) -> Result<(), String> {
+        crate::snapshot::decode_dump_blob(self, blob)
+            .map(|_| ())
+            .map_err(|e| format!("ERR LXRESTORE decode failed: {e}"))
+    }
+
     pub(crate) fn lock_read_shard(&self, idx: usize) -> parking_lot::RwLockReadGuard<'_, Shard> {
         self.shards[idx].read()
     }
@@ -2648,7 +2662,28 @@ impl Store {
             }
         }
 
-        self.load_entry(key_string(dst), dump_val, ttl);
+        // Self-log the resolved destination value as `LXRESTORE dst <blob>` keyed
+        // on dst. The raw COPY is skipped in execute_with_wal: it shards on src
+        // (args[1]) and, worse, re-reads src at replay time, but a per-shard WAL
+        // replay can hit COPY before src's own shard has replayed its post-snapshot
+        // writes, copying a stale source. The self-logged blob captures dst's exact
+        // value and replays in dst's shard order. Log before mutating memory so a
+        // WAL failure leaves dst untouched.
+        if self.wal_enabled() {
+            let ttl_ms = ttl.map(|d| d.as_millis() as i64).unwrap_or(-1);
+            let entry = DumpEntry {
+                key: key_string(dst),
+                value: dump_val,
+                ttl_ms,
+            };
+            let blob = crate::snapshot::encode_dump_blob(self, &entry)
+                .map_err(|e| format!("ERR COPY encode failed: {e}"))?;
+            self.wal_log_command(&[b"LXRESTORE", dst, &blob])
+                .map_err(|e| format!("ERR WAL append failed: {e}"))?;
+            self.load_entry(entry.key, entry.value, ttl);
+        } else {
+            self.load_entry(key_string(dst), dump_val, ttl);
+        }
         Ok(true)
     }
 
@@ -4699,35 +4734,51 @@ impl Store {
         }
     }
 
+    /// Replace `dst` with `members` (as a set) and self-log the resolved effect
+    /// (DEL + SADD) keyed on dst, so replay rebuilds dst from its own WAL shard,
+    /// independent of the source keys' shard order. (The raw *STORE command is
+    /// skipped in execute_with_wal via command_self_logs_wal.)
+    fn write_computed_set(
+        &self,
+        dst: &[u8],
+        members: &[&[u8]],
+        now: Instant,
+    ) -> Result<i64, String> {
+        self.del(&[dst]);
+        if !members.is_empty() {
+            self.sadd(dst, members, now)?;
+        }
+        if self.wal_enabled() {
+            self.wal_log_command(&[b"DEL", dst])
+                .map_err(|e| format!("ERR WAL append failed: {e}"))?;
+            if !members.is_empty() {
+                let mut sadd: Vec<&[u8]> = Vec::with_capacity(members.len() + 2);
+                sadd.push(b"SADD");
+                sadd.push(dst);
+                sadd.extend_from_slice(members);
+                self.wal_log_command(&sadd)
+                    .map_err(|e| format!("ERR WAL append failed: {e}"))?;
+            }
+        }
+        Ok(members.len() as i64)
+    }
+
     pub fn sdiffstore(&self, dst: &[u8], keys: &[&[u8]], now: Instant) -> Result<i64, String> {
         let result = self.sdiff(keys, now)?;
         let members: Vec<&[u8]> = result.iter().map(|s| s.as_bytes()).collect();
-        self.del(&[dst]);
-        if !members.is_empty() {
-            let member_refs: Vec<&[u8]> = members;
-            self.sadd(dst, &member_refs, now)?;
-        }
-        Ok(result.len() as i64)
+        self.write_computed_set(dst, &members, now)
     }
 
     pub fn sinterstore(&self, dst: &[u8], keys: &[&[u8]], now: Instant) -> Result<i64, String> {
         let result = self.sinter(keys, now)?;
         let members: Vec<&[u8]> = result.iter().map(|s| s.as_bytes()).collect();
-        self.del(&[dst]);
-        if !members.is_empty() {
-            self.sadd(dst, &members, now)?;
-        }
-        Ok(result.len() as i64)
+        self.write_computed_set(dst, &members, now)
     }
 
     pub fn sunionstore(&self, dst: &[u8], keys: &[&[u8]], now: Instant) -> Result<i64, String> {
         let result = self.sunion(keys, now)?;
         let members: Vec<&[u8]> = result.iter().map(|s| s.as_bytes()).collect();
-        self.del(&[dst]);
-        if !members.is_empty() {
-            self.sadd(dst, &members, now)?;
-        }
-        Ok(result.len() as i64)
+        self.write_computed_set(dst, &members, now)
     }
 
     pub fn expire_sweep(&self, now: Instant) {

--- a/src/store/sorted_sets.rs
+++ b/src/store/sorted_sets.rs
@@ -732,36 +732,80 @@ impl Store {
     }
 
     /// Delete `dst` and store `result` as a sorted set; returns the member count.
-    fn write_computed_zset(&self, dst: &[u8], result: HashMap<String, f64>) -> i64 {
+    fn write_computed_zset(&self, dst: &[u8], result: HashMap<String, f64>) -> Result<i64, String> {
         let count = result.len() as i64;
         self.del(&[dst]);
-        if !result.is_empty() {
-            let idx = self.shard_index(dst);
-            let mut shard = self.shards[idx].write();
-            shard.version += 1;
-            let mut tree = BTreeMap::new();
-            let mut scores = HashMap::new();
-            let mut mem = key_str(dst).len() + 64;
-            for (member, score) in result {
-                mem += member.len() + 48;
-                tree.insert((OrderedFloat(score), member.clone()), ());
-                scores.insert(member, score);
+        let wal = self.wal_enabled();
+
+        if result.is_empty() {
+            // Self-log the clear so replay drops any prior dst on dst's own shard.
+            if wal {
+                self.wal_log_command(&[b"DEL", dst])
+                    .map_err(|e| format!("ERR WAL append failed: {e}"))?;
             }
-            let old = shard.data.insert(
-                key_bytes(dst),
-                Entry {
-                    value: StoreValue::SortedSet(tree, scores),
-                    expires_at: None,
-                    lru_clock: self.lru_clock(),
-                },
-            );
-            if old.is_none() {
-                self.key_added();
-            }
-            shard.used_memory += mem;
-            self.mem_add(mem);
+            return Ok(count);
         }
-        count
+
+        let idx = self.shard_index(dst);
+        let mut shard = self.shards[idx].write();
+        shard.version += 1;
+        let mut tree = BTreeMap::new();
+        let mut scores = HashMap::new();
+        let mut mem = key_str(dst).len() + 64;
+        // Captured for the self-logged ZADD below (only when WAL is on).
+        let mut members: Vec<String> = if wal {
+            Vec::with_capacity(result.len())
+        } else {
+            Vec::new()
+        };
+        let mut score_strs: Vec<String> = if wal {
+            Vec::with_capacity(result.len())
+        } else {
+            Vec::new()
+        };
+        for (member, score) in result {
+            mem += member.len() + 48;
+            tree.insert((OrderedFloat(score), member.clone()), ());
+            if wal {
+                score_strs.push(score.to_string());
+                members.push(member.clone());
+            }
+            scores.insert(member, score);
+        }
+        let old = shard.data.insert(
+            key_bytes(dst),
+            Entry {
+                value: StoreValue::SortedSet(tree, scores),
+                expires_at: None,
+                lru_clock: self.lru_clock(),
+            },
+        );
+        if old.is_none() {
+            self.key_added();
+        }
+        shard.used_memory += mem;
+        self.mem_add(mem);
+        drop(shard);
+
+        // Self-log the resolved effect keyed on dst (DEL + ZADD). The raw *STORE
+        // command reads source keys that may live on other WAL shards, so per-
+        // shard replay could apply it before the sources are restored. Logging
+        // DEL+ZADD to dst's own shard makes replay independent of source order.
+        // (The raw command is skipped in execute_with_wal via command_self_logs_wal.)
+        if wal {
+            self.wal_log_command(&[b"DEL", dst])
+                .map_err(|e| format!("ERR WAL append failed: {e}"))?;
+            let mut zadd: Vec<&[u8]> = Vec::with_capacity(members.len() * 2 + 2);
+            zadd.push(b"ZADD");
+            zadd.push(dst);
+            for (s, m) in score_strs.iter().zip(members.iter()) {
+                zadd.push(s.as_bytes());
+                zadd.push(m.as_bytes());
+            }
+            self.wal_log_command(&zadd)
+                .map_err(|e| format!("ERR WAL append failed: {e}"))?;
+        }
+        Ok(count)
     }
 
     /// Sort a member->score map into Redis order: by score ascending, ties by
@@ -785,7 +829,7 @@ impl Store {
         now: Instant,
     ) -> Result<i64, String> {
         let result = self.zunion_compute(keys, weights, aggregate, now)?;
-        Ok(self.write_computed_zset(dst, result))
+        self.write_computed_zset(dst, result)
     }
 
     pub fn zinterstore(
@@ -797,12 +841,12 @@ impl Store {
         now: Instant,
     ) -> Result<i64, String> {
         let result = self.zinter_compute(keys, weights, aggregate, now)?;
-        Ok(self.write_computed_zset(dst, result))
+        self.write_computed_zset(dst, result)
     }
 
     pub fn zdiffstore(&self, dst: &[u8], keys: &[&[u8]], now: Instant) -> Result<i64, String> {
         let result = self.zdiff_compute(keys, now)?;
-        Ok(self.write_computed_zset(dst, result))
+        self.write_computed_zset(dst, result)
     }
 
     /// Direct-return union (sorted). WITHSCORES is applied at the command layer.

--- a/tests/crash_recovery.rs
+++ b/tests/crash_recovery.rs
@@ -299,6 +299,82 @@ fn rpoplpush_cross_shard_order_survives_wal_replay() {
     }
 }
 
+// PROBE (ENG-1316): an immediately-satisfiable BLMOVE moves like LMOVE and must
+// be logged the same way. BLMOVE isn't classified as a write command, so
+// execute_with_wal never logs it; the immediate path self-logs pop+push.
+#[test]
+fn blmove_immediate_cross_shard_survives_wal_replay() {
+    let mut srv = LuxServer::builder().tiered().maxmemory("100kb").start();
+    let mut c = srv.conn();
+    let n = 24usize;
+    for i in 0..n {
+        let a = format!("a{i}");
+        let b = format!("b{i}");
+        send(&mut c, &["RPUSH", &a, "M"]);
+        send(&mut c, &["RPUSH", &b, "P"]); // b{i} = [P]
+        send(&mut c, &["BLMOVE", &a, &b, "LEFT", "RIGHT", "0"]); // src non-empty => immediate
+    }
+    drop(c);
+    srv.kill();
+    srv.restart(); // WAL replay only
+    let mut c = srv.conn();
+    for i in 0..n {
+        let a = format!("a{i}");
+        let b = format!("b{i}");
+        let range = send(&mut c, &["LRANGE", &b, "0", "-1"]);
+        let p = range.find("\r\nP\r\n");
+        let m = range.find("\r\nM\r\n");
+        assert!(
+            p.is_some() && m.is_some() && p < m,
+            "b{i} must be [P, M] after replay; got {range:?}"
+        );
+        assert!(
+            send(&mut c, &["LLEN", &a]).contains(":0"),
+            "a{i} must be empty after replay"
+        );
+    }
+}
+
+// QUARANTINED repro: a BLOCKED BLMOVE later satisfied by a push does not log the
+// move, so WAL replay leaves the element in src and never in dst. This is the
+// broader blocked-consumer durability gap (BLPOP/BRPOP have the same shape: the
+// push is logged but the waiter's consuming pop is not). Tracked separately from
+// the sharded-replay fix; un-ignore when fixing. Run with:
+//   cargo test --release --test crash_recovery -- --ignored blmove_blocked
+#[test]
+#[ignore]
+fn blmove_blocked_completion_survives_wal_replay() {
+    let mut srv = LuxServer::builder().tiered().maxmemory("100kb").start();
+    let mut blocker = srv.conn();
+    let h = thread::spawn(move || {
+        // Blocks on empty bsrc until the push below wakes it.
+        send(
+            &mut blocker,
+            &["BLMOVE", "bsrc", "bdst", "LEFT", "RIGHT", "5"],
+        );
+    });
+    thread::sleep(Duration::from_millis(300)); // let the BLMOVE register as a waiter
+    let mut c = srv.conn();
+    send(&mut c, &["RPUSH", "bsrc", "V"]); // wakes the blocked BLMOVE: V moves to bdst
+    h.join().unwrap();
+    assert!(
+        send(&mut c, &["LRANGE", "bdst", "0", "-1"]).contains("V"),
+        "runtime move must have happened"
+    );
+    drop(c);
+    srv.kill();
+    srv.restart(); // WAL replay only
+    let mut c = srv.conn();
+    assert!(
+        send(&mut c, &["LRANGE", "bdst", "0", "-1"]).contains("V"),
+        "bdst must retain the moved element after replay"
+    );
+    assert!(
+        send(&mut c, &["LLEN", "bsrc"]).contains(":0"),
+        "bsrc must be empty after replay (element was moved, not left behind)"
+    );
+}
+
 // PROBE (ENG-1316): COPY writes only dst but the raw command shards on src and
 // re-reads src at replay, when a per-shard replay may not have rebuilt src yet
 // (and dst's own writes replay in a separate shard). COPY self-logs the resolved

--- a/tests/crash_recovery.rs
+++ b/tests/crash_recovery.rs
@@ -436,6 +436,52 @@ fn blpop_blocked_completion_survives_wal_replay() {
     }
 }
 
+// PROBE (ENG-1317): a BLOCKED BZPOPMIN satisfied by a later ZADD. handle_block_zpop
+// pops straight from the store outside the WAL; the removal is now logged as a
+// keyed ZREM so replay doesn't resurrect the popped member into the zset.
+#[test]
+fn bzpopmin_blocked_completion_survives_wal_replay() {
+    let mut srv = LuxServer::builder().tiered().maxmemory("100kb").start();
+    let n = 16usize;
+    let port = srv.port();
+    let mut blockers = Vec::new();
+    for i in 0..n {
+        let h = thread::spawn(move || {
+            let mut b = common::connect(port);
+            let z = format!("z{i}");
+            send(&mut b, &["BZPOPMIN", &z, "5"]);
+        });
+        blockers.push(h);
+    }
+    thread::sleep(Duration::from_millis(400)); // let every BZPOPMIN register/poll
+    let mut c = srv.conn();
+    for i in 0..n {
+        let z = format!("z{i}");
+        send(&mut c, &["ZADD", &z, "1", "m"]); // wakes the blocked BZPOPMIN: m consumed
+    }
+    for h in blockers {
+        h.join().unwrap();
+    }
+    for i in 0..n {
+        let z = format!("z{i}");
+        assert!(
+            send(&mut c, &["ZCARD", &z]).contains(":0"),
+            "z{i} must be empty at runtime (consumed by the blocked BZPOPMIN)"
+        );
+    }
+    drop(c);
+    srv.kill();
+    srv.restart(); // WAL replay only
+    let mut c = srv.conn();
+    for i in 0..n {
+        let z = format!("z{i}");
+        assert!(
+            send(&mut c, &["ZCARD", &z]).contains(":0"),
+            "z{i} must stay empty after replay (ZREM was logged, member not resurrected)"
+        );
+    }
+}
+
 // PROBE (ENG-1316): COPY writes only dst but the raw command shards on src and
 // re-reads src at replay, when a per-shard replay may not have rebuilt src yet
 // (and dst's own writes replay in a separate shard). COPY self-logs the resolved

--- a/tests/crash_recovery.rs
+++ b/tests/crash_recovery.rs
@@ -168,6 +168,175 @@ fn tsadd_star_timestamp_stable_after_wal_replay() {
     );
 }
 
+// PROBE (ENG-1316): ZUNIONSTORE reads source keys that may live on other WAL
+// shards. Per-shard replay applies each shard fully in order, so a dst whose
+// shard replays before a source's shard computes the union from empty sources.
+// With many sources spread across shards, most dsts are affected.
+#[test]
+fn zunionstore_cross_shard_survives_wal_replay() {
+    let mut srv = LuxServer::builder().tiered().maxmemory("100kb").start();
+    let mut c = srv.conn();
+    let n = 24usize;
+    let srcs: Vec<String> = (0..n).map(|i| format!("src{i}")).collect();
+    for (i, k) in srcs.iter().enumerate() {
+        send(&mut c, &["ZADD", k, "1", &format!("m{i}")]);
+    }
+    let numkeys = n.to_string();
+    for d in 0..10 {
+        let dst = format!("dst{d}");
+        let mut args: Vec<&str> = vec!["ZUNIONSTORE", &dst, &numkeys];
+        args.extend(srcs.iter().map(String::as_str));
+        send(&mut c, &args);
+    }
+    drop(c);
+    srv.kill();
+    srv.restart(); // WAL replay only
+    let mut c = srv.conn();
+    for d in 0..10 {
+        let dst = format!("dst{d}");
+        let card = send(&mut c, &["ZCARD", &dst]);
+        assert!(
+            card.contains(&format!(":{n}\r\n")),
+            "dst{d} must hold all {n} union members after replay; got {card:?}"
+        );
+    }
+}
+
+// PROBE (ENG-1316): SMOVE adds the member to dst, which may live on a different
+// WAL shard than src. A conflicting SREM on dst must stay ordered after the move.
+// Under raw logging the whole move lands in src's shard and can replay after
+// dst's SREM, resurrecting the member. Self-logging `SREM src` + `SADD dst` keys
+// each effect to its own shard so append order is preserved on replay.
+#[test]
+fn smove_cross_shard_survives_wal_replay() {
+    let mut srv = LuxServer::builder().tiered().maxmemory("100kb").start();
+    let mut c = srv.conn();
+    let n = 24usize;
+    for i in 0..n {
+        let a = format!("a{i}");
+        let b = format!("b{i}");
+        send(&mut c, &["SADD", &a, "m"]);
+        send(&mut c, &["SMOVE", &a, &b, "m"]); // b{i} = {m}
+        send(&mut c, &["SREM", &b, "m"]); // b{i} = {}
+    }
+    drop(c);
+    srv.kill();
+    srv.restart(); // WAL replay only
+    let mut c = srv.conn();
+    for i in 0..n {
+        let a = format!("a{i}");
+        let b = format!("b{i}");
+        assert!(
+            send(&mut c, &["SCARD", &b]).contains(":0"),
+            "b{i} must be empty (SADD-then-SREM order preserved) after replay"
+        );
+        assert!(
+            send(&mut c, &["SISMEMBER", &a, "m"]).contains(":0"),
+            "a{i} must not resurrect the moved member after replay"
+        );
+    }
+}
+
+// PROBE (ENG-1316): LMOVE pushes the moved element onto dst, whose shard may
+// differ from src's. List order is significant, so a pre-existing element on dst
+// must stay ordered before the moved one. Raw logging puts the whole move in
+// src's shard and can replay it before dst's own push, inverting the order.
+#[test]
+fn lmove_cross_shard_order_survives_wal_replay() {
+    let mut srv = LuxServer::builder().tiered().maxmemory("100kb").start();
+    let mut c = srv.conn();
+    let n = 24usize;
+    for i in 0..n {
+        let a = format!("a{i}");
+        let b = format!("b{i}");
+        send(&mut c, &["RPUSH", &a, "M"]);
+        send(&mut c, &["RPUSH", &b, "P"]); // b{i} = [P]
+        send(&mut c, &["LMOVE", &a, &b, "LEFT", "RIGHT"]); // b{i} = [P, M]
+    }
+    drop(c);
+    srv.kill();
+    srv.restart(); // WAL replay only
+    let mut c = srv.conn();
+    for i in 0..n {
+        let b = format!("b{i}");
+        let range = send(&mut c, &["LRANGE", &b, "0", "-1"]);
+        let p = range.find("\r\nP\r\n");
+        let m = range.find("\r\nM\r\n");
+        assert!(
+            p.is_some() && m.is_some() && p < m,
+            "b{i} must be [P, M] after replay; got {range:?}"
+        );
+    }
+}
+
+// PROBE (ENG-1316): RPOPLPUSH is LMOVE src dst RIGHT LEFT; same cross-shard
+// ordering hazard on the destination push.
+#[test]
+fn rpoplpush_cross_shard_order_survives_wal_replay() {
+    let mut srv = LuxServer::builder().tiered().maxmemory("100kb").start();
+    let mut c = srv.conn();
+    let n = 24usize;
+    for i in 0..n {
+        let a = format!("a{i}");
+        let b = format!("b{i}");
+        send(&mut c, &["RPUSH", &a, "M"]);
+        send(&mut c, &["RPUSH", &b, "P"]); // b{i} = [P]
+        send(&mut c, &["RPOPLPUSH", &a, &b]); // pop tail M of a, push head of b => [M, P]
+    }
+    drop(c);
+    srv.kill();
+    srv.restart(); // WAL replay only
+    let mut c = srv.conn();
+    for i in 0..n {
+        let b = format!("b{i}");
+        let range = send(&mut c, &["LRANGE", &b, "0", "-1"]);
+        let m = range.find("\r\nM\r\n");
+        let p = range.find("\r\nP\r\n");
+        assert!(
+            m.is_some() && p.is_some() && m < p,
+            "b{i} must be [M, P] after replay; got {range:?}"
+        );
+    }
+}
+
+// PROBE (ENG-1316): COPY writes only dst but the raw command shards on src and
+// re-reads src at replay, when a per-shard replay may not have rebuilt src yet
+// (and dst's own writes replay in a separate shard). COPY self-logs the resolved
+// dst value as a keyed `LXRESTORE dst <blob>`.
+#[test]
+fn copy_cross_shard_survives_wal_replay() {
+    let mut srv = LuxServer::builder().tiered().maxmemory("100kb").start();
+    let mut c = srv.conn();
+    let n = 24usize;
+    for i in 0..n {
+        let s = format!("s{i}");
+        let d = format!("d{i}");
+        send(&mut c, &["SET", &s, &format!("v{i}")]);
+        send(&mut c, &["SET", &d, "OLD"]); // independent write to dst's shard
+        send(&mut c, &["COPY", &s, &d, "REPLACE"]); // d{i} = v{i}
+    }
+    // Cover a non-string type through the dump blob.
+    send(&mut c, &["RPUSH", "lsrc", "l0", "l1", "l2"]);
+    send(&mut c, &["COPY", "lsrc", "ldst"]);
+    drop(c);
+    srv.kill();
+    srv.restart(); // WAL replay only
+    let mut c = srv.conn();
+    for i in 0..n {
+        let d = format!("d{i}");
+        let got = send(&mut c, &["GET", &d]);
+        assert!(
+            got.contains(&format!("v{i}\r")),
+            "d{i} must hold the copied value (not OLD) after replay; got {got:?}"
+        );
+    }
+    let l = send(&mut c, &["LRANGE", "ldst", "0", "-1"]);
+    assert!(
+        l.contains("l0") && l.contains("l1") && l.contains("l2"),
+        "list COPY must survive replay through the dump blob; got {l:?}"
+    );
+}
+
 // ZMPOP mutates the sorted set, so the pop must survive a WAL-only restart
 // (regression guard that ZMPOP is classified as a write and WAL-logged).
 #[test]

--- a/tests/crash_recovery.rs
+++ b/tests/crash_recovery.rs
@@ -337,6 +337,39 @@ fn copy_cross_shard_survives_wal_replay() {
     );
 }
 
+// PROBE (ENG-1316): MSET writes many keys but the raw command shards on the
+// first key only, so a later independent write to a non-first key can replay
+// before the MSET's value for that key, losing the newer write. Self-logging a
+// keyed SET per pair puts each in its own shard in append order.
+#[test]
+fn mset_cross_shard_survives_wal_replay() {
+    let mut srv = LuxServer::builder().tiered().maxmemory("100kb").start();
+    let mut c = srv.conn();
+    let n = 24usize;
+    for i in 0..n {
+        let a = format!("first{i}");
+        let b = format!("second{i}");
+        send(&mut c, &["MSET", &a, "F", &b, "S"]);
+        send(&mut c, &["SET", &b, "OVERWRITE"]); // later write to the non-first key
+    }
+    drop(c);
+    srv.kill();
+    srv.restart(); // WAL replay only
+    let mut c = srv.conn();
+    for i in 0..n {
+        let a = format!("first{i}");
+        let b = format!("second{i}");
+        assert!(
+            send(&mut c, &["GET", &a]).contains("F\r"),
+            "first{i} must survive MSET replay"
+        );
+        assert!(
+            send(&mut c, &["GET", &b]).contains("OVERWRITE"),
+            "second{i} must reflect the later SET, not the replayed MSET value"
+        );
+    }
+}
+
 // ZMPOP mutates the sorted set, so the pop must survive a WAL-only restart
 // (regression guard that ZMPOP is classified as a write and WAL-logged).
 #[test]

--- a/tests/crash_recovery.rs
+++ b/tests/crash_recovery.rs
@@ -335,44 +335,105 @@ fn blmove_immediate_cross_shard_survives_wal_replay() {
     }
 }
 
-// QUARANTINED repro: a BLOCKED BLMOVE later satisfied by a push does not log the
-// move, so WAL replay leaves the element in src and never in dst. This is the
-// broader blocked-consumer durability gap (BLPOP/BRPOP have the same shape: the
-// push is logged but the waiter's consuming pop is not). Tracked separately from
-// the sharded-replay fix; un-ignore when fixing. Run with:
-//   cargo test --release --test crash_recovery -- --ignored blmove_blocked
+// PROBE (ENG-1317): a BLOCKED BLMOVE later satisfied by a push. The satisfying
+// push is logged, but the consuming pop (src) and the deferred dst push happen
+// outside the WAL. The woken handler now logs both, keyed so each lands on its
+// own shard, so replay leaves the element only in dst. Cross-shard fan-out so
+// each bsrc{i}/bdst{i} pair spans different disk-WAL shards.
 #[test]
-#[ignore]
 fn blmove_blocked_completion_survives_wal_replay() {
     let mut srv = LuxServer::builder().tiered().maxmemory("100kb").start();
-    let mut blocker = srv.conn();
-    let h = thread::spawn(move || {
-        // Blocks on empty bsrc until the push below wakes it.
-        send(
-            &mut blocker,
-            &["BLMOVE", "bsrc", "bdst", "LEFT", "RIGHT", "5"],
-        );
-    });
-    thread::sleep(Duration::from_millis(300)); // let the BLMOVE register as a waiter
+    let n = 16usize;
+    let port = srv.port();
+    let mut blockers = Vec::new();
+    for i in 0..n {
+        let h = thread::spawn(move || {
+            let mut b = common::connect(port);
+            let src = format!("bsrc{i}");
+            let dst = format!("bdst{i}");
+            // Blocks on empty src until the push below wakes it.
+            send(&mut b, &["BLMOVE", &src, &dst, "LEFT", "RIGHT", "5"]);
+        });
+        blockers.push(h);
+    }
+    thread::sleep(Duration::from_millis(400)); // let every BLMOVE register as a waiter
     let mut c = srv.conn();
-    send(&mut c, &["RPUSH", "bsrc", "V"]); // wakes the blocked BLMOVE: V moves to bdst
-    h.join().unwrap();
-    assert!(
-        send(&mut c, &["LRANGE", "bdst", "0", "-1"]).contains("V"),
-        "runtime move must have happened"
-    );
+    for i in 0..n {
+        let src = format!("bsrc{i}");
+        send(&mut c, &["RPUSH", &src, "V"]); // wakes the blocked BLMOVE: V moves to dst
+    }
+    for h in blockers {
+        h.join().unwrap();
+    }
+    for i in 0..n {
+        let dst = format!("bdst{i}");
+        assert!(
+            send(&mut c, &["LRANGE", &dst, "0", "-1"]).contains("V"),
+            "runtime move to bdst{i} must have happened"
+        );
+    }
     drop(c);
     srv.kill();
     srv.restart(); // WAL replay only
     let mut c = srv.conn();
-    assert!(
-        send(&mut c, &["LRANGE", "bdst", "0", "-1"]).contains("V"),
-        "bdst must retain the moved element after replay"
-    );
-    assert!(
-        send(&mut c, &["LLEN", "bsrc"]).contains(":0"),
-        "bsrc must be empty after replay (element was moved, not left behind)"
-    );
+    for i in 0..n {
+        let src = format!("bsrc{i}");
+        let dst = format!("bdst{i}");
+        assert!(
+            send(&mut c, &["LRANGE", &dst, "0", "-1"]).contains("V"),
+            "bdst{i} must retain the moved element after replay"
+        );
+        assert!(
+            send(&mut c, &["LLEN", &src]).contains(":0"),
+            "bsrc{i} must be empty after replay (element moved, not left behind)"
+        );
+    }
+}
+
+// PROBE (ENG-1317): a BLOCKED BLPOP satisfied by a later push. The push is
+// logged; the waiter's consuming pop is now logged too (keyed on the popped
+// key), so replay does not resurrect the element into the source list.
+#[test]
+fn blpop_blocked_completion_survives_wal_replay() {
+    let mut srv = LuxServer::builder().tiered().maxmemory("100kb").start();
+    let n = 16usize;
+    let port = srv.port();
+    let mut blockers = Vec::new();
+    for i in 0..n {
+        let h = thread::spawn(move || {
+            let mut b = common::connect(port);
+            let q = format!("q{i}");
+            send(&mut b, &["BLPOP", &q, "5"]);
+        });
+        blockers.push(h);
+    }
+    thread::sleep(Duration::from_millis(400)); // let every BLPOP register as a waiter
+    let mut c = srv.conn();
+    for i in 0..n {
+        let q = format!("q{i}");
+        send(&mut c, &["RPUSH", &q, "V"]); // wakes the blocked BLPOP: V is consumed
+    }
+    for h in blockers {
+        h.join().unwrap();
+    }
+    for i in 0..n {
+        let q = format!("q{i}");
+        assert!(
+            send(&mut c, &["LLEN", &q]).contains(":0"),
+            "q{i} must be empty at runtime (consumed by the blocked BLPOP)"
+        );
+    }
+    drop(c);
+    srv.kill();
+    srv.restart(); // WAL replay only
+    let mut c = srv.conn();
+    for i in 0..n {
+        let q = format!("q{i}");
+        assert!(
+            send(&mut c, &["LLEN", &q]).contains(":0"),
+            "q{i} must stay empty after replay (pop was logged, not resurrected)"
+        );
+    }
 }
 
 // PROBE (ENG-1316): COPY writes only dst but the raw command shards on src and


### PR DESCRIPTION
## Problem

The WAL is sharded per key: `wal_log_command` routes each frame to `disk_shard_index(args[1])`, and on startup each shard's WAL is replayed independently, shard by shard. That is only correct when a command touches exactly one key at `args[1]`. On tiered / multi-shard-WAL configs, several command classes corrupt data on crash recovery:

- **Multi-key cross-shard writes** (`Z*STORE`, `S*STORE`, `LMOVE`/`RPOPLPUSH`, `SMOVE`, `COPY`): the raw frame lands in one shard but the command reads/writes state in others, so a per-shard replay can run before the state it depends on exists.
- **`MSET`/`MSETNX`**: raw-logged sharded on the first key only, so a later independent write to a non-first key can replay before the MSET's value for that key.
- **Blocked consumers** (`BLPOP`/`BRPOP`/`BLMOVE`, `BZPOPMIN`/`BZPOPMAX`): when a push/add satisfies a blocked waiter, the consuming pop (and BLMOVE's destination push) happened outside the WAL entirely, so replay resurrected the element in the source (and, for BLMOVE, duplicated it).

## Fix

No WAL format change. Each affected command self-logs its resolved single-key effects, keyed so every frame routes to the correct shard in append order:

- `Z*STORE`/`S*STORE` -> `DEL dst` + `ZADD/SADD dst ...`
- movers -> keyed pop(src) + push(dst), batched (atomic when same shard, split per-shard otherwise)
- `COPY` -> internal `LXRESTORE dst <blob>` reusing the snapshot serializer, so a stale-src replay can't matter
- `MSET`/`MSETNX` -> one keyed `SET` per applied pair
- blocked `BLPOP`/`BRPOP`/`BLMOVE` -> the woken handler logs the pop (and BLMOVE's dst push), running with no shard locks held so there is no memory->WAL nesting against replay's WAL->memory order
- blocked `BZPOPMIN`/`BZPOPMAX` -> `handle_block_zpop` pops straight from the store, so it logs the removal as a keyed `ZREM`

The blocked-consumer effects are logged in the woken handler, which holds no shard locks; the satisfying push/add was already WAL-logged before the waiter wakes, so replay order stays correct.

## Tests

`tests/crash_recovery.rs` gains cross-shard (16-24-way fan-out) kill -9 + replay probes for every case above, including blocked-completion probes for BLMOVE, BLPOP, and BZPOPMIN. Full suite green; fmt + clippy `-D warnings` clean; no write-path benchmark regression.