### PR TITLE
feat(streams): real XGROUP consumer lifecycle + XINFO CONSUMERS

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -114,9 +114,10 @@ Current missing Redis OSS/core command groups:
 - Hash field TTL/value helpers: `HEXPIRE`, `HPEXPIRE`, `HEXPIREAT`,
   `HPEXPIREAT`, `HTTL`, `HPTTL`, `HEXPIRETIME`, `HPEXPIRETIME`, `HPERSIST`,
   `HGETEX`, `HGETDEL`.
-- Sorted sets: `ZRANDMEMBER`, `ZMPOP`, `BZMPOP`, `ZRANGESTORE`, `ZUNION`,
-  `ZINTER`, `ZDIFF`, `ZINTERCARD`.
-- Streams: `XSETID` and option-level stream parity audits.
+- Sorted sets: `BZMPOP`, `ZRANGESTORE`.
+- Streams: `XSETID` (top-level command). Consumer-group lifecycle
+  (`XGROUP CREATE`/`SETID`/`DESTROY`/`CREATECONSUMER`/`DELCONSUMER`/`HELP`)
+  and `XINFO STREAM`/`GROUPS`/`CONSUMERS` are implemented.
 - Scripting/functions: `EVAL_RO`, `EVALSHA_RO`, `FCALL`, `FCALL_RO`.
 - Pub/Sub introspection/sharded Pub/Sub: `PUBSUB`, `SPUBLISH`, `SSUBSCRIBE`,
   `SUNSUBSCRIBE`.

