### PR TITLE
feat(live): incremental view maintenance for .live() table queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "lux"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "argon2",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lux"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "An open-source application database engine with tables, cache, vectors, auth, realtime, queues, time series, and Redis-compatible commands."
 license = "MIT"

--- a/src/http.rs
+++ b/src/http.rs
@@ -1070,6 +1070,11 @@ enum LiveSubscription {
         spec: Box<LiveTableSpec>,
         state: LiveQueryState,
         receivers: Vec<broadcast::Receiver<crate::pubsub::Message>>,
+        /// When set, this query is maintained incrementally from typed row
+        /// deltas (single-table, no joins/near/limit/aggregate). `pk_col` is the
+        /// primary-key column used to re-evaluate a single changed row.
+        delta_rx: Option<broadcast::Receiver<crate::pubsub::RowDelta>>,
+        pk_col: String,
     },
     VectorNear {
         spec: LiveVectorNearSpec,
@@ -1182,8 +1187,16 @@ where
             }
             _ = tick.tick() => {
                 drain_live_subscription_events(&mut ws, &mut subscriptions, &store, &cache).await?;
+                drain_live_row_deltas(&mut ws, &mut subscriptions, &store, &cache).await?;
             }
         }
+    }
+
+    // Tear down every subscription on disconnect so broker bookkeeping (row-delta
+    // subscriber count, per-table channels) doesn't leak past the socket.
+    let ids: Vec<String> = subscriptions.keys().cloned().collect();
+    for id in ids {
+        stop_live_subscription(&broker, &mut subscriptions, &id);
     }
 
     Ok(())
@@ -1349,7 +1362,21 @@ async fn build_live_subscription(
                 table_spec.principal = Some(p.clone());
             }
         }
-        let receivers = live_table_dependencies(&table_spec)
+        let pk_field = live_table_pk_field(store, cache, &table_spec.table);
+        let pk_col = pk_field.clone().unwrap_or_else(|| "id".to_string());
+        // A single-table query (no joins/near/limit/offset/aggregate) whose
+        // projection includes the pk is maintained incrementally from typed row
+        // deltas; anything else keeps the re-query-and-diff path. The pk must be
+        // projected so `state.rows` keys line up with the delta's pk. IVM subs
+        // still watch auth-dependency tables via key-events so a grant-membership
+        // change triggers a full resync.
+        let ivm = ivm_eligible(&table_spec) && select_projects_pk(&table_spec.select, &pk_col);
+        let key_tables: Vec<String> = if ivm {
+            table_spec.auth_dependencies.clone()
+        } else {
+            live_table_dependencies(&table_spec)
+        };
+        let receivers = key_tables
             .into_iter()
             .flat_map(|table| {
                 [
@@ -1358,8 +1385,8 @@ async fn build_live_subscription(
                 ]
             })
             .collect();
+        let delta_rx = ivm.then(|| broker.subscribe_row_deltas(&table_spec.table));
         let rows = fetch_live_table_rows(store, cache, &table_spec)?;
-        let pk_field = live_table_pk_field(store, cache, &table_spec.table);
         let query = json!({"type":"table","table":table_spec.table});
         let state = LiveQueryState {
             query: query.clone(),
@@ -1371,6 +1398,8 @@ async fn build_live_subscription(
                 spec: Box::new(table_spec),
                 state,
                 receivers,
+                delta_rx,
+                pk_col,
             },
             vec![json!({"kind":"snapshot","scope":"query","query":query,"rows":rows})],
         ));