--- a/src/cmd/streams.rs
+++ b/src/cmd/streams.rs
@@ -382,9 +382,48 @@ pub fn cmd_xgroup(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
             Err(e) => resp::write_error(out, &e),
         }
     } else if cmd_eq(args[1], b"CREATECONSUMER") {
-        resp::write_integer(out, 1);
+        if args.len() < 5 {
+            resp::write_error(
+                out,
+                "ERR wrong number of arguments for 'xgroup|createconsumer' command",
+            );
+            return CmdResult::Written;
+        }
+        match store.xgroup_createconsumer(args[2], arg_str(args[3]), arg_str(args[4]), now) {
+            Ok(created) => resp::write_integer(out, if created { 1 } else { 0 }),
+            Err(e) => resp::write_error(out, &e),
+        }
     } else if cmd_eq(args[1], b"DELCONSUMER") {
-        resp::write_integer(out, 0);
+        if args.len() < 5 {
+            resp::write_error(
+                out,
+                "ERR wrong number of arguments for 'xgroup|delconsumer' command",
+            );
+            return CmdResult::Written;
+        }
+        match store.xgroup_delconsumer(args[2], arg_str(args[3]), arg_str(args[4]), now) {
+            Ok(pending) => resp::write_integer(out, pending),
+            Err(e) => resp::write_error(out, &e),
+        }
+    } else if cmd_eq(args[1], b"HELP") {
+        let help = [
+            "XGROUP CREATE <key> <groupname> <id|$> [MKSTREAM]",
+            "    Create a new consumer group.",
+            "XGROUP SETID <key> <groupname> <id|$>",
+            "    Set the current group ID.",
+            "XGROUP DESTROY <key> <groupname>",
+            "    Remove the specified group.",
+            "XGROUP CREATECONSUMER <key> <groupname> <consumer>",
+            "    Create a new consumer in the specified group.",
+            "XGROUP DELCONSUMER <key> <groupname> <consumer>",
+            "    Remove the specified consumer from the group.",
+            "XGROUP HELP",
+            "    Print this help.",
+        ];
+        resp::write_array_header(out, help.len());
+        for line in help {
+            resp::write_bulk(out, line);
+        }
     } else {
         resp::write_error(
             out,
@@ -737,6 +776,31 @@ pub fn cmd_xinfo(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
                         resp::write_bulk(out, k);
                         resp::write_bulk(out, v);
                     }
+                }
+            }
+            Err(e) => resp::write_error(out, &e),
+        }
+    } else if cmd_eq(args[1], b"CONSUMERS") {
+        if args.len() < 4 {
+            resp::write_error(
+                out,
+                "ERR wrong number of arguments for 'xinfo|consumers' command",
+            );
+            return CmdResult::Written;
+        }
+        match store.xinfo_consumers(args[2], arg_str(args[3]), now) {
+            Ok(consumers) => {
+                resp::write_array_header(out, consumers.len());
+                for (name, pending, idle, inactive) in &consumers {
+                    resp::write_array_header(out, 8);
+                    resp::write_bulk(out, "name");
+                    resp::write_bulk(out, name);
+                    resp::write_bulk(out, "pending");
+                    resp::write_integer(out, *pending);
+                    resp::write_bulk(out, "idle");
+                    resp::write_integer(out, *idle);
+                    resp::write_bulk(out, "inactive");
+                    resp::write_integer(out, *inactive);
                 }
             }
             Err(e) => resp::write_error(out, &e),

--- a/src/store/streams.rs
+++ b/src/store/streams.rs
@@ -1,5 +1,15 @@
 use super::*;
 
+/// Standard Redis error when a consumer group is not found for a key (also used
+/// when the key itself is missing, matching Redis for the consumer subcommands).
+fn nogroup_err(group: &str, key: &[u8]) -> String {
+    format!(
+        "NOGROUP No such consumer group '{}' for key name '{}'",
+        group,
+        key_str(key)
+    )
+}
+
 impl Store {
     pub fn xadd(
         &self,
@@ -282,6 +292,11 @@ impl Store {
         match shard.data.get_mut(&ks) {
             Some(entry) if !entry.is_expired_at(now) => match &mut entry.value {
                 StoreValue::Stream(s) => {
+                    if s.groups.contains_key(group) {
+                        return Err(
+                            "BUSYGROUP Consumer Group name already exists".to_string()
+                        );
+                    }
                     let last_delivered_id = if id == "$" {
                         s.last_id
                     } else {
@@ -346,6 +361,113 @@ impl Store {
                 _ => Err(WRONGTYPE.to_string()),
             },
             _ => Err("ERR no such key".to_string()),
+        }
+    }
+
+    /// XGROUP CREATECONSUMER: create the consumer if it does not exist.
+    /// Returns true when a new consumer was created, false if it already existed.
+    pub fn xgroup_createconsumer(
+        &self,
+        key: &[u8],
+        group: &str,
+        consumer: &str,
+        now: Instant,
+    ) -> Result<bool, String> {
+        let idx = self.shard_index(key);
+        let mut shard = self.shards[idx].write();
+        shard.version += 1;
+        match shard.data.get_mut(key) {
+            Some(entry) if !entry.is_expired_at(now) => match &mut entry.value {
+                StoreValue::Stream(s) => {
+                    let Some(cg) = s.groups.get_mut(group) else {
+                        return Err(nogroup_err(group, key));
+                    };
+                    if cg.consumers.contains_key(consumer) {
+                        Ok(false)
+                    } else {
+                        cg.consumers.insert(
+                            consumer.to_string(),
+                            Consumer {
+                                pel: HashSet::new(),
+                                seen_time: now,
+                            },
+                        );
+                        Ok(true)
+                    }
+                }
+                _ => Err(WRONGTYPE.to_string()),
+            },
+            _ => Err(nogroup_err(group, key)),
+        }
+    }
+
+    /// XGROUP DELCONSUMER: remove the consumer and its pending entries from the
+    /// group PEL. Returns the number of pending messages the consumer owned.
+    pub fn xgroup_delconsumer(
+        &self,
+        key: &[u8],
+        group: &str,
+        consumer: &str,
+        now: Instant,
+    ) -> Result<i64, String> {
+        let idx = self.shard_index(key);
+        let mut shard = self.shards[idx].write();
+        shard.version += 1;
+        match shard.data.get_mut(key) {
+            Some(entry) if !entry.is_expired_at(now) => match &mut entry.value {
+                StoreValue::Stream(s) => {
+                    let Some(cg) = s.groups.get_mut(group) else {
+                        return Err(nogroup_err(group, key));
+                    };
+                    match cg.consumers.remove(consumer) {
+                        Some(c) => {
+                            let count = c.pel.len() as i64;
+                            for id in &c.pel {
+                                cg.pel.remove(id);
+                            }
+                            Ok(count)
+                        }
+                        None => Ok(0),
+                    }
+                }
+                _ => Err(WRONGTYPE.to_string()),
+            },
+            _ => Err(nogroup_err(group, key)),
+        }
+    }
+
+    /// XINFO CONSUMERS: per-consumer (name, pending, idle-ms, inactive-ms).
+    /// idle and inactive both derive from the consumer's last-seen time; Lux
+    /// does not yet track a distinct active time, so they report the same value.
+    pub fn xinfo_consumers(
+        &self,
+        key: &[u8],
+        group: &str,
+        now: Instant,
+    ) -> Result<Vec<(String, i64, i64, i64)>, String> {
+        let idx = self.shard_index(key);
+        let shard = self.shards[idx].read();
+        match shard.data.get(key) {
+            Some(entry) if !entry.is_expired_at(now) => match &entry.value {
+                StoreValue::Stream(s) => {
+                    let Some(cg) = s.groups.get(group) else {
+                        return Err(nogroup_err(group, key));
+                    };
+                    let mut consumers: Vec<(String, i64, i64, i64)> = cg
+                        .consumers
+                        .iter()
+                        .map(|(name, c)| {
+                            let idle =
+                                now.saturating_duration_since(c.seen_time).as_millis() as i64;
+                            (name.clone(), c.pel.len() as i64, idle, idle)
+                        })
+                        .collect();
+                    consumers.sort_by(|a, b| a.0.cmp(&b.0));
+                    Ok(consumers)
+                }
+                _ => Err(WRONGTYPE.to_string()),
+            },
+            _ => Err(nogroup_err(group, key)),
         }
     }
 

--- a/tests/streams.rs
+++ b/tests/streams.rs
@@ -236,3 +236,120 @@ fn xtrim_limits_length() {
     let resp = send_and_read(&mut conn, &["XLEN", "s"]);
     assert!(resp.contains(":5"), "len is 5: {resp}");
 }
+
+#[test]
+fn xgroup_create_duplicate_returns_busygroup() {
+    let server = LuxServer::start();
+    let mut conn = server.conn();
+    send_and_read(&mut conn, &["XADD", "s", "*", "f", "v"]);
+    let ok = send_and_read(&mut conn, &["XGROUP", "CREATE", "s", "g", "0"]);
+    assert!(ok.contains("OK"), "first create ok: {ok}");
+    let dup = send_and_read(&mut conn, &["XGROUP", "CREATE", "s", "g", "0"]);
+    assert!(
+        dup.contains("BUSYGROUP"),
+        "duplicate group must return BUSYGROUP: {dup}"
+    );
+}
+
+#[test]
+fn xgroup_create_mkstream_makes_empty_stream() {
+    let server = LuxServer::start();
+    let mut conn = server.conn();
+    // key does not exist yet; MKSTREAM creates it
+    let resp = send_and_read(&mut conn, &["XGROUP", "CREATE", "ns", "g", "$", "MKSTREAM"]);
+    assert!(resp.contains("OK"), "mkstream create ok: {resp}");
+    let len = send_and_read(&mut conn, &["XLEN", "ns"]);
+    assert!(len.contains(":0"), "mkstream stream is empty: {len}");
+    // without MKSTREAM on a missing key -> error
+    let err = send_and_read(&mut conn, &["XGROUP", "CREATE", "missing", "g", "$"]);
+    assert!(
+        err.contains("requires the key to exist") || err.contains("MKSTREAM"),
+        "missing key without MKSTREAM errors: {err}"
+    );
+}
+
+#[test]
+fn xgroup_createconsumer_accounting() {
+    let server = LuxServer::start();
+    let mut conn = server.conn();
+    send_and_read(&mut conn, &["XADD", "s", "*", "f", "v"]);
+    send_and_read(&mut conn, &["XGROUP", "CREATE", "s", "g", "0"]);
+    let first = send_and_read(&mut conn, &["XGROUP", "CREATECONSUMER", "s", "g", "c1"]);
+    assert!(first.contains(":1"), "new consumer returns 1: {first}");
+    let again = send_and_read(&mut conn, &["XGROUP", "CREATECONSUMER", "s", "g", "c1"]);
+    assert!(again.contains(":0"), "existing consumer returns 0: {again}");
+    // consumer shows up in XINFO CONSUMERS with 0 pending
+    let info = send_and_read(&mut conn, &["XINFO", "CONSUMERS", "s", "g"]);
+    assert!(info.contains("c1"), "consumer listed: {info}");
+    assert!(info.contains("pending"), "has pending field: {info}");
+}
+
+#[test]
+fn xgroup_delconsumer_returns_pending_and_removes() {
+    let server = LuxServer::start();
+    let mut conn = server.conn();
+    send_and_read(&mut conn, &["XADD", "s", "*", "f", "v1"]);
+    send_and_read(&mut conn, &["XADD", "s", "*", "f", "v2"]);
+    send_and_read(&mut conn, &["XGROUP", "CREATE", "s", "g", "0"]);
+    // c1 reads both -> 2 pending
+    send_and_read(
+        &mut conn,
+        &["XREADGROUP", "GROUP", "g", "c1", "STREAMS", "s", ">"],
+    );
+    let before = send_and_read(&mut conn, &["XINFO", "GROUPS", "s"]);
+    assert!(before.contains("pending"), "groups info shape: {before}");
+    // delconsumer returns the 2 pending it owned
+    let del = send_and_read(&mut conn, &["XGROUP", "DELCONSUMER", "s", "g", "c1"]);
+    assert!(
+        del.contains(":2"),
+        "delconsumer returns owned pending count: {del}"
+    );
+    // consumer is gone
+    let info = send_and_read(&mut conn, &["XINFO", "CONSUMERS", "s", "g"]);
+    assert!(info.contains("*0"), "no consumers left: {info}");
+    // group PEL drained
+    let summary = send_and_read(&mut conn, &["XPENDING", "s", "g"]);
+    assert!(summary.contains(":0"), "group pending drained: {summary}");
+}
+
+#[test]
+fn xgroup_consumer_ops_missing_group_return_nogroup() {
+    let server = LuxServer::start();
+    let mut conn = server.conn();
+    send_and_read(&mut conn, &["XADD", "s", "*", "f", "v"]);
+    // no group created
+    let cc = send_and_read(&mut conn, &["XGROUP", "CREATECONSUMER", "s", "nope", "c1"]);
+    assert!(cc.contains("NOGROUP"), "createconsumer missing group: {cc}");
+    let dc = send_and_read(&mut conn, &["XGROUP", "DELCONSUMER", "s", "nope", "c1"]);
+    assert!(dc.contains("NOGROUP"), "delconsumer missing group: {dc}");
+    let xi = send_and_read(&mut conn, &["XINFO", "CONSUMERS", "s", "nope"]);
+    assert!(
+        xi.contains("NOGROUP"),
+        "xinfo consumers missing group: {xi}"
+    );
+}
+
+#[test]
+fn xinfo_consumers_empty_group_is_empty_array() {
+    let server = LuxServer::start();
+    let mut conn = server.conn();
+    send_and_read(&mut conn, &["XADD", "s", "*", "f", "v"]);
+    send_and_read(&mut conn, &["XGROUP", "CREATE", "s", "g", "0"]);
+    let info = send_and_read(&mut conn, &["XINFO", "CONSUMERS", "s", "g"]);
+    assert!(
+        info.contains("*0"),
+        "empty group -> empty consumers array: {info}"
+    );
+}
+
+#[test]
+fn xgroup_help_returns_array() {
+    let server = LuxServer::start();
+    let mut conn = server.conn();
+    let help = send_and_read(&mut conn, &["XGROUP", "HELP"]);
+    assert!(help.contains("CREATE"), "help mentions CREATE: {help}");
+    assert!(
+        help.contains("DELCONSUMER"),
+        "help mentions DELCONSUMER: {help}"
+    );
+}


### PR DESCRIPTION
## Problem

`XGROUP CREATECONSUMER` and `XGROUP DELCONSUMER` were stubs that returned a hardcoded `1`/`0` without touching consumer state — exactly the "fake success where Redis returns state-dependent values" the parity audit flagged. `XINFO CONSUMERS` and `XGROUP HELP` were missing, and duplicate `XGROUP CREATE` silently overwrote the existing group instead of erroring.

## Changes

- **CREATECONSUMER** — creates the consumer if absent; returns `1` when created, `0` when it already existed.
- **DELCONSUMER** — removes the consumer and returns the number of pending messages it owned, dropping those entries from the group PEL.
- **XINFO CONSUMERS** — returns per-consumer `name`, `pending`, `idle`, `inactive`. (`idle`/`inactive` both derive from the consumer's last-seen time; Lux doesn't yet track a distinct active time, documented as such.)
- **XGROUP HELP** — standard subcommand help array.
- **XGROUP CREATE** now returns `BUSYGROUP Consumer Group name already exists` on a duplicate group.
- Consumer-subcommand errors return the standard `NOGROUP No such consumer group '<g>' for key name '<k>'`.

Empty consumers (created via CREATECONSUMER) already persist through the snapshot path, which enumerates `group.consumers` directly.

## Tests

`tests/streams.rs`: duplicate-create BUSYGROUP, MKSTREAM, CREATECONSUMER idempotency, DELCONSUMER pending-count + removal + PEL drain, missing-group NOGROUP for all three consumer ops, empty-group XINFO CONSUMERS, and HELP. Full suite green; fmt + clippy `-D warnings` clean. COMPATIBILITY.md updated (also corrected stale zset entries now shipped in v0.28.0).

## Follow-up (separate)

Audit noted XGROUP raw-logs to the WAL sharded on `args[1]` (the subcommand), not the stream key — an ENG-1316-family sharded-WAL replay bug. Filing separately; not in this PR.