@@ -1542,10 +1571,24 @@ fn stop_live_subscription(
         LiveSubscription::Key { pattern, .. } => broker.kunsub(&pattern),
         LiveSubscription::Channel { channel, .. } => broker.unsubscribe_channel(&channel),
         LiveSubscription::PubSubPattern { pattern, .. } => broker.punsubscribe_pattern(&pattern),
-        LiveSubscription::Table { spec, .. } => {
-            for table in live_table_dependencies(&spec) {
+        LiveSubscription::Table { spec, delta_rx, .. } => {
+            // Drop this receiver first so the row-delta channel's receiver_count
+            // reflects reality when unsubscribe decides whether to reclaim it.
+            let was_ivm = delta_rx.is_some();
+            drop(delta_rx);
+            // Mirror the subscribe set: IVM subs watch only auth-dependency tables
+            // via key-events (plus their own row-delta channel); others watch all.
+            let key_tables = if was_ivm {
+                spec.auth_dependencies.clone()
+            } else {
+                live_table_dependencies(&spec)
+            };
+            for table in key_tables {
                 broker.kunsub(&table);
                 broker.kunsub(&format!("_t:{table}:row:*"));
+            }
+            if was_ivm {
+                broker.unsubscribe_row_deltas(&spec.table);
             }
         }
         LiveSubscription::VectorNear { .. } => broker.kunsub("*"),
@@ -1587,6 +1630,162 @@ fn diff_live_query(
 
     state.rows = next;
     events
+}
+
+/// A single-table query with no joins/near/limit/offset/aggregate can be
+/// maintained incrementally from typed row deltas. Everything else keeps the
+/// re-query-and-diff path.
+fn ivm_eligible(spec: &LiveTableSpec) -> bool {
+    spec.joins.is_empty()
+        && spec.near.is_none()
+        && spec.limit.is_none()
+        && spec.offset.is_none()
+        && !select_has_aggregate(&spec.select)
+}
+
+fn select_has_aggregate(select: &str) -> bool {
+    let s = select.to_ascii_lowercase();
+    s.contains("count(")
+        || s.contains("sum(")
+        || s.contains("avg(")
+        || s.contains("min(")
+        || s.contains("max(")
+        || s.contains("group by")
+}
+
+/// True if the projection surfaces `pk_col`, so incrementally-maintained rows
+/// key on the same value the snapshot indexed on. `*` projects everything;
+/// otherwise the column must appear as a selected term (bare or aliased).
+fn select_projects_pk(select: &str, pk_col: &str) -> bool {
+    let s = select.trim();
+    if s == "*" {
+        return true;
+    }
+    let pk = pk_col.to_ascii_lowercase();
+    s.split(',').any(|term| {
+        // Drop any `AS alias`, then take the column past a `table.` qualifier.
+        let base = term.split_whitespace().next().unwrap_or("");
+        let col = base.rsplit('.').next().unwrap_or(base).trim();
+        col == "*" || col.eq_ignore_ascii_case(&pk)
+    })
+}
+
+/// Re-evaluate one row (by pk) against the live query + RLS, reusing the normal
+/// fetch so projection/typing/grants match the snapshot exactly. Returns the
+/// projected JSON row if that pk currently belongs in the result, else None.
+fn fetch_live_table_row_for_pk(
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+    spec: &LiveTableSpec,
+    pk_col: &str,
+    pk: &str,
+) -> Option<Value> {
+    let mut s = spec.clone();
+    s.where_conditions.push((
+        pk_col.to_string(),
+        "=".to_string(),
+        Value::String(pk.to_string()),
+    ));
+    s.order_by = None;
+    s.offset = None;
+    s.limit = Some(1);
+    fetch_live_table_rows(store, cache, &s)
+        .ok()?
+        .into_iter()
+        .next()
+}
+
+/// Incremental view maintenance: drain typed row deltas for IVM table
+/// subscriptions and emit per-row insert/update/delete by re-evaluating only the
+/// changed pk, instead of re-running the whole query.
+async fn drain_live_row_deltas<S>(
+    ws: &mut WebSocketStream<S>,
+    subscriptions: &mut HashMap<String, LiveSubscription>,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> std::io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut outgoing: Vec<(String, Value)> = Vec::new();
+    for (id, subscription) in subscriptions.iter_mut() {
+        let LiveSubscription::Table {
+            spec,
+            state,
+            delta_rx: Some(rx),
+            pk_col,
+            ..
+        } = subscription
+        else {
+            continue;
+        };
+        // Distinct changed pks since the last tick (one re-eval each).
+        let mut changed: Vec<String> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut lagged = false;
+        loop {
+            match rx.try_recv() {
+                Ok(delta) => {
+                    if seen.insert(delta.pk.clone()) {
+                        changed.push(delta.pk);
+                    }
+                }
+                Err(broadcast::error::TryRecvError::Lagged(_)) => {
+                    lagged = true;
+                    continue;
+                }
+                Err(_) => break,
+            }
+        }
+        if lagged {
+            // Fell behind the delta stream: resync from a fresh query (safe truth).
+            let rows = fetch_live_table_rows(store, cache, spec).unwrap_or_default();
+            outgoing.extend(diff_live_query(
+                id,
+                state,
+                rows,
+                Some(json!({"kind":"resync","scope":"query"})),
+            ));
+            continue;
+        }
+        for pk in changed {
+            let now_row = fetch_live_table_row_for_pk(store, cache, spec, pk_col, &pk);
+            let prev = state.rows.get(&pk).cloned();
+            // The cause reflects the row's transition in this query's result set
+            // (which is what the client observes); table names the source table.
+            let table = spec.table.as_str();
+            match (prev, now_row) {
+                (None, Some(row)) => {
+                    state.rows.insert(pk.clone(), row.clone());
+                    outgoing.push((
+                        id.clone(),
+                        json!({"kind":"insert","scope":"query","query":state.query,"pk":pk,"row":row,"previous":null,"cause":{"kind":"table.insert","table":table,"operation":"tinsert"}}),
+                    ));
+                }
+                (Some(before), None) => {
+                    state.rows.remove(&pk);
+                    outgoing.push((
+                        id.clone(),
+                        json!({"kind":"delete","scope":"query","query":state.query,"pk":pk,"row":null,"previous":before,"cause":{"kind":"table.delete","table":table,"operation":"tdelete"}}),
+                    ));
+                }
+                (Some(before), Some(row)) => {
+                    if row_fingerprint(&before) != row_fingerprint(&row) {
+                        state.rows.insert(pk.clone(), row.clone());
+                        outgoing.push((
+                            id.clone(),
+                            json!({"kind":"update","scope":"query","query":state.query,"pk":pk,"row":row,"previous":before,"changed":changed_json_fields(&before,&row),"cause":{"kind":"table.update","table":table,"operation":"tupdate"}}),
+                        ));
+                    }
+                }
+                (None, None) => {}
+            }
+        }
+    }
+    for (id, event) in outgoing {
+        send_live_json(ws, json!({"type":"live.event","id":id,"event":event})).await?;
+    }
+    Ok(())
 }
 
 fn parse_live_table_spec(spec: &Value) -> Result<LiveTableSpec, Value> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3014,6 +3014,8 @@ impl Runtime {
         let schema_cache: SharedSchemaCache =
             std::sync::Arc::new(parking_lot::RwLock::new(tables::SchemaCache::new()));
         let broker = Broker::new();
+        // Wire the row-delta sink so table writes feed reactive live queries.
+        store.set_row_delta_broker(broker.clone());
         let shard_executor = ShardExecutor::new(store.clone(), broker.clone());
         let script_engine = Arc::new(lua::ScriptEngine::new());
 

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -79,6 +79,9 @@ pub struct Broker {
     stream_waiters: Arc<parking_lot::Mutex<HashMap<String, Vec<StreamWaiter>>>>,
     stream_waiter_count: Arc<AtomicU64>,
     waiter_counter: Arc<AtomicU64>,
+    /// Per-table broadcast of typed row deltas for reactive live queries.
+    row_delta_subs: Arc<parking_lot::RwLock<HashMap<String, broadcast::Sender<RowDelta>>>>,
+    row_delta_sub_count: Arc<AtomicU64>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -94,6 +97,18 @@ pub struct Message {
     pub pattern: Option<String>,
     pub kind: MessageKind,
 }
+
+/// A typed hint, emitted at the table mutation site, that row `pk` in `table`
+/// changed. The live-query engine re-evaluates just that pk against each
+/// affected subscription, so the delta only carries the identity of what moved,
+/// not the row image.
+#[derive(Clone, Debug)]
+pub struct RowDelta {
+    pub table: String,
+    pub pk: String,
+}
+
+const ROW_DELTA_CAPACITY: usize = 4096;
 
 impl Broker {
     pub fn new() -> Self {
@@ -126,6 +141,46 @@ impl Broker {
             stream_waiters: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             stream_waiter_count: Arc::new(AtomicU64::new(0)),
             waiter_counter: Arc::new(AtomicU64::new(0)),
+            row_delta_subs: Arc::new(parking_lot::RwLock::new(HashMap::new())),
+            row_delta_sub_count: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Cheap global gate: are there any reactive live-query subscribers at all?
+    /// Checked on the table write hot path before doing any delta work.
+    pub fn has_any_row_delta_subs(&self) -> bool {
+        self.row_delta_sub_count.load(Ordering::Relaxed) > 0
+    }
+
+    /// Subscribe to typed row deltas for `table`. The receiver is per live query.
+    pub fn subscribe_row_deltas(&self, table: &str) -> broadcast::Receiver<RowDelta> {
+        let mut subs = self.row_delta_subs.write();
+        let tx = subs
+            .entry(table.to_string())
+            .or_insert_with(|| broadcast::channel(ROW_DELTA_CAPACITY).0);
+        let rx = tx.subscribe();
+        self.row_delta_sub_count.fetch_add(1, Ordering::Relaxed);
+        rx
+    }
+
+    /// Drop one live-query subscription to `table`'s row deltas.
+    pub fn unsubscribe_row_deltas(&self, table: &str) {
+        self.row_delta_sub_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                Some(n.saturating_sub(1))
+            })
+            .ok();
+        let mut subs = self.row_delta_subs.write();
+        if subs.get(table).is_some_and(|tx| tx.receiver_count() == 0) {
+            subs.remove(table);
+        }
+    }
+
+    /// Publish a typed row delta to any live queries watching its table.
+    pub fn publish_row_delta(&self, delta: RowDelta) {
+        let subs = self.row_delta_subs.read();
+        if let Some(tx) = subs.get(&delta.table) {
+            let _ = tx.send(delta);
         }
     }
 
@@ -727,5 +782,46 @@ mod tests {
             rx2.try_recv().err(),
             Some(broadcast::error::TryRecvError::Empty)
         );
+    }
+
+    #[test]
+    fn row_delta_subscriber_count_gates_and_reclaims() {
+        let broker = Broker::new();
+        assert!(!broker.has_any_row_delta_subs());
+
+        let rx1 = broker.subscribe_row_deltas("tasks");
+        let mut rx2 = broker.subscribe_row_deltas("tasks");
+        assert!(broker.has_any_row_delta_subs());
+
+        // A published delta reaches every live receiver on the table.
+        broker.publish_row_delta(RowDelta {
+            table: "tasks".to_string(),
+            pk: "t1".to_string(),
+        });
+        assert_eq!(rx2.try_recv().unwrap().pk, "t1");
+
+        // Dropping one receiver then unsubscribing keeps the channel (rx2 lives).
+        drop(rx1);
+        broker.unsubscribe_row_deltas("tasks");
+        assert!(broker.has_any_row_delta_subs());
+        assert!(broker.row_delta_subs.read().contains_key("tasks"));
+
+        // Dropping the last receiver before unsubscribe reclaims the channel and
+        // flips the global gate back off.
+        drop(rx2);
+        broker.unsubscribe_row_deltas("tasks");
+        assert!(!broker.has_any_row_delta_subs());
+        assert!(!broker.row_delta_subs.read().contains_key("tasks"));
+    }
+
+    #[test]
+    fn publish_row_delta_to_idle_table_is_noop() {
+        let broker = Broker::new();
+        // No panic, no subscribers, nothing to receive.
+        broker.publish_row_delta(RowDelta {
+            table: "ghost".to_string(),
+            pk: "x".to_string(),
+        });
+        assert!(!broker.has_any_row_delta_subs());
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -542,6 +542,10 @@ pub struct Store {
     disk_shards: Option<Box<[parking_lot::Mutex<crate::disk::DiskShard>]>>,
     wal_shards: Option<Box<[parking_lot::Mutex<crate::disk::Wal>]>>,
     pub(crate) wal_suppress: std::sync::atomic::AtomicBool,
+    /// Set once at runtime startup; sink for typed row deltas feeding reactive
+    /// live queries. Absent for embedded/replay-only stores, so emission is a
+    /// cheap no-op there.
+    row_delta_broker: std::sync::OnceLock<crate::pubsub::Broker>,
 }
 
 #[inline(always)]
@@ -761,6 +765,7 @@ impl Store {
             disk_shards,
             wal_shards,
             wal_suppress: std::sync::atomic::AtomicBool::new(false),
+            row_delta_broker: std::sync::OnceLock::new(),
         }
     }
 
@@ -1260,6 +1265,41 @@ impl Store {
     /// replay-only commands (e.g. `LXRESTORE`) so clients can't invoke them.
     pub(crate) fn wal_replaying(&self) -> bool {
         self.wal_suppress.load(Ordering::Relaxed)
+    }
+
+    /// Wire the row-delta sink (reactive live queries) at runtime startup.
+    pub fn set_row_delta_broker(&self, broker: crate::pubsub::Broker) {
+        let _ = self.row_delta_broker.set(broker);
+    }
+
+    /// Cheap gate for table mutation sites: is anyone watching row deltas right
+    /// now? Lets callers skip building old/new row snapshots when idle.
+    pub(crate) fn wants_row_deltas(&self) -> bool {
+        !self.wal_suppress.load(Ordering::Relaxed)
+            && self
+                .row_delta_broker
+                .get()
+                .is_some_and(|b| b.has_any_row_delta_subs())
+    }
+
+    /// Emit a typed row delta for a table row change. Cheap no-op unless a
+    /// broker is wired AND some live query is watching AND we aren't replaying
+    /// the WAL. The delta carries only the changed pk; the live-query engine
+    /// re-evaluates that pk against each subscription.
+    pub(crate) fn emit_row_delta(&self, table: &str, pk: &str) {
+        if self.wal_suppress.load(Ordering::Relaxed) {
+            return;
+        }
+        let Some(broker) = self.row_delta_broker.get() else {
+            return;
+        };
+        if !broker.has_any_row_delta_subs() {
+            return;
+        }
+        broker.publish_row_delta(crate::pubsub::RowDelta {
+            table: table.to_string(),
+            pk: pk.to_string(),
+        });
     }
 
     /// Decode and apply an `LXRESTORE` blob (COPY's self-logged effect). Only

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -2820,6 +2820,12 @@ fn table_insert_pk(
         let _ = store.wal_log_command(&refs);
     }
 
+    // Reactive live queries: hint that this pk changed so watching queries
+    // re-evaluate it (gated, so idle writes pay nothing).
+    if store.wants_row_deltas() {
+        store.emit_row_delta(table, &pk_str);
+    }
+
     Ok(pk_str)
 }
 
@@ -3052,6 +3058,11 @@ fn table_update_by_pk_str(
         }
         let refs: Vec<&[u8]> = a.iter().map(|v| v.as_slice()).collect();
         let _ = store.wal_log_command(&refs);
+    }
+
+    // Reactive live queries: hint that this pk changed.
+    if store.wants_row_deltas() {
+        store.emit_row_delta(table, pk_str);
     }
 
     Ok(())
@@ -3290,6 +3301,12 @@ fn table_delete_inner(
             pk_str.as_bytes(),
         ];
         let _ = store.wal_log_command(&a);
+    }
+
+    // Reactive live queries: hint that this pk changed. Cascaded child deletes
+    // emit too (every real row removal is a live-query change).
+    if store.wants_row_deltas() {
+        store.emit_row_delta(table, pk_str);
     }
 
     Ok(())

--- a/tests/live_ws.rs
+++ b/tests/live_ws.rs
@@ -843,3 +843,291 @@ async fn live_anonymous_session_subscribes_granted_table() {
     assert_eq!(insert["pk"], "n1");
     assert_eq!(insert["row"]["body"], "hello");
 }
+
+// Incremental view maintenance: an UPDATE that moves a row across the WHERE
+// predicate must emit exactly one insert (move-in) or delete (move-out), and an
+// in-place change to a matching row must emit an update. This is the case the
+// coarse re-query path handled but the delta path must reproduce precisely.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_table_where_predicate_transitions_emit_incremental_deltas() {
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start_lux(resp_port, http_port, None);
+
+    let (status, created) = http_json_request(
+        http_port,
+        "POST",
+        "/v1/tables",
+        r#"{"name":"tasks","columns":[{"name":"id","type":"STR","primaryKey":true},{"name":"status","type":"STR","notNull":true},{"name":"title","type":"STR"}]}"#,
+        None,
+    );
+    assert_eq!(status, 200, "create table: {created}");
+
+    let mut ws = connect_live(http_port, None).await;
+    send_json(
+        &mut ws,
+        json!({
+            "type":"live.subscribe",
+            "id":"open",
+            "spec":{"kind":"table","table":"tasks","where":{"status":"open"}}
+        }),
+    )
+    .await;
+    assert_eq!(recv_json(&mut ws).await["type"], "live.subscribed");
+    assert_eq!(recv_live_event(&mut ws, "open").await["kind"], "snapshot");
+
+    // Insert a matching row -> insert.
+    let (status, _) = http_json_request(
+        http_port,
+        "POST",
+        "/v1/tables/tasks",
+        r#"{"id":"t1","status":"open","title":"first"}"#,
+        None,
+    );
+    assert_eq!(status, 200);
+    let e = recv_live_event(&mut ws, "open").await;
+    assert_eq!(e["kind"], "insert");
+    assert_eq!(e["pk"], "t1");
+    assert_eq!(e["cause"]["kind"], "table.insert");
+
+    // Insert a non-matching row -> no event.
+    let (status, _) = http_json_request(
+        http_port,
+        "POST",
+        "/v1/tables/tasks",
+        r#"{"id":"t2","status":"closed","title":"second"}"#,
+        None,
+    );
+    assert_eq!(status, 200);
+    let none = tokio::time::timeout(Duration::from_millis(250), ws.next()).await;
+    assert!(none.is_err(), "non-matching insert should not emit");
+
+    // Move t2 into the predicate via UPDATE -> insert (not update).
+    let (status, _) = http_json_request(
+        http_port,
+        "PATCH",
+        "/v1/tables/tasks/t2",
+        r#"{"status":"open"}"#,
+        None,
+    );
+    assert_eq!(status, 200);
+    let e = recv_live_event(&mut ws, "open").await;
+    assert_eq!(e["kind"], "insert", "move-in should read as insert: {e}");
+    assert_eq!(e["pk"], "t2");
+
+    // In-place change to a matching row -> update.
+    let (status, _) = http_json_request(
+        http_port,
+        "PATCH",
+        "/v1/tables/tasks/t1",
+        r#"{"title":"renamed"}"#,
+        None,
+    );
+    assert_eq!(status, 200);
+    let e = recv_live_event(&mut ws, "open").await;
+    assert_eq!(e["kind"], "update", "in-place change should be update: {e}");
+    assert_eq!(e["pk"], "t1");
+    assert_eq!(e["row"]["title"], "renamed");
+    assert_eq!(e["cause"]["kind"], "table.update");
+
+    // Move t1 out of the predicate via UPDATE -> delete (not update).
+    let (status, _) = http_json_request(
+        http_port,
+        "PATCH",
+        "/v1/tables/tasks/t1",
+        r#"{"status":"done"}"#,
+        None,
+    );
+    assert_eq!(status, 200);
+    let e = recv_live_event(&mut ws, "open").await;
+    assert_eq!(e["kind"], "delete", "move-out should read as delete: {e}");
+    assert_eq!(e["pk"], "t1");
+    assert_eq!(e["cause"]["kind"], "table.delete");
+
+    // An UPDATE to a row that is out of the set on both sides -> no event.
+    let (status, _) = http_json_request(
+        http_port,
+        "PATCH",
+        "/v1/tables/tasks/t1",
+        r#"{"title":"still done"}"#,
+        None,
+    );
+    assert_eq!(status, 200);
+    let none = tokio::time::timeout(Duration::from_millis(250), ws.next()).await;
+    assert!(none.is_err(), "out-of-set update should not emit");
+
+    // Delete the remaining matching row -> delete.
+    let reply = resp_command(
+        resp_port,
+        &["TDELETE", "FROM", "tasks", "WHERE", "id", "=", "t2"],
+    );
+    assert!(!reply.contains("ERR"), "tdelete: {reply}");
+    let e = recv_live_event(&mut ws, "open").await;
+    assert_eq!(e["kind"], "delete");
+    assert_eq!(e["pk"], "t2");
+}
+
+// Parity: the incrementally-maintained result set must equal a fresh TSELECT of
+// the same query after an arbitrary write sequence (IVM == ground truth).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_table_ivm_result_matches_fresh_select() {
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start_lux(resp_port, http_port, None);
+
+    let (status, created) = http_json_request(
+        http_port,
+        "POST",
+        "/v1/tables",
+        r#"{"name":"items","columns":[{"name":"id","type":"STR","primaryKey":true},{"name":"bucket","type":"STR","notNull":true},{"name":"v","type":"INT"}]}"#,
+        None,
+    );
+    assert_eq!(status, 200, "create: {created}");
+
+    let mut ws = connect_live(http_port, None).await;
+    send_json(
+        &mut ws,
+        json!({
+            "type":"live.subscribe",
+            "id":"a",
+            "spec":{"kind":"table","table":"items","where":{"bucket":"a"}}
+        }),
+    )
+    .await;
+    assert_eq!(recv_json(&mut ws).await["type"], "live.subscribed");
+    assert_eq!(recv_live_event(&mut ws, "a").await["kind"], "snapshot");
+
+    // A mixed write sequence: inserts, in/out moves, in-place updates, deletes.
+    let writes: &[(&str, &str, &str)] = &[
+        (
+            "POST",
+            "/v1/tables/items",
+            r#"{"id":"i1","bucket":"a","v":1}"#,
+        ),
+        (
+            "POST",
+            "/v1/tables/items",
+            r#"{"id":"i2","bucket":"b","v":2}"#,
+        ),
+        (
+            "POST",
+            "/v1/tables/items",
+            r#"{"id":"i3","bucket":"a","v":3}"#,
+        ),
+        ("PATCH", "/v1/tables/items/i2", r#"{"bucket":"a"}"#), // move in
+        ("PATCH", "/v1/tables/items/i1", r#"{"v":10}"#),       // in-place
+        ("PATCH", "/v1/tables/items/i3", r#"{"bucket":"c"}"#), // move out
+        (
+            "POST",
+            "/v1/tables/items",
+            r#"{"id":"i4","bucket":"a","v":4}"#,
+        ),
+    ];
+    for (method, path, body) in writes {
+        let (status, resp) = http_json_request(http_port, method, path, body, None);
+        assert_eq!(status, 200, "{method} {path}: {resp}");
+    }
+    // Delete i2 (RESP, since HTTP delete-by-id is a where-filtered bulk route).
+    let reply = resp_command(
+        resp_port,
+        &["TDELETE", "FROM", "items", "WHERE", "id", "=", "i2"],
+    );
+    assert!(!reply.contains("ERR"), "tdelete: {reply}");
+
+    // Reconstruct the client's maintained result set purely from the delta
+    // stream, applying each event the way a real client would.
+    let mut client: std::collections::HashMap<String, Value> = std::collections::HashMap::new();
+    while let Ok(event) =
+        tokio::time::timeout(Duration::from_millis(300), recv_live_event(&mut ws, "a")).await
+    {
+        let pk = event["pk"].as_str().unwrap().to_string();
+        match event["kind"].as_str().unwrap() {
+            "insert" | "update" => {
+                client.insert(pk, event["row"].clone());
+            }
+            "delete" => {
+                client.remove(&pk);
+            }
+            other => panic!("unexpected event kind {other}: {event}"),
+        }
+    }
+
+    // Ground truth after the sequence, restricted to bucket == "a":
+    //   i1: inserted (a,1) then v->10           => present, v=10
+    //   i2: (b,2) -> moved to a -> deleted        => absent
+    //   i3: (a,3) -> moved to c                    => absent
+    //   i4: inserted (a,4)                         => present, v=4
+    let mut client_ids: Vec<&String> = client.keys().collect();
+    client_ids.sort();
+    assert_eq!(
+        client_ids,
+        vec![&"i1".to_string(), &"i4".to_string()],
+        "IVM-maintained set must converge to ground truth: {client:?}"
+    );
+    assert_eq!(
+        client["i1"]["v"],
+        json!(10),
+        "i1 reflects the in-place update"
+    );
+    assert_eq!(client["i4"]["v"], json!(4));
+}
+
+// After a live socket disconnects, its row-delta subscription must be torn down
+// so the broker's per-table channel and subscriber gate are reclaimed. A fresh
+// connection re-subscribing to the same table must still receive deltas, proving
+// the teardown left the broker in a clean, reusable state.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_table_ivm_survives_reconnect_after_disconnect() {
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start_lux(resp_port, http_port, None);
+
+    let (status, _) = http_json_request(
+        http_port,
+        "POST",
+        "/v1/tables",
+        r#"{"name":"beats","columns":[{"name":"id","type":"STR","primaryKey":true},{"name":"room","type":"STR"}]}"#,
+        None,
+    );
+    assert_eq!(status, 200);
+
+    // First subscriber connects, gets its snapshot, then drops the socket.
+    {
+        let mut ws = connect_live(http_port, None).await;
+        send_json(
+            &mut ws,
+            json!({"type":"live.subscribe","id":"b","spec":{"kind":"table","table":"beats"}}),
+        )
+        .await;
+        assert_eq!(recv_json(&mut ws).await["type"], "live.subscribed");
+        assert_eq!(recv_live_event(&mut ws, "b").await["kind"], "snapshot");
+        // ws dropped here -> server-side teardown should reclaim the channel.
+    }
+
+    // Give the server a moment to observe the close and run teardown.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // A brand-new connection re-subscribes to the same table and must still get
+    // incremental deltas (the reclaimed channel is transparently recreated).
+    let mut ws2 = connect_live(http_port, None).await;
+    send_json(
+        &mut ws2,
+        json!({"type":"live.subscribe","id":"b2","spec":{"kind":"table","table":"beats"}}),
+    )
+    .await;
+    assert_eq!(recv_json(&mut ws2).await["type"], "live.subscribed");
+    assert_eq!(recv_live_event(&mut ws2, "b2").await["kind"], "snapshot");
+
+    let (status, _) = http_json_request(
+        http_port,
+        "POST",
+        "/v1/tables/beats",
+        r#"{"id":"k1","room":"main"}"#,
+        None,
+    );
+    assert_eq!(status, 200);
+
+    let e = recv_live_event(&mut ws2, "b2").await;
+    assert_eq!(e["kind"], "insert");
+    assert_eq!(e["pk"], "k1");
+}


### PR DESCRIPTION
## Summary

Makes `.live()` table subscriptions genuinely incremental. Before, every write to a subscribed table re-ran the whole query and diffed the full result set (O(query) per write per subscription). Now an eligible live query is maintained from a typed per-row delta by re-evaluating only the changed pk.

No wire-protocol or client changes: existing `.live()` clients transparently get the faster path.

## How it works

**Emission** (`pubsub.rs`, `store/mod.rs`, `tables/mod.rs`, `lib.rs`)
- `RowDelta { table, pk }` broadcast per table via the Broker.
- `Store::emit_row_delta` sink, wired to the Broker at runtime startup.
- Emitted from the insert/update/delete mutation leaves, gated on live subscribers and skipped during WAL replay, so idle writes pay only a couple of atomic loads.

**Consumer** (`http.rs`)
- IVM-eligible = single table, no joins/near/limit/offset/aggregate, with the pk projected. Everything else keeps the existing re-query-and-diff fallback, so no query shape regresses.
- On a delta, re-evaluate just the changed pk through the same `fetch_live_table_rows` path (RLS/projection/typing stay identical to a fresh `TSELECT`), then derive insert/update/delete from before/after result-set membership. Coalesces deltas per pk per tick; resyncs on broadcast lag.
- `cause` field preserved so the emitted `live.event` shape matches the fallback.

## Fixes surfaced

- Socket disconnect now tears down subscriptions, so the row-delta subscriber gate and per-table channels do not leak (otherwise the write path would keep doing delta work after the first live query ever connected).
- `stop_live_subscription` drops the receiver before checking `receiver_count()`, so the last unsubscribe reclaims the channel.

## Tests

- Predicate move-in / in-place / move-out transitions emit exactly one insert / update / delete.
- Mixed-write parity: the delta-reconstructed set converges to ground truth.
- Reconnect after disconnect: a fresh sub on the same table still receives deltas.
- Broker subscribe/unsubscribe/reclaim + idle no-op unit tests.
- All existing live_ws tests pass; several now route through the IVM path (single-table WHERE, TTL delete, custom pk, RLS-filtered inserts). Joins stay on the fallback.

## Scope

Covers single-table WHERE (the common case). Joins, vector-near, and aggregate live queries keep the re-query-diff path; incrementalizing those is a follow-up. The `RowDelta` seam is designed to be reused by replication later.