### PR TITLE
feat(push): native push notifications (APNs + Web Push)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +686,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1506,6 +1526,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2071,6 +2092,19 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tokio-tungstenite = "0.24"
 argon2 = "0.5"
 bcrypt = "0.17"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
-p256 = { version = "0.13", features = ["jwk"] }
+p256 = { version = "0.13", features = ["jwk", "ecdh"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
 ring = "0.17"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "http2"] }
 [dev-dependencies]
 tempfile = "3"
 proptest = "1"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@luxdb/sdk",
-    "version": "2.8.4",
+    "version": "2.9.0",
     "description": "Official Lux TypeScript SDK for app data, auth, tables, vectors, realtime, and Redis-compatible direct access",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -47,6 +47,7 @@ export {
 };
 export { LuxProjectLiveSubscription } from './project';
 export { createBrowserClient } from './browser';
+export { LuxPushNamespace } from './push';
 export { LuxStorageBucketClient, LuxStorageNamespace } from './storage';
 export type { LuxBrowserClientOptions } from './browser';
 export { createServerClient } from './ssr';
@@ -66,6 +67,11 @@ export type {
 	LuxTableColumn,
 	LuxVectorSearchOptions,
 } from './project';
+export type {
+	LuxPushDevice,
+	LuxPushNotification,
+	LuxPushRegisterOptions,
+} from './push';
 export type {
 	LuxStorageListOptions,
 	LuxStorageObject,

--- a/sdk/src/project.ts
+++ b/sdk/src/project.ts
@@ -1,4 +1,5 @@
 import { LuxAuthClient, type LuxAuthOptions } from './auth';
+import { LuxPushNamespace } from './push';
 import { LuxStorageNamespace } from './storage';
 import type { LuxError, LuxResult, LuxSchema, LuxTypedRow } from './types';
 import { err, ok, toLuxError } from './utils';
@@ -120,6 +121,7 @@ export class LuxProjectClient<DB extends Record<string, object> = LuxSchema> {
 	readonly key: string;
 	readonly auth: LuxAuthClient;
 	readonly storage: LuxStorageNamespace;
+	readonly push: LuxPushNamespace;
 	private fetchImpl: typeof fetch;
 	private WebSocketImpl?: typeof WebSocket;
 	private liveSocket: WebSocket | null = null;
@@ -143,6 +145,7 @@ export class LuxProjectClient<DB extends Record<string, object> = LuxSchema> {
 			else this.restartLiveSocket();
 		});
 		this.storage = new LuxStorageNamespace(this);
+		this.push = new LuxPushNamespace(this);
 	}
 
 	/**

--- a/sdk/src/push.ts
+++ b/sdk/src/push.ts
@@ -1,0 +1,102 @@
+import type { LuxProjectClient } from './project';
+import type { LuxResult } from './types';
+
+export interface LuxPushDevice {
+	id: string;
+	subject_id?: string;
+	platform: string;
+	app_id: string;
+	created_at: string;
+	last_seen_at: string;
+}
+
+export interface LuxPushRegisterOptions {
+	/** The platform push token (APNs hex device token, Web Push subscription, etc.). */
+	token: string;
+	/** Defaults to `'ios'`. */
+	platform?: string;
+	/** App/credential set to route through. Defaults to `'default'`. */
+	app_id?: string;
+}
+
+/** A notification. `title`/`body` render the alert; the rest map to APNs `aps`
+ *  fields (and their platform equivalents). `data` arrives in the client. */
+export interface LuxPushNotification {
+	title?: string;
+	body?: string;
+	subtitle?: string;
+	/** Lock-screen grouping key (APNs `thread-id`). */
+	thread_id?: string;
+	/** Notification category (action buttons). */
+	category?: string;
+	sound?: string;
+	badge?: number;
+	/** Image URL; flips `mutable-content` so a notification-service-extension
+	 *  can attach a thumbnail. */
+	image?: string;
+	mutable_content?: boolean;
+	/** Silent/background delivery (APNs `content-available`). */
+	content_available?: boolean;
+	/** Arbitrary string key/values delivered to the client. */
+	data?: Record<string, string>;
+}
+
+/**
+ * `db.push` — device registration + delivery, keyed by an opaque **subject id**.
+ * A subject id MAY be a Lux auth user id but doesn't have to be, so push works
+ * with or without Lux auth. Registering with a user session self-registers
+ * (subject = `auth.uid()`); a trusted **secret-key** caller registers and sends
+ * on any subject's behalf.
+ */
+export class LuxPushNamespace {
+	constructor(private client: LuxProjectClient<any>) {}
+
+	/** Register the CURRENT user's device (subject = `auth.uid()`). Needs a session. */
+	async register(options: LuxPushRegisterOptions): Promise<LuxResult<{ id: string }>> {
+		return this.client.request('POST', '/push/devices', {
+			token: options.token,
+			platform: options.platform ?? 'ios',
+			app_id: options.app_id ?? 'default',
+		});
+	}
+
+	/** Register a device for an explicit subject id. Requires a secret key. */
+	async registerFor(
+		subjectId: string,
+		options: LuxPushRegisterOptions,
+	): Promise<LuxResult<{ id: string }>> {
+		return this.client.request('POST', '/push/devices', {
+			subject_id: subjectId,
+			token: options.token,
+			platform: options.platform ?? 'ios',
+			app_id: options.app_id ?? 'default',
+		});
+	}
+
+	/** Remove a device by id. */
+	async unregister(id: string): Promise<LuxResult<{ deleted: boolean }>> {
+		return this.client.request('DELETE', `/push/devices/${encodeURIComponent(id)}`);
+	}
+
+	/** List a subject's active devices. With a user session, omit `subjectId` to
+	 *  list your own; with a secret key, pass the subject. */
+	async devices(subjectId?: string): Promise<LuxResult<LuxPushDevice[]>> {
+		const path = subjectId
+			? `/push/devices?subject_id=${encodeURIComponent(subjectId)}`
+			: '/push/devices';
+		const res = await this.client.request<{ devices: LuxPushDevice[] }>('GET', path);
+		if (res.error) return { data: null, error: res.error };
+		return { data: res.data?.devices ?? [], error: null };
+	}
+
+	/** Send a notification to one subject or many at once. Requires a secret key. */
+	async send(
+		subjects: string | string[],
+		notification: LuxPushNotification,
+	): Promise<LuxResult<{ enqueued: number }>> {
+		const body = Array.isArray(subjects)
+			? { subject_ids: subjects, notification }
+			: { subject_id: subjects, notification };
+		return this.client.request('POST', '/push/send', body);
+	}
+}

--- a/sdk/src/push.ts
+++ b/sdk/src/push.ts
@@ -1,5 +1,6 @@
 import type { LuxProjectClient } from './project';
 import type { LuxResult } from './types';
+import { err, toLuxError } from './utils';
 
 export interface LuxPushDevice {
 	id: string;
@@ -99,4 +100,53 @@ export class LuxPushNamespace {
 			: { subject_id: subjects, notification };
 		return this.client.request('POST', '/push/send', body);
 	}
+
+	// ── Web Push (VAPID) ──
+
+	/** The project's VAPID public key (the browser `applicationServerKey`). */
+	async getVapidPublicKey(): Promise<LuxResult<string>> {
+		const res = await this.client.request<{ public_key: string }>('GET', '/push/vapid');
+		if (res.error) return { data: null, error: res.error };
+		return { data: res.data?.public_key ?? '', error: null };
+	}
+
+	/**
+	 * Browser helper: prompt for notification permission, subscribe via the
+	 * service worker's PushManager using the project VAPID key, and register the
+	 * subscription. Requires an active service worker. Pass `vapidPublicKey` to
+	 * skip the network fetch, or `serviceWorker` to use a specific registration.
+	 */
+	async subscribeWebPush(
+		options: { vapidPublicKey?: string; serviceWorker?: ServiceWorkerRegistration } = {},
+	): Promise<LuxResult<{ id: string }>> {
+		try {
+			const key = options.vapidPublicKey ?? (await this.getVapidPublicKey()).data ?? '';
+			if (!key) return err('LUX_PUSH_NO_VAPID', 'No VAPID public key is configured');
+			if (typeof Notification === 'undefined' || !navigator?.serviceWorker) {
+				return err('LUX_PUSH_UNSUPPORTED', 'Web Push is not available in this environment');
+			}
+			const permission = await Notification.requestPermission();
+			if (permission !== 'granted') {
+				return err('LUX_PUSH_PERMISSION_DENIED', 'Notification permission was not granted');
+			}
+			const registration = options.serviceWorker ?? (await navigator.serviceWorker.ready);
+			const subscription = await registration.pushManager.subscribe({
+				userVisibleOnly: true,
+				applicationServerKey: urlBase64ToUint8Array(key),
+			});
+			return this.register({ token: JSON.stringify(subscription), platform: 'web' });
+		} catch (e) {
+			return err('LUX_PUSH_SUBSCRIBE_ERROR', 'Web push subscribe failed', toLuxError(e));
+		}
+	}
+}
+
+/** Decode a base64url VAPID key into the byte array PushManager expects. */
+function urlBase64ToUint8Array(base64: string): Uint8Array<ArrayBuffer> {
+	const padding = '='.repeat((4 - (base64.length % 4)) % 4);
+	const normalized = (base64 + padding).replace(/-/g, '+').replace(/_/g, '/');
+	const raw = atob(normalized);
+	const out = new Uint8Array(new ArrayBuffer(raw.length));
+	for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+	return out;
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -32,6 +32,9 @@ pub(crate) const GRANTS_TABLE: &str = "auth.grants";
 pub(crate) const PROVIDERS_TABLE: &str = "auth.providers";
 pub(crate) const FLOW_TOKENS_TABLE: &str = "auth.flow_tokens";
 pub(crate) const SETTINGS_TABLE: &str = "auth.settings";
+pub(crate) const DEVICES_TABLE: &str = "auth.devices";
+pub(crate) const PUSH_CREDENTIALS_TABLE: &str = "auth.push_credentials";
+pub(crate) const PUSH_OUTBOX_TABLE: &str = "auth.push_outbox";
 
 const AUTH_SCHEMA_VERSION_KEY: &[u8] = b"_auth:schema_version";
 const AUTH_SCHEMA_VERSION: &[u8] = b"2";
@@ -319,6 +322,9 @@ fn sensitive_auth_fields(table: &str) -> &'static [&'static str] {
         SIGNING_KEYS_TABLE => &["private_key_encrypted"],
         PROVIDERS_TABLE => &["client_secret"],
         FLOW_TOKENS_TABLE => &["token_hash"],
+        DEVICES_TABLE => &["token"],
+        PUSH_CREDENTIALS_TABLE => &["apns_p8_pem"],
+        PUSH_OUTBOX_TABLE => &["target_token"],
         _ => &[],
     }
 }
@@ -475,6 +481,60 @@ pub(crate) fn bootstrap(
         cache,
         SETTINGS_TABLE,
         &["key STR PRIMARY KEY,", "value STR,", "updated_at INT"],
+        now,
+    )?;
+    // lux push: per-user device registry, per-app push credentials, and the
+    // durable delivery outbox. All under `auth.*` so the reserved-table guards
+    // (mutation/read/redaction) cover them for free.
+    create_table_if_missing(
+        store,
+        cache,
+        DEVICES_TABLE,
+        &[
+            "id STR PRIMARY KEY,",
+            "user_id UUID,",
+            "token STR,",
+            "platform STR,",
+            "app_id STR,",
+            "created_at INT,",
+            "last_seen_at INT,",
+            "disabled_at INT",
+        ],
+        now,
+    )?;
+    create_table_if_missing(
+        store,
+        cache,
+        PUSH_CREDENTIALS_TABLE,
+        &[
+            "app_id STR PRIMARY KEY,",
+            "platform STR,",
+            "apns_team_id STR,",
+            "apns_key_id STR,",
+            "apns_p8_pem STR,",
+            "apns_topic STR,",
+            "environment STR,",
+            "created_at INT",
+        ],
+        now,
+    )?;
+    create_table_if_missing(
+        store,
+        cache,
+        PUSH_OUTBOX_TABLE,
+        &[
+            "id STR PRIMARY KEY,",
+            "user_id UUID,",
+            "app_id STR,",
+            "target_token STR,",
+            "platform STR,",
+            "payload STR,",
+            "attempts INT,",
+            "next_attempt_at INT,",
+            "state STR,",
+            "last_error STR,",
+            "created_at INT",
+        ],
         now,
     )?;
     store.set(AUTH_SCHEMA_VERSION_KEY, AUTH_SCHEMA_VERSION, None, now);
@@ -2574,7 +2634,7 @@ fn create_table_if_missing(
     }
 }
 
-fn durable_table_insert(
+pub(crate) fn durable_table_insert(
     store: &Store,
     cache: &SharedSchemaCache,
     table: &str,
@@ -2590,7 +2650,7 @@ fn durable_table_insert(
     tables::table_insert(store, cache, table, field_values, now)
 }
 
-fn durable_table_update_where(
+pub(crate) fn durable_table_update_where(
     store: &Store,
     cache: &SharedSchemaCache,
     table: &str,
@@ -2615,7 +2675,7 @@ fn durable_table_update_where(
     tables::table_update_where(store, cache, table, field_values, where_args, now)
 }
 
-fn durable_table_delete_where(
+pub(crate) fn durable_table_delete_where(
     store: &Store,
     cache: &SharedSchemaCache,
     table: &str,
@@ -4290,7 +4350,7 @@ fn app_metadata_with_provider(existing: Option<&str>, provider: &str) -> String 
     value.to_string()
 }
 
-fn find_row_by_field(
+pub(crate) fn find_row_by_field(
     store: &Store,
     cache: &SharedSchemaCache,
     table: &str,
@@ -5152,7 +5212,7 @@ fn random_token(bytes: usize) -> String {
     base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw)
 }
 
-fn random_id(prefix: &str) -> String {
+pub(crate) fn random_id(prefix: &str) -> String {
     format!("{prefix}_{}", random_token(18))
 }
 
@@ -5160,7 +5220,7 @@ fn key_prefix(key: &str) -> String {
     key.chars().take(12).collect()
 }
 
-fn unix_seconds() -> u64 {
+pub(crate) fn unix_seconds() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -32,9 +32,6 @@ pub(crate) const GRANTS_TABLE: &str = "auth.grants";
 pub(crate) const PROVIDERS_TABLE: &str = "auth.providers";
 pub(crate) const FLOW_TOKENS_TABLE: &str = "auth.flow_tokens";
 pub(crate) const SETTINGS_TABLE: &str = "auth.settings";
-pub(crate) const DEVICES_TABLE: &str = "auth.devices";
-pub(crate) const PUSH_CREDENTIALS_TABLE: &str = "auth.push_credentials";
-pub(crate) const PUSH_OUTBOX_TABLE: &str = "auth.push_outbox";
 
 const AUTH_SCHEMA_VERSION_KEY: &[u8] = b"_auth:schema_version";
 const AUTH_SCHEMA_VERSION: &[u8] = b"2";
@@ -189,6 +186,12 @@ pub(crate) fn is_reserved_auth_table(table: &str) -> bool {
     table.starts_with("auth.")
 }
 
+/// Reserved system scopes managed by the engine (auth + push). Client `T*`/raw-KV
+/// access is blocked and sensitive columns are redacted on operator reads.
+pub(crate) fn is_reserved_system_table(table: &str) -> bool {
+    table.starts_with("auth.") || table.starts_with("push.")
+}
+
 pub(crate) fn reserved_table_mutation_error(args: &[&[u8]], store: &Store) -> Option<String> {
     if store
         .wal_suppress
@@ -209,7 +212,7 @@ pub(crate) fn reserved_table_mutation_error(args: &[&[u8]], store: &Store) -> Op
     }
     .and_then(|raw| std::str::from_utf8(raw).ok())?;
 
-    if is_reserved_auth_table(table) {
+    if is_reserved_system_table(table) {
         Some(reserved_table_error(table))
     } else {
         None
@@ -217,7 +220,7 @@ pub(crate) fn reserved_table_mutation_error(args: &[&[u8]], store: &Store) -> Op
 }
 
 pub(crate) fn reserved_table_access_error(table: &str) -> Option<String> {
-    if is_reserved_auth_table(table) {
+    if is_reserved_system_table(table) {
         Some(reserved_table_error(table))
     } else {
         None
@@ -252,8 +255,8 @@ pub(crate) fn reserved_key_mutation_error(args: &[&[u8]], store: &Store) -> Opti
     }
     for raw in &args[1..] {
         if let Ok(k) = std::str::from_utf8(raw) {
-            if k.starts_with("_t:auth.") {
-                return Some("ERR access to Lux Auth internal keys is not permitted".to_string());
+            if k.starts_with("_t:auth.") || k.starts_with("_t:push.") {
+                return Some("ERR access to Lux internal keys is not permitted".to_string());
             }
         }
     }
@@ -276,7 +279,7 @@ pub(crate) fn reserved_plan_access_error(plan: &SelectPlan) -> Option<String> {
 }
 
 pub(crate) fn redact_auth_table_row(table: &str, row: &mut [(String, String)]) {
-    if !is_reserved_auth_table(table) {
+    if !is_reserved_system_table(table) {
         return;
     }
     if table == SETTINGS_TABLE {
@@ -322,18 +325,20 @@ fn sensitive_auth_fields(table: &str) -> &'static [&'static str] {
         SIGNING_KEYS_TABLE => &["private_key_encrypted"],
         PROVIDERS_TABLE => &["client_secret"],
         FLOW_TOKENS_TABLE => &["token_hash"],
-        DEVICES_TABLE => &["token"],
-        PUSH_CREDENTIALS_TABLE => &["apns_p8_pem"],
-        PUSH_OUTBOX_TABLE => &["target_token"],
+        "push.devices" => &["token"],
+        "push.credentials" => &["apns_p8_pem", "vapid_private"],
+        "push.outbox" => &["target_token"],
         _ => &[],
     }
 }
 
 fn reserved_table_error(table: &str) -> String {
-    format!(
-        "ERR table '{}' is managed by Lux Auth; use /auth/v1 APIs",
-        table
-    )
+    let scope = if table.starts_with("push.") {
+        "Lux Push"
+    } else {
+        "Lux Auth"
+    };
+    format!("ERR table '{table}' is managed by {scope}; use its API")
 }
 
 pub(crate) fn bootstrap(
@@ -481,60 +486,6 @@ pub(crate) fn bootstrap(
         cache,
         SETTINGS_TABLE,
         &["key STR PRIMARY KEY,", "value STR,", "updated_at INT"],
-        now,
-    )?;
-    // lux push: per-user device registry, per-app push credentials, and the
-    // durable delivery outbox. All under `auth.*` so the reserved-table guards
-    // (mutation/read/redaction) cover them for free.
-    create_table_if_missing(
-        store,
-        cache,
-        DEVICES_TABLE,
-        &[
-            "id STR PRIMARY KEY,",
-            "user_id UUID,",
-            "token STR,",
-            "platform STR,",
-            "app_id STR,",
-            "created_at INT,",
-            "last_seen_at INT,",
-            "disabled_at INT",
-        ],
-        now,
-    )?;
-    create_table_if_missing(
-        store,
-        cache,
-        PUSH_CREDENTIALS_TABLE,
-        &[
-            "app_id STR PRIMARY KEY,",
-            "platform STR,",
-            "apns_team_id STR,",
-            "apns_key_id STR,",
-            "apns_p8_pem STR,",
-            "apns_topic STR,",
-            "environment STR,",
-            "created_at INT",
-        ],
-        now,
-    )?;
-    create_table_if_missing(
-        store,
-        cache,
-        PUSH_OUTBOX_TABLE,
-        &[
-            "id STR PRIMARY KEY,",
-            "user_id UUID,",
-            "app_id STR,",
-            "target_token STR,",
-            "platform STR,",
-            "payload STR,",
-            "attempts INT,",
-            "next_attempt_at INT,",
-            "state STR,",
-            "last_error STR,",
-            "created_at INT",
-        ],
         now,
     )?;
     store.set(AUTH_SCHEMA_VERSION_KEY, AUTH_SCHEMA_VERSION, None, now);
@@ -2621,7 +2572,7 @@ fn admin_revoke_key(
     }
 }
 
-fn create_table_if_missing(
+pub(crate) fn create_table_if_missing(
     store: &Store,
     cache: &SharedSchemaCache,
     table: &str,

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -369,6 +369,10 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         min_arity: 1,
     },
     CommandSpec {
+        name: b"LUX",
+        min_arity: 3,
+    },
+    CommandSpec {
         name: b"CONFIG",
         min_arity: 1,
     },
@@ -1970,6 +1974,10 @@ pub fn execute(
             }
         }
         b'L' => {
+            if cmd_eq(cmd, b"LUX") {
+                crate::push::cmd_push(args, store, cache, out, now);
+                return CmdResult::Written;
+            }
             if cmd_eq(cmd, b"LCS") {
                 return strings::cmd_lcs(args, store, out, now);
             }
@@ -2582,6 +2590,7 @@ fn command_self_logs_wal(cmd: &[u8]) -> bool {
             | b"HPEXPIRE"
             | b"HEXPIREAT"
             | b"HPEXPIREAT"
+            | b"LUX"
     )
 }
 

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -117,7 +117,11 @@ pub fn cmd_info(
     } else {
         "all".to_string()
     };
-    let info = build_info(store, broker, &section, now);
+    let mut info = build_info(store, broker, &section, now);
+    if section == "all" || section == "push" {
+        info.push_str("\r\n");
+        crate::push::append_info(&mut info);
+    }
     resp::write_bulk(out, &info);
     CmdResult::Written
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -2630,7 +2630,7 @@ fn route_request_with_auth(
 
         // ── push routes (lux push) ──
         ("POST", ["push", "devices"]) => push_register(body, store, cache, auth),
-        ("GET", ["push", "devices"]) => push_list_devices(store, cache, auth),
+        ("GET", ["push", "devices"]) => push_list_devices(params, store, cache, auth),
         ("DELETE", ["push", "devices", id]) => push_delete_device(id, store, cache, auth),
         ("POST", ["push", "send"]) => push_send(body, store, cache),
         ("POST", ["push", "credentials"]) => push_set_credentials(body, store, cache),
@@ -3039,17 +3039,16 @@ fn push_json_error(
     )
 }
 
-/// `POST /v1/push/devices` — the current user registers a device token. The
-/// user id is taken from the JWT (`auth.uid()`), never asserted by the client.
+/// `POST /v1/push/devices` — register a device token under a subject id.
+/// A **secret key / operator** caller supplies `subject_id` explicitly (this is
+/// the Supabase-auth-style path: your server registers on the user's behalf).
+/// A **user JWT** caller omits it; the subject is taken from `auth.uid()`.
 fn push_register(
     body: &str,
     store: &Arc<Store>,
     cache: &SharedSchemaCache,
     auth: &HttpAuthContext,
 ) -> (u16, &'static str, String) {
-    let Some(principal) = live_auth_principal(auth) else {
-        return push_json_error(401, "Unauthorized", "user authentication required");
-    };
     let parsed: serde_json::Value = match serde_json::from_str(body) {
         Ok(v) => v,
         Err(_) => return push_json_error(400, "Bad Request", "invalid json"),
@@ -3058,12 +3057,29 @@ fn push_register(
     if token.is_empty() {
         return push_json_error(400, "Bad Request", "token is required");
     }
+    let subject_id = match auth {
+        HttpAuthContext::User(principal) => principal.user_id.clone(),
+        HttpAuthContext::Operator => {
+            let s = parsed["subject_id"].as_str().unwrap_or("");
+            if s.is_empty() {
+                return push_json_error(
+                    400,
+                    "Bad Request",
+                    "subject_id is required for secret-key registration",
+                );
+            }
+            s.to_string()
+        }
+        HttpAuthContext::Anonymous => {
+            return push_json_error(401, "Unauthorized", "authentication required")
+        }
+    };
     let platform = parsed["platform"].as_str().unwrap_or("ios");
     let app_id = parsed["app_id"].as_str().unwrap_or("default");
     match crate::push::register_device(
         store,
         cache,
-        &principal.user_id,
+        &subject_id,
         token,
         platform,
         app_id,
@@ -3074,38 +3090,60 @@ fn push_register(
     }
 }
 
-/// `GET /v1/push/devices` — list the current user's active devices.
+/// `GET /v1/push/devices` — list devices. A user JWT lists its own; an operator
+/// lists a given `?subject_id=`.
 fn push_list_devices(
+    params: &[(String, String)],
     store: &Arc<Store>,
     cache: &SharedSchemaCache,
     auth: &HttpAuthContext,
 ) -> (u16, &'static str, String) {
-    let Some(principal) = live_auth_principal(auth) else {
-        return push_json_error(401, "Unauthorized", "user authentication required");
+    let subject_id = match auth {
+        HttpAuthContext::User(principal) => principal.user_id.clone(),
+        HttpAuthContext::Operator => {
+            let s = get_param(params, "subject_id").unwrap_or("");
+            if s.is_empty() {
+                return push_json_error(400, "Bad Request", "subject_id query param is required");
+            }
+            s.to_string()
+        }
+        HttpAuthContext::Anonymous => {
+            return push_json_error(401, "Unauthorized", "authentication required")
+        }
     };
-    match crate::push::list_devices(store, cache, &principal.user_id, Instant::now()) {
+    match crate::push::list_devices(store, cache, &subject_id, Instant::now()) {
         Ok(devices) => ok(json!({ "devices": devices }).to_string()),
         Err(e) => push_json_error(400, "Bad Request", &e),
     }
 }
 
-/// `DELETE /v1/push/devices/:id` — remove one of the current user's devices.
+/// `DELETE /v1/push/devices/:id` — remove a device. A user JWT removes its own;
+/// an operator removes by id regardless of subject.
 fn push_delete_device(
     id: &str,
     store: &Arc<Store>,
     cache: &SharedSchemaCache,
     auth: &HttpAuthContext,
 ) -> (u16, &'static str, String) {
-    let Some(principal) = live_auth_principal(auth) else {
-        return push_json_error(401, "Unauthorized", "user authentication required");
+    let result = match auth {
+        HttpAuthContext::User(principal) => {
+            crate::push::delete_device(store, cache, &principal.user_id, id, Instant::now())
+        }
+        HttpAuthContext::Operator => {
+            crate::push::delete_device_by_id(store, cache, id, Instant::now())
+        }
+        HttpAuthContext::Anonymous => {
+            return push_json_error(401, "Unauthorized", "authentication required")
+        }
     };
-    match crate::push::delete_device(store, cache, &principal.user_id, id, Instant::now()) {
+    match result {
         Ok(deleted) => ok(json!({ "deleted": deleted }).to_string()),
         Err(e) => push_json_error(400, "Bad Request", &e),
     }
 }
 
-/// `POST /v1/push/send` (operator) — fan a notification out to a user's devices.
+/// `POST /v1/push/send` (operator) — fan a notification out to a subject's
+/// devices, or to many subjects at once via `subject_ids`.
 fn push_send(
     body: &str,
     store: &Arc<Store>,
@@ -3115,15 +3153,20 @@ fn push_send(
         Ok(v) => v,
         Err(_) => return push_json_error(400, "Bad Request", "invalid json"),
     };
-    let user_id = parsed["user_id"].as_str().unwrap_or("");
-    if user_id.is_empty() {
-        return push_json_error(400, "Bad Request", "user_id is required");
-    }
     let notification = parsed
         .get("notification")
         .cloned()
         .unwrap_or_else(|| json!({}));
-    match crate::push::enqueue_send(store, cache, user_id, &notification, Instant::now()) {
+    let now = Instant::now();
+    let result = if let Some(arr) = parsed.get("subject_ids").and_then(|v| v.as_array()) {
+        let ids: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
+        crate::push::enqueue_send_many(store, cache, &ids, &notification, now)
+    } else if let Some(subject_id) = parsed["subject_id"].as_str().filter(|s| !s.is_empty()) {
+        crate::push::enqueue_send(store, cache, subject_id, &notification, now)
+    } else {
+        return push_json_error(400, "Bad Request", "subject_id or subject_ids is required");
+    };
+    match result {
         Ok(n) => ok(json!({ "enqueued": n }).to_string()),
         Err(e) => push_json_error(400, "Bad Request", &e),
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -2634,6 +2634,8 @@ fn route_request_with_auth(
         ("DELETE", ["push", "devices", id]) => push_delete_device(id, store, cache, auth),
         ("POST", ["push", "send"]) => push_send(body, store, cache),
         ("POST", ["push", "credentials"]) => push_set_credentials(body, store, cache),
+        ("GET", ["push", "admin", "devices"]) => push_admin_devices(store, cache),
+        ("GET", ["push", "admin", "outbox"]) => push_admin_outbox(store, cache),
 
         // ── KV routes ──
         ("GET", ["kv", key]) => ok(exec_json(
@@ -3011,6 +3013,8 @@ fn route_requires_operator(method: &str, base: &[&str]) -> bool {
             | ("DELETE", ["vectors", _])
             | ("POST", ["push", "send"])
             | ("POST", ["push", "credentials"])
+            | ("GET", ["push", "admin", "devices"])
+            | ("GET", ["push", "admin", "outbox"])
     )
 }
 
@@ -3121,6 +3125,25 @@ fn push_send(
         .unwrap_or_else(|| json!({}));
     match crate::push::enqueue_send(store, cache, user_id, &notification, Instant::now()) {
         Ok(n) => ok(json!({ "enqueued": n }).to_string()),
+        Err(e) => push_json_error(400, "Bad Request", &e),
+    }
+}
+
+/// `GET /v1/push/admin/devices` (operator) — every device in the project.
+fn push_admin_devices(
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> (u16, &'static str, String) {
+    match crate::push::list_all_devices(store, cache, Instant::now()) {
+        Ok(devices) => ok(json!({ "devices": devices }).to_string()),
+        Err(e) => push_json_error(400, "Bad Request", &e),
+    }
+}
+
+/// `GET /v1/push/admin/outbox` (operator) — dead-lettered deliveries.
+fn push_admin_outbox(store: &Arc<Store>, cache: &SharedSchemaCache) -> (u16, &'static str, String) {
+    match crate::push::list_dead_letters(store, cache, Instant::now()) {
+        Ok(dead) => ok(json!({ "dead_letters": dead }).to_string()),
         Err(e) => push_json_error(400, "Bad Request", &e),
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -2628,6 +2628,13 @@ fn route_request_with_auth(
         // ── exec (escape hatch) ──
         ("POST", ["exec"]) => ok(handle_exec(body, store, broker, cache, script_engine)),
 
+        // ── push routes (lux push) ──
+        ("POST", ["push", "devices"]) => push_register(body, store, cache, auth),
+        ("GET", ["push", "devices"]) => push_list_devices(store, cache, auth),
+        ("DELETE", ["push", "devices", id]) => push_delete_device(id, store, cache, auth),
+        ("POST", ["push", "send"]) => push_send(body, store, cache),
+        ("POST", ["push", "credentials"]) => push_set_credentials(body, store, cache),
+
         // ── KV routes ──
         ("GET", ["kv", key]) => ok(exec_json(
             store,
@@ -3002,11 +3009,159 @@ fn route_requires_operator(method: &str, base: &[&str]) -> bool {
             | ("GET", ["vectors", ..])
             | ("POST", ["vectors", ..])
             | ("DELETE", ["vectors", _])
+            | ("POST", ["push", "send"])
+            | ("POST", ["push", "credentials"])
     )
 }
 
 fn ok(result: String) -> (u16, &'static str, String) {
     (200, "OK", result)
+}
+
+// ── Push handlers (lux push) ──
+
+fn push_json_error(
+    status: u16,
+    status_text: &'static str,
+    msg: &str,
+) -> (u16, &'static str, String) {
+    (
+        status,
+        status_text,
+        format!(
+            r#"{{"error":{}}}"#,
+            serde_json::Value::String(msg.to_string())
+        ),
+    )
+}
+
+/// `POST /v1/push/devices` — the current user registers a device token. The
+/// user id is taken from the JWT (`auth.uid()`), never asserted by the client.
+fn push_register(
+    body: &str,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+    auth: &HttpAuthContext,
+) -> (u16, &'static str, String) {
+    let Some(principal) = live_auth_principal(auth) else {
+        return push_json_error(401, "Unauthorized", "user authentication required");
+    };
+    let parsed: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(_) => return push_json_error(400, "Bad Request", "invalid json"),
+    };
+    let token = parsed["token"].as_str().unwrap_or("");
+    if token.is_empty() {
+        return push_json_error(400, "Bad Request", "token is required");
+    }
+    let platform = parsed["platform"].as_str().unwrap_or("ios");
+    let app_id = parsed["app_id"].as_str().unwrap_or("default");
+    match crate::push::register_device(
+        store,
+        cache,
+        &principal.user_id,
+        token,
+        platform,
+        app_id,
+        Instant::now(),
+    ) {
+        Ok(id) => ok(format!(r#"{{"id":{}}}"#, serde_json::Value::String(id))),
+        Err(e) => push_json_error(400, "Bad Request", &e),
+    }
+}
+
+/// `GET /v1/push/devices` — list the current user's active devices.
+fn push_list_devices(
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+    auth: &HttpAuthContext,
+) -> (u16, &'static str, String) {
+    let Some(principal) = live_auth_principal(auth) else {
+        return push_json_error(401, "Unauthorized", "user authentication required");
+    };
+    match crate::push::list_devices(store, cache, &principal.user_id, Instant::now()) {
+        Ok(devices) => ok(json!({ "devices": devices }).to_string()),
+        Err(e) => push_json_error(400, "Bad Request", &e),
+    }
+}
+
+/// `DELETE /v1/push/devices/:id` — remove one of the current user's devices.
+fn push_delete_device(
+    id: &str,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+    auth: &HttpAuthContext,
+) -> (u16, &'static str, String) {
+    let Some(principal) = live_auth_principal(auth) else {
+        return push_json_error(401, "Unauthorized", "user authentication required");
+    };
+    match crate::push::delete_device(store, cache, &principal.user_id, id, Instant::now()) {
+        Ok(deleted) => ok(json!({ "deleted": deleted }).to_string()),
+        Err(e) => push_json_error(400, "Bad Request", &e),
+    }
+}
+
+/// `POST /v1/push/send` (operator) — fan a notification out to a user's devices.
+fn push_send(
+    body: &str,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> (u16, &'static str, String) {
+    let parsed: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(_) => return push_json_error(400, "Bad Request", "invalid json"),
+    };
+    let user_id = parsed["user_id"].as_str().unwrap_or("");
+    if user_id.is_empty() {
+        return push_json_error(400, "Bad Request", "user_id is required");
+    }
+    let notification = parsed
+        .get("notification")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    match crate::push::enqueue_send(store, cache, user_id, &notification, Instant::now()) {
+        Ok(n) => ok(json!({ "enqueued": n }).to_string()),
+        Err(e) => push_json_error(400, "Bad Request", &e),
+    }
+}
+
+/// `POST /v1/push/credentials` (operator) — set an app's APNs credentials.
+fn push_set_credentials(
+    body: &str,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> (u16, &'static str, String) {
+    let parsed: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(_) => return push_json_error(400, "Bad Request", "invalid json"),
+    };
+    let app_id = parsed["app_id"].as_str().unwrap_or("default");
+    let team_id = parsed["team_id"].as_str().unwrap_or("");
+    let key_id = parsed["key_id"].as_str().unwrap_or("");
+    let p8_pem = parsed["p8_pem"].as_str().unwrap_or("");
+    let topic = parsed["topic"].as_str().unwrap_or("");
+    let environment = parsed["environment"].as_str().unwrap_or("sandbox");
+    if team_id.is_empty() || key_id.is_empty() || p8_pem.is_empty() || topic.is_empty() {
+        return push_json_error(
+            400,
+            "Bad Request",
+            "team_id, key_id, p8_pem, and topic are required",
+        );
+    }
+    match crate::push::set_apns_credentials(
+        store,
+        cache,
+        app_id,
+        team_id,
+        key_id,
+        p8_pem,
+        topic,
+        environment,
+        Instant::now(),
+    ) {
+        Ok(()) => ok(json!({ "ok": true }).to_string()),
+        Err(e) => push_json_error(400, "Bad Request", &e),
+    }
 }
 
 // ── Table handlers ──

--- a/src/http.rs
+++ b/src/http.rs
@@ -2636,6 +2636,7 @@ fn route_request_with_auth(
         ("POST", ["push", "credentials"]) => push_set_credentials(body, store, cache),
         ("GET", ["push", "admin", "devices"]) => push_admin_devices(store, cache),
         ("GET", ["push", "admin", "outbox"]) => push_admin_outbox(store, cache),
+        ("GET", ["push", "vapid"]) => push_vapid_public(params, store, cache),
 
         // ── KV routes ──
         ("GET", ["kv", key]) => ok(exec_json(
@@ -3202,6 +3203,30 @@ fn push_set_credentials(
         Err(_) => return push_json_error(400, "Bad Request", "invalid json"),
     };
     let app_id = parsed["app_id"].as_str().unwrap_or("default");
+    let now = Instant::now();
+
+    // VAPID (Web Push) credentials, distinguished by the presence of the key.
+    if let Some(vapid_private) = parsed["vapid_private"].as_str().filter(|s| !s.is_empty()) {
+        let vapid_public = parsed["vapid_public"].as_str().unwrap_or("");
+        let subject = parsed["vapid_subject"].as_str().unwrap_or("");
+        if vapid_public.is_empty() {
+            return push_json_error(400, "Bad Request", "vapid_public is required");
+        }
+        return match crate::push::set_vapid_credentials(
+            store,
+            cache,
+            app_id,
+            vapid_public,
+            vapid_private,
+            subject,
+            now,
+        ) {
+            Ok(()) => ok(json!({ "ok": true }).to_string()),
+            Err(e) => push_json_error(400, "Bad Request", &e),
+        };
+    }
+
+    // APNs credentials.
     let team_id = parsed["team_id"].as_str().unwrap_or("");
     let key_id = parsed["key_id"].as_str().unwrap_or("");
     let p8_pem = parsed["p8_pem"].as_str().unwrap_or("");
@@ -3223,9 +3248,24 @@ fn push_set_credentials(
         p8_pem,
         topic,
         environment,
-        Instant::now(),
+        now,
     ) {
         Ok(()) => ok(json!({ "ok": true }).to_string()),
+        Err(e) => push_json_error(400, "Bad Request", &e),
+    }
+}
+
+/// `GET /v1/push/vapid` (public) — the VAPID public key a browser needs to
+/// subscribe. Safe to expose; it's a public key.
+fn push_vapid_public(
+    params: &[(String, String)],
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> (u16, &'static str, String) {
+    let app_id = get_param(params, "app_id").unwrap_or("default");
+    match crate::push::vapid_public_key(store, cache, app_id, Instant::now()) {
+        Ok(Some(key)) => ok(json!({ "public_key": key }).to_string()),
+        Ok(None) => push_json_error(404, "Not Found", "web push is not configured"),
         Err(e) => push_json_error(400, "Bad Request", &e),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3127,6 +3127,15 @@ impl Runtime {
             }
         }
 
+        // One-time migration of any pre-`push.*` data (PR1 stored it under
+        // `auth.*`). Runs post-replay with WAL logging on; a no-op when there is
+        // no legacy data. Best-effort: a failure here must not block startup.
+        if let Err(e) =
+            push::migrate_from_auth_scope(&runtime.store, &runtime.schema_cache, Instant::now())
+        {
+            eprintln!("push scope migration skipped: {e}");
+        }
+
         background_tasks.spawn(snapshot::background_save_loop(runtime.store.clone()));
 
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3056,6 +3056,10 @@ impl Runtime {
                 ));
             }
         }
+        // lux push tables are created lazily on first use (see push::ensure_tables),
+        // so a project that never uses push carries no push.* tables. On restart,
+        // the `push.*` TCREATE/TINSERT commands are restored from the WAL like any
+        // other write, so no eager bootstrap is needed here.
         runtime
             .store
             .wal_suppress
@@ -3158,10 +3162,10 @@ impl Runtime {
             });
         }
 
-        // lux push delivery worker: drains the durable outbox and delivers to
-        // APNs/etc. Only runs when auth is enabled (the push registry lives under
-        // the `auth.*` reserved tables, bootstrapped above).
-        if runtime.config.auth.enabled {
+        // lux push delivery worker: drains the durable `push.outbox` and delivers
+        // to APNs/etc. Runs unconditionally — push is a standalone scope and does
+        // not depend on Lux auth.
+        {
             let store = runtime.store.clone();
             let cache = runtime.schema_cache.clone();
             background_tasks.spawn(push::worker::run_delivery_worker(store, cache));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ mod http;
 mod jsonb;
 mod lua;
 mod pubsub;
+mod push;
 mod resp;
 mod shard_exec;
 mod snapshot;
@@ -3155,6 +3156,15 @@ impl Runtime {
                     }
                 }
             });
+        }
+
+        // lux push delivery worker: drains the durable outbox and delivers to
+        // APNs/etc. Only runs when auth is enabled (the push registry lives under
+        // the `auth.*` reserved tables, bootstrapped above).
+        if runtime.config.auth.enabled {
+            let store = runtime.store.clone();
+            let cache = runtime.schema_cache.clone();
+            background_tasks.spawn(push::worker::run_delivery_worker(store, cache));
         }
 
         if runtime.config.storage.mode == StorageMode::Tiered {

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -171,19 +171,94 @@ impl ApnsSink {
 /// is `{title, body, data?}` JSON; we wrap it into the APNs `aps` envelope.
 pub(crate) fn apns_body_from_payload(payload: &[u8]) -> Vec<u8> {
     let parsed: serde_json::Value = serde_json::from_slice(payload).unwrap_or(json!({}));
-    let title = parsed.get("title").and_then(|v| v.as_str()).unwrap_or("");
-    let body = parsed.get("body").and_then(|v| v.as_str()).unwrap_or("");
-    let mut envelope = json!({
-        "aps": { "alert": { "title": title, "body": body } }
-    });
+    let s = |k: &str| {
+        parsed
+            .get(k)
+            .and_then(|v| v.as_str())
+            .filter(|v| !v.is_empty())
+    };
+
+    // aps.alert (title / body / subtitle)
+    let mut alert = serde_json::Map::new();
+    if let Some(v) = s("title") {
+        alert.insert("title".into(), json!(v));
+    }
+    if let Some(v) = s("body") {
+        alert.insert("body".into(), json!(v));
+    }
+    if let Some(v) = s("subtitle") {
+        alert.insert("subtitle".into(), json!(v));
+    }
+
+    let mut aps = serde_json::Map::new();
+    if !alert.is_empty() {
+        aps.insert("alert".into(), serde_json::Value::Object(alert));
+    }
+    if let Some(v) = s("thread_id") {
+        aps.insert("thread-id".into(), json!(v));
+    }
+    if let Some(v) = s("category") {
+        aps.insert("category".into(), json!(v));
+    }
+    if let Some(v) = s("sound") {
+        aps.insert("sound".into(), json!(v));
+    }
+    if let Some(v) = parsed.get("badge").and_then(|v| v.as_i64()) {
+        aps.insert("badge".into(), json!(v));
+    }
+    let has_image = s("image").is_some();
+    let mutable = parsed
+        .get("mutable_content")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    // Flip mutable-content when an image is attached so the iOS NSE runs and
+    // downloads the thumbnail (mirrors FCM `fcmOptions.imageUrl`).
+    if mutable || has_image {
+        aps.insert("mutable-content".into(), json!(1));
+    }
+    if parsed
+        .get("content_available")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        aps.insert("content-available".into(), json!(1));
+    }
+
+    let mut envelope = serde_json::Map::new();
+    envelope.insert("aps".into(), serde_json::Value::Object(aps));
+    if let Some(v) = s("image") {
+        envelope.insert("image_url".into(), json!(v));
+    }
+    // Arbitrary custom data merged at top level (arrives in the client userInfo).
     if let Some(data) = parsed.get("data").and_then(|v| v.as_object()) {
-        if let Some(obj) = envelope.as_object_mut() {
-            for (k, v) in data {
-                obj.insert(k.clone(), v.clone());
-            }
+        for (k, v) in data {
+            envelope.insert(k.clone(), v.clone());
         }
     }
-    serde_json::to_vec(&envelope).unwrap_or_else(|_| b"{}".to_vec())
+    serde_json::to_vec(&serde_json::Value::Object(envelope)).unwrap_or_else(|_| b"{}".to_vec())
+}
+
+/// `(apns-push-type, apns-priority)` for a payload. A `content_available` push
+/// with no visible alert is a background push (type `background`, priority 5);
+/// everything else is a normal alert (type `alert`, priority 10).
+pub(crate) fn apns_delivery_headers(payload: &[u8]) -> (&'static str, &'static str) {
+    let parsed: serde_json::Value = serde_json::from_slice(payload).unwrap_or(json!({}));
+    let s = |k: &str| {
+        parsed
+            .get(k)
+            .and_then(|v| v.as_str())
+            .filter(|v| !v.is_empty())
+    };
+    let has_alert = s("title").is_some() || s("body").is_some();
+    let content_available = parsed
+        .get("content_available")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if content_available && !has_alert {
+        ("background", "5")
+    } else {
+        ("alert", "10")
+    }
 }
 
 impl Sink for ApnsSink {
@@ -192,13 +267,14 @@ impl Sink for ApnsSink {
         let jwt = self.provider_token(now_secs)?;
         let url = format!("{}/3/device/{}", self.base_url, target.token);
         let body = apns_body_from_payload(payload);
+        let (push_type, priority) = apns_delivery_headers(payload);
         let resp = self
             .client
             .post(&url)
             .header("authorization", format!("bearer {jwt}"))
             .header("apns-topic", &target.topic)
-            .header("apns-push-type", "alert")
-            .header("apns-priority", "10")
+            .header("apns-push-type", push_type)
+            .header("apns-priority", priority)
             .header("content-type", "application/json")
             .body(body)
             .send()
@@ -304,5 +380,37 @@ mod tests {
         assert_eq!(v["aps"]["alert"]["title"], "Hi");
         assert_eq!(v["aps"]["alert"]["body"], "There");
         assert_eq!(v["k"], "v");
+    }
+
+    #[test]
+    fn body_maps_rich_fields() {
+        let payload = br#"{
+            "title":"T","body":"B","subtitle":"S","thread_id":"th1",
+            "category":"MSG","sound":"ping.caf","badge":3,"image":"https://x/i.png",
+            "data":{"route":"/w/1"}
+        }"#;
+        let v: serde_json::Value =
+            serde_json::from_slice(&apns_body_from_payload(payload)).unwrap();
+        assert_eq!(v["aps"]["alert"]["subtitle"], "S");
+        assert_eq!(v["aps"]["thread-id"], "th1");
+        assert_eq!(v["aps"]["category"], "MSG");
+        assert_eq!(v["aps"]["sound"], "ping.caf");
+        assert_eq!(v["aps"]["badge"], 3);
+        assert_eq!(v["aps"]["mutable-content"], 1); // image → NSE
+        assert_eq!(v["image_url"], "https://x/i.png");
+        assert_eq!(v["route"], "/w/1");
+    }
+
+    #[test]
+    fn content_available_is_a_background_push() {
+        assert_eq!(
+            apns_delivery_headers(br#"{"content_available":true}"#),
+            ("background", "5")
+        );
+        assert_eq!(
+            apns_delivery_headers(br#"{"title":"hi","content_available":true}"#),
+            ("alert", "10")
+        );
+        assert_eq!(apns_delivery_headers(br#"{"title":"hi"}"#), ("alert", "10"));
     }
 }

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -1,0 +1,308 @@
+//! APNs delivery sink and the generic `Sink` abstraction the delivery worker
+//! drives. `ApnsSink` speaks the native APNs HTTP/2 protocol directly (no
+//! OneSignal/Firebase in the path): an ES256 provider JWT minted from the app's
+//! `.p8` key, cached and refreshed, and a `POST /3/device/<token>`.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use serde::Serialize;
+use serde_json::json;
+
+/// A single delivery target: the platform token plus whatever routing metadata
+/// the sink needs (APNs topic, etc.).
+#[derive(Clone, Debug)]
+pub(crate) struct DeliveryTarget {
+    pub token: String,
+    pub topic: String,
+}
+
+/// Outcome of a failed delivery. `Retryable` is re-attempted with backoff;
+/// `Terminal` means the token is dead (prune the device) or the request is
+/// permanently malformed.
+#[derive(Debug)]
+pub(crate) enum DeliveryError {
+    Retryable(String),
+    Terminal(String),
+}
+
+impl DeliveryError {
+    pub fn message(&self) -> &str {
+        match self {
+            DeliveryError::Retryable(m) | DeliveryError::Terminal(m) => m,
+        }
+    }
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, DeliveryError::Terminal(_))
+    }
+}
+
+/// A delivery transport for one platform. Implementors turn a `(target,
+/// payload)` into an at-most-one network attempt and classify the result.
+pub(crate) trait Sink: Send + Sync {
+    fn deliver(
+        &self,
+        target: &DeliveryTarget,
+        payload: &[u8],
+    ) -> impl std::future::Future<Output = Result<(), DeliveryError>> + Send;
+}
+
+/// Provider-token claims: APNs wants `{iss: team_id, iat}` signed ES256 with the
+/// `.p8` key id in the JWT header `kid`.
+#[derive(Serialize)]
+struct ApnsClaims {
+    iss: String,
+    iat: u64,
+}
+
+struct CachedToken {
+    jwt: String,
+    minted: Instant,
+}
+
+/// Apple rotates provider tokens on a 20-60 min window; refresh at 50 min.
+const APNS_TOKEN_TTL: Duration = Duration::from_secs(50 * 60);
+const APNS_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The credential material for one app's APNs connection.
+#[derive(Clone)]
+pub(crate) struct ApnsCredentials {
+    pub team_id: String,
+    pub key_id: String,
+    pub p8_pem: String,
+}
+
+pub(crate) struct ApnsSink {
+    client: reqwest::Client,
+    base_url: String,
+    creds: ApnsCredentials,
+    token_cache: Mutex<Option<CachedToken>>,
+}
+
+impl ApnsSink {
+    /// `base_url` is `https://api.push.apple.com` (production) or
+    /// `https://api.sandbox.push.apple.com` (sandbox); tests inject a localhost
+    /// mock. A single reused HTTP/2 client (ALPN negotiates h2 over TLS).
+    pub fn new(base_url: impl Into<String>, creds: ApnsCredentials) -> Result<Self, String> {
+        let client = reqwest::Client::builder()
+            .timeout(APNS_REQUEST_TIMEOUT)
+            .build()
+            .map_err(|e| format!("apns client setup failed: {e}"))?;
+        Ok(Self {
+            client,
+            base_url: base_url.into(),
+            creds,
+            token_cache: Mutex::new(None),
+        })
+    }
+
+    /// Resolve the APNs base URL from the stored `environment`. `production`/
+    /// `prod` and anything else map to the two Apple hosts; a literal
+    /// `http(s)://` value is used verbatim (operator escape hatch for a relay,
+    /// and the seam tests point at a local mock).
+    pub fn resolve_base_url(environment: &str) -> String {
+        if environment.starts_with("http://") || environment.starts_with("https://") {
+            environment.trim_end_matches('/').to_string()
+        } else if environment == "production" || environment == "prod" {
+            "https://api.push.apple.com".to_string()
+        } else {
+            "https://api.sandbox.push.apple.com".to_string()
+        }
+    }
+
+    /// Mint (or reuse a cached) ES256 provider JWT. Mirrors the auth-layer
+    /// signing at `src/auth.rs` (`EncodingKey::from_ec_pem` + `Header.kid`); a
+    /// `.p8` file is a PKCS8 EC PEM, so it feeds `from_ec_pem` directly.
+    fn provider_token(&self, now_secs: u64) -> Result<String, DeliveryError> {
+        let mut cache = self.token_cache.lock().unwrap();
+        if let Some(cached) = cache.as_ref() {
+            if cached.minted.elapsed() < APNS_TOKEN_TTL {
+                return Ok(cached.jwt.clone());
+            }
+        }
+        let jwt = self.mint_token(now_secs).map_err(DeliveryError::Terminal)?;
+        *cache = Some(CachedToken {
+            jwt: jwt.clone(),
+            minted: Instant::now(),
+        });
+        Ok(jwt)
+    }
+
+    fn mint_token(&self, now_secs: u64) -> Result<String, String> {
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some(self.creds.key_id.clone());
+        let key = EncodingKey::from_ec_pem(self.creds.p8_pem.as_bytes())
+            .map_err(|e| format!("invalid APNs .p8 key: {e}"))?;
+        let claims = ApnsClaims {
+            iss: self.creds.team_id.clone(),
+            iat: now_secs,
+        };
+        encode(&header, &claims, &key).map_err(|e| format!("APNs JWT sign failed: {e}"))
+    }
+
+    /// Map an APNs HTTP status + `reason` body into a delivery outcome. 410
+    /// (`Unregistered`) and 400/`BadDeviceToken` are terminal (dead token);
+    /// 429 and 5xx are retryable.
+    fn classify_status(status: u16, reason: &str) -> Result<(), DeliveryError> {
+        match status {
+            200 => Ok(()),
+            410 => Err(DeliveryError::Terminal(format!("unregistered: {reason}"))),
+            400 if reason.contains("BadDeviceToken")
+                || reason.contains("DeviceTokenNotForTopic") =>
+            {
+                Err(DeliveryError::Terminal(format!("bad token: {reason}")))
+            }
+            400 | 403 | 404 => Err(DeliveryError::Terminal(format!(
+                "rejected ({status}): {reason}"
+            ))),
+            429 => Err(DeliveryError::Retryable(format!("throttled: {reason}"))),
+            500..=599 => Err(DeliveryError::Retryable(format!(
+                "apns server error ({status}): {reason}"
+            ))),
+            other => Err(DeliveryError::Retryable(format!(
+                "unexpected apns status {other}: {reason}"
+            ))),
+        }
+    }
+}
+
+/// Build the APNs request body from a caller notification payload. The payload
+/// is `{title, body, data?}` JSON; we wrap it into the APNs `aps` envelope.
+pub(crate) fn apns_body_from_payload(payload: &[u8]) -> Vec<u8> {
+    let parsed: serde_json::Value = serde_json::from_slice(payload).unwrap_or(json!({}));
+    let title = parsed.get("title").and_then(|v| v.as_str()).unwrap_or("");
+    let body = parsed.get("body").and_then(|v| v.as_str()).unwrap_or("");
+    let mut envelope = json!({
+        "aps": { "alert": { "title": title, "body": body } }
+    });
+    if let Some(data) = parsed.get("data").and_then(|v| v.as_object()) {
+        if let Some(obj) = envelope.as_object_mut() {
+            for (k, v) in data {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+    }
+    serde_json::to_vec(&envelope).unwrap_or_else(|_| b"{}".to_vec())
+}
+
+impl Sink for ApnsSink {
+    async fn deliver(&self, target: &DeliveryTarget, payload: &[u8]) -> Result<(), DeliveryError> {
+        let now_secs = crate::auth::unix_seconds();
+        let jwt = self.provider_token(now_secs)?;
+        let url = format!("{}/3/device/{}", self.base_url, target.token);
+        let body = apns_body_from_payload(payload);
+        let resp = self
+            .client
+            .post(&url)
+            .header("authorization", format!("bearer {jwt}"))
+            .header("apns-topic", &target.topic)
+            .header("apns-push-type", "alert")
+            .header("apns-priority", "10")
+            .header("content-type", "application/json")
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() || e.is_connect() {
+                    DeliveryError::Retryable(format!("apns transport: {e}"))
+                } else {
+                    DeliveryError::Retryable(format!("apns request failed: {e}"))
+                }
+            })?;
+        let status = resp.status().as_u16();
+        let reason = resp.text().await.unwrap_or_default();
+        ApnsSink::classify_status(status, &reason)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{decode_header, Algorithm};
+    use p256::pkcs8::{EncodePrivateKey, LineEnding};
+    use p256::SecretKey;
+    use rand_core::OsRng;
+
+    fn test_p8() -> String {
+        SecretKey::random(&mut OsRng)
+            .to_pkcs8_pem(LineEnding::LF)
+            .unwrap()
+            .to_string()
+    }
+
+    fn sink_with(p8: String) -> ApnsSink {
+        ApnsSink::new(
+            "https://api.sandbox.push.apple.com",
+            ApnsCredentials {
+                team_id: "TEAM123456".to_string(),
+                key_id: "KEY7890AB".to_string(),
+                p8_pem: p8,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn mints_es256_jwt_with_kid_and_iss() {
+        let sink = sink_with(test_p8());
+        let jwt = sink.mint_token(1_700_000_000).unwrap();
+        let header = decode_header(&jwt).unwrap();
+        assert_eq!(header.alg, Algorithm::ES256);
+        assert_eq!(header.kid.as_deref(), Some("KEY7890AB"));
+        // Middle segment decodes to claims carrying the team id as issuer.
+        let claims_b64 = jwt.split('.').nth(1).unwrap();
+        let claims_json = base64::Engine::decode(
+            &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+            claims_b64,
+        )
+        .unwrap();
+        let claims: serde_json::Value = serde_json::from_slice(&claims_json).unwrap();
+        assert_eq!(claims["iss"], "TEAM123456");
+        assert_eq!(claims["iat"], 1_700_000_000);
+    }
+
+    #[test]
+    fn provider_token_is_cached() {
+        let sink = sink_with(test_p8());
+        let a = sink.provider_token(1_700_000_000).unwrap();
+        let b = sink.provider_token(1_700_000_030).unwrap();
+        assert_eq!(a, b, "token within TTL should be reused");
+    }
+
+    #[test]
+    fn invalid_p8_is_terminal() {
+        let sink = sink_with(
+            "-----BEGIN PRIVATE KEY-----\nnonsense\n-----END PRIVATE KEY-----".to_string(),
+        );
+        let err = sink.provider_token(1_700_000_000).unwrap_err();
+        assert!(err.is_terminal(), "bad key must be terminal, got {err:?}");
+    }
+
+    #[test]
+    fn status_classification() {
+        assert!(ApnsSink::classify_status(200, "").is_ok());
+        assert!(ApnsSink::classify_status(410, "Unregistered")
+            .unwrap_err()
+            .is_terminal());
+        assert!(ApnsSink::classify_status(400, "BadDeviceToken")
+            .unwrap_err()
+            .is_terminal());
+        assert!(!ApnsSink::classify_status(429, "TooManyRequests")
+            .unwrap_err()
+            .is_terminal());
+        assert!(!ApnsSink::classify_status(503, "ServiceUnavailable")
+            .unwrap_err()
+            .is_terminal());
+    }
+
+    #[test]
+    fn body_wraps_alert_and_merges_data() {
+        let payload = br#"{"title":"Hi","body":"There","data":{"k":"v"}}"#;
+        let out = apns_body_from_payload(payload);
+        let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["aps"]["alert"]["title"], "Hi");
+        assert_eq!(v["aps"]["alert"]["body"], "There");
+        assert_eq!(v["k"], "v");
+    }
+}

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -1,9 +1,11 @@
 //! lux push: native push notifications. This module owns the engine-side
-//! delivery pipeline: a per-user device registry (`auth.devices`), per-app push
-//! credentials (`auth.push_credentials`), a durable at-least-once delivery
-//! outbox (`auth.push_outbox`), and the background worker that drains it through
-//! platform `Sink`s. PR1 ships the APNs sink; WebPush/FCM/HTTP plug into the
-//! same `Sink` seam later.
+//! delivery pipeline as its own standalone, auth-independent scope: a device
+//! registry (`push.devices`) keyed by an opaque `subject_id`, per-app push
+//! credentials (`push.credentials`), a durable at-least-once delivery outbox
+//! (`push.outbox`), and the background worker that drains it through platform
+//! `Sink`s. A `subject_id` MAY be a Lux `auth.users.id` but doesn't have to be —
+//! push works with Lux auth entirely off, managed by the secret key. PR1 ships
+//! the APNs sink; WebPush/FCM/HTTP plug into the same `Sink` seam later.
 
 pub(crate) mod apns;
 pub(crate) mod worker;
@@ -14,14 +16,88 @@ use bytes::BytesMut;
 use serde_json::{json, Value};
 
 use crate::auth::{
-    durable_table_delete_where, durable_table_insert, durable_table_update_where,
-    find_row_by_field, random_id, unix_seconds, DEVICES_TABLE, PUSH_CREDENTIALS_TABLE,
-    PUSH_OUTBOX_TABLE,
+    create_table_if_missing, durable_table_delete_where, durable_table_insert,
+    durable_table_update_where, find_row_by_field, random_id, unix_seconds,
 };
 use crate::resp;
 use crate::store::Store;
 use crate::tables::{self, CmpOp, SelectPlan, SelectResult, SharedSchemaCache, WhereClause};
 use std::time::Instant;
+
+/// Reserved `push.*` scope tables (protected + redacted by the shared reserved
+/// machinery in `auth.rs`, but bootstrapped and owned here).
+pub(crate) const DEVICES_TABLE: &str = "push.devices";
+pub(crate) const CREDENTIALS_TABLE: &str = "push.credentials";
+pub(crate) const OUTBOX_TABLE: &str = "push.outbox";
+
+/// Create the `push.*` tables if they don't exist. Called lazily on the first
+/// write (register / set-credentials / send) so a project that never uses push
+/// carries no `push.*` tables and no overhead. Idempotent + cheap thereafter
+/// (a schema-cache hit). Push does not depend on Lux auth being enabled.
+pub(crate) fn ensure_tables(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    now: Instant,
+) -> Result<(), String> {
+    create_table_if_missing(
+        store,
+        cache,
+        DEVICES_TABLE,
+        &[
+            "id STR PRIMARY KEY,",
+            // Opaque owner id. MAY be a Lux auth.users id; no FK, no existence
+            // check. Set from auth.uid() on JWT self-register, or supplied
+            // explicitly by a trusted secret-key caller.
+            "subject_id STR,",
+            "token STR,",
+            "platform STR,",
+            "app_id STR,",
+            "created_at INT,",
+            "last_seen_at INT,",
+            "disabled_at INT",
+        ],
+        now,
+    )?;
+    create_table_if_missing(
+        store,
+        cache,
+        CREDENTIALS_TABLE,
+        &[
+            "app_id STR PRIMARY KEY,",
+            "platform STR,",
+            "apns_team_id STR,",
+            "apns_key_id STR,",
+            "apns_p8_pem STR,",
+            "apns_topic STR,",
+            "environment STR,",
+            "vapid_public STR,",
+            "vapid_private STR,",
+            "vapid_subject STR,",
+            "created_at INT",
+        ],
+        now,
+    )?;
+    create_table_if_missing(
+        store,
+        cache,
+        OUTBOX_TABLE,
+        &[
+            "id STR PRIMARY KEY,",
+            "subject_id STR,",
+            "app_id STR,",
+            "target_token STR,",
+            "platform STR,",
+            "payload STR,",
+            "attempts INT,",
+            "next_attempt_at INT,",
+            "state STR,",
+            "last_error STR,",
+            "created_at INT",
+        ],
+        now,
+    )?;
+    Ok(())
+}
 
 /// Cumulative + gauge counters surfaced through `INFO` so the cloud monitor can
 /// scrape push activity like ops. `devices` is a live gauge; the rest are
@@ -61,18 +137,20 @@ pub(crate) struct ResolvedApnsCreds {
 // Device registry
 // ---------------------------------------------------------------------------
 
-/// Register (or refresh) a device token for `user_id`. A token is unique across
-/// the registry: re-registering an existing token re-points it at the current
-/// user and re-activates it rather than duplicating. Returns the device id.
+/// Register (or refresh) a device token for `subject_id`. A token is unique
+/// across the registry: re-registering an existing token re-points it at the
+/// current subject and re-activates it rather than duplicating. Returns the
+/// device id.
 pub(crate) fn register_device(
     store: &Store,
     cache: &SharedSchemaCache,
-    user_id: &str,
+    subject_id: &str,
     token: &str,
     platform: &str,
     app_id: &str,
     now: Instant,
 ) -> Result<String, String> {
+    ensure_tables(store, cache, now)?;
     let now_s = unix_seconds().to_string();
     if let Some(existing) = find_row_by_field(store, cache, DEVICES_TABLE, "token", token, now)? {
         let id = existing.get("id").cloned().unwrap_or_default();
@@ -81,7 +159,7 @@ pub(crate) fn register_device(
             cache,
             DEVICES_TABLE,
             &[
-                ("user_id", user_id),
+                ("subject_id", subject_id),
                 ("platform", platform),
                 ("app_id", app_id),
                 ("last_seen_at", now_s.as_str()),
@@ -99,7 +177,7 @@ pub(crate) fn register_device(
         DEVICES_TABLE,
         &[
             ("id", id.as_str()),
-            ("user_id", user_id),
+            ("subject_id", subject_id),
             ("token", token),
             ("platform", platform),
             ("app_id", app_id),
@@ -113,11 +191,11 @@ pub(crate) fn register_device(
     Ok(id)
 }
 
-/// List a user's active devices as JSON, omitting the raw token.
+/// List a subject's active devices as JSON, omitting the raw token.
 pub(crate) fn list_devices(
     store: &Store,
     cache: &SharedSchemaCache,
-    user_id: &str,
+    subject_id: &str,
     now: Instant,
 ) -> Result<Vec<Value>, String> {
     let rows = select_rows(
@@ -125,7 +203,7 @@ pub(crate) fn list_devices(
         cache,
         DEVICES_TABLE,
         vec![
-            WhereClause::single("user_id".into(), CmpOp::Eq, user_id.into()),
+            WhereClause::single("subject_id".into(), CmpOp::Eq, subject_id.into()),
             WhereClause::single("disabled_at".into(), CmpOp::Eq, "0".into()),
         ],
         None,
@@ -146,11 +224,11 @@ pub(crate) fn list_devices(
         .collect())
 }
 
-/// Delete a user's own device by id. Returns whether a row was removed.
+/// Delete a subject's own device by id. Returns whether a row was removed.
 pub(crate) fn delete_device(
     store: &Store,
     cache: &SharedSchemaCache,
-    user_id: &str,
+    subject_id: &str,
     id: &str,
     now: Instant,
 ) -> Result<bool, String> {
@@ -158,9 +236,24 @@ pub(crate) fn delete_device(
         store,
         cache,
         DEVICES_TABLE,
-        &["id", "=", id, "AND", "user_id", "=", user_id],
+        &["id", "=", id, "AND", "subject_id", "=", subject_id],
         now,
     )?;
+    if removed > 0 {
+        metrics().devices.fetch_sub(1, Ordering::Relaxed);
+    }
+    Ok(removed > 0)
+}
+
+/// Delete any device by id (operator), regardless of subject. Returns whether a
+/// row was removed.
+pub(crate) fn delete_device_by_id(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    id: &str,
+    now: Instant,
+) -> Result<bool, String> {
+    let removed = durable_table_delete_where(store, cache, DEVICES_TABLE, &["id", "=", id], now)?;
     if removed > 0 {
         metrics().devices.fetch_sub(1, Ordering::Relaxed);
     }
@@ -184,7 +277,7 @@ pub(crate) fn list_all_devices(
             let m: std::collections::HashMap<String, String> = row.into_iter().collect();
             json!({
                 "id": m.get("id").cloned().unwrap_or_default(),
-                "user_id": m.get("user_id").cloned().unwrap_or_default(),
+                "subject_id": m.get("subject_id").cloned().unwrap_or_default(),
                 "platform": m.get("platform").cloned().unwrap_or_default(),
                 "app_id": m.get("app_id").cloned().unwrap_or_default(),
                 "created_at": m.get("created_at").cloned().unwrap_or_default(),
@@ -204,7 +297,7 @@ pub(crate) fn list_dead_letters(
     let rows = select_rows(
         store,
         cache,
-        PUSH_OUTBOX_TABLE,
+        OUTBOX_TABLE,
         vec![WhereClause::single(
             "state".into(),
             CmpOp::Eq,
@@ -219,7 +312,7 @@ pub(crate) fn list_dead_letters(
             let m: std::collections::HashMap<String, String> = row.into_iter().collect();
             json!({
                 "id": m.get("id").cloned().unwrap_or_default(),
-                "user_id": m.get("user_id").cloned().unwrap_or_default(),
+                "subject_id": m.get("subject_id").cloned().unwrap_or_default(),
                 "app_id": m.get("app_id").cloned().unwrap_or_default(),
                 "platform": m.get("platform").cloned().unwrap_or_default(),
                 "attempts": m.get("attempts").cloned().unwrap_or_default(),
@@ -247,10 +340,11 @@ pub(crate) fn set_apns_credentials(
     environment: &str,
     now: Instant,
 ) -> Result<(), String> {
+    ensure_tables(store, cache, now)?;
     durable_table_delete_where(
         store,
         cache,
-        PUSH_CREDENTIALS_TABLE,
+        CREDENTIALS_TABLE,
         &["app_id", "=", app_id],
         now,
     )?;
@@ -258,7 +352,7 @@ pub(crate) fn set_apns_credentials(
     durable_table_insert(
         store,
         cache,
-        PUSH_CREDENTIALS_TABLE,
+        CREDENTIALS_TABLE,
         &[
             ("app_id", app_id),
             ("platform", "ios"),
@@ -280,7 +374,7 @@ pub(crate) fn get_apns_credentials(
     app_id: &str,
     now: Instant,
 ) -> Result<Option<ResolvedApnsCreds>, String> {
-    let Some(row) = find_row_by_field(store, cache, PUSH_CREDENTIALS_TABLE, "app_id", app_id, now)?
+    let Some(row) = find_row_by_field(store, cache, CREDENTIALS_TABLE, "app_id", app_id, now)?
     else {
         return Ok(None);
     };
@@ -300,28 +394,58 @@ pub(crate) fn get_apns_credentials(
 // Send / enqueue
 // ---------------------------------------------------------------------------
 
-/// Fan a notification out to all of `user_id`'s active devices by inserting one
-/// pending outbox row each. Returns the number enqueued. The worker delivers
+/// Fan a notification out to all of `subject_id`'s active devices by inserting
+/// one pending outbox row each. Returns the number enqueued. The worker delivers
 /// asynchronously.
 pub(crate) fn enqueue_send(
     store: &Store,
     cache: &SharedSchemaCache,
-    user_id: &str,
+    subject_id: &str,
     notification: &Value,
     now: Instant,
 ) -> Result<usize, String> {
+    let payload = serde_json::to_string(notification).unwrap_or_else(|_| "{}".to_string());
+    enqueue_to_subject(store, cache, subject_id, &payload, now)
+}
+
+/// Fan a notification out to many subjects in one call. Returns the total number
+/// of device rows enqueued across all subjects.
+pub(crate) fn enqueue_send_many(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    subject_ids: &[&str],
+    notification: &Value,
+    now: Instant,
+) -> Result<usize, String> {
+    let payload = serde_json::to_string(notification).unwrap_or_else(|_| "{}".to_string());
+    let mut total = 0usize;
+    for subject_id in subject_ids {
+        total += enqueue_to_subject(store, cache, subject_id, &payload, now)?;
+    }
+    Ok(total)
+}
+
+/// Insert one pending outbox row per active device of `subject_id`. `payload` is
+/// the already-serialized notification JSON.
+fn enqueue_to_subject(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    subject_id: &str,
+    payload: &str,
+    now: Instant,
+) -> Result<usize, String> {
+    ensure_tables(store, cache, now)?;
     let rows = select_rows(
         store,
         cache,
         DEVICES_TABLE,
         vec![
-            WhereClause::single("user_id".into(), CmpOp::Eq, user_id.into()),
+            WhereClause::single("subject_id".into(), CmpOp::Eq, subject_id.into()),
             WhereClause::single("disabled_at".into(), CmpOp::Eq, "0".into()),
         ],
         None,
         now,
     )?;
-    let payload = serde_json::to_string(notification).unwrap_or_else(|_| "{}".to_string());
     let now_s = unix_seconds().to_string();
     let mut count = 0usize;
     for row in rows {
@@ -334,17 +458,17 @@ pub(crate) fn enqueue_send(
         durable_table_insert(
             store,
             cache,
-            PUSH_OUTBOX_TABLE,
+            OUTBOX_TABLE,
             &[
                 ("id", id.as_str()),
-                ("user_id", user_id),
+                ("subject_id", subject_id),
                 ("app_id", m.get("app_id").map(String::as_str).unwrap_or("")),
                 ("target_token", token.as_str()),
                 (
                     "platform",
                     m.get("platform").map(String::as_str).unwrap_or(""),
                 ),
-                ("payload", payload.as_str()),
+                ("payload", payload),
                 ("attempts", "0"),
                 ("next_attempt_at", now_s.as_str()),
                 ("state", "pending"),
@@ -371,6 +495,12 @@ pub(crate) fn select_rows(
     limit: Option<usize>,
     now: Instant,
 ) -> Result<Vec<Vec<(String, String)>>, String> {
+    // Push tables are created lazily on first write, so a project that has never
+    // used push has no `push.*` tables. Treat a missing table as no rows — this
+    // keeps reads (and the worker's outbox scan) quiet until push is configured.
+    if tables::table_schema(store, cache, table, now).is_err() {
+        return Ok(Vec::new());
+    }
     let plan = SelectPlan {
         table: table.to_string(),
         alias: None,
@@ -422,15 +552,14 @@ pub(crate) fn append_info(out: &mut String) {
 // RESP command: LUX PUSH ...
 // ---------------------------------------------------------------------------
 
-/// `LUX PUSH REGISTER <user_id> <token> <platform> <app_id>`
-/// `LUX PUSH SEND <user_id> <json>`
+/// `LUX PUSH REGISTER <subject_id> <token> <platform> <app_id>`
+/// `LUX PUSH SEND <subject_id> <json>`
 /// `LUX PUSH CRED <app_id> <team_id> <key_id> <topic> <environment> <p8_pem>`
-/// `LUX PUSH DEVICES <user_id>`
+/// `LUX PUSH DEVICES <subject_id>`
 /// `LUX PUSH STATS`
 ///
-/// Operator-level RESP parity for the HTTP surface (device registration also
-/// available over HTTP with a user JWT). Self-logs resolved `TINSERT auth.*`
-/// writes via the durable helpers.
+/// Operator-level RESP parity for the HTTP surface. Self-logs resolved
+/// `TINSERT push.*` writes via the durable helpers.
 pub(crate) fn cmd_push(
     args: &[&[u8]],
     store: &Store,

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -1,0 +1,452 @@
+//! lux push: native push notifications. This module owns the engine-side
+//! delivery pipeline: a per-user device registry (`auth.devices`), per-app push
+//! credentials (`auth.push_credentials`), a durable at-least-once delivery
+//! outbox (`auth.push_outbox`), and the background worker that drains it through
+//! platform `Sink`s. PR1 ships the APNs sink; WebPush/FCM/HTTP plug into the
+//! same `Sink` seam later.
+
+pub(crate) mod apns;
+pub(crate) mod worker;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use bytes::BytesMut;
+use serde_json::{json, Value};
+
+use crate::auth::{
+    durable_table_delete_where, durable_table_insert, durable_table_update_where,
+    find_row_by_field, random_id, unix_seconds, DEVICES_TABLE, PUSH_CREDENTIALS_TABLE,
+    PUSH_OUTBOX_TABLE,
+};
+use crate::resp;
+use crate::store::Store;
+use crate::tables::{self, CmpOp, SelectPlan, SelectResult, SharedSchemaCache, WhereClause};
+use std::time::Instant;
+
+/// Cumulative + gauge counters surfaced through `INFO` so the cloud monitor can
+/// scrape push activity like ops. `devices` is a live gauge; the rest are
+/// monotonic counters.
+pub(crate) struct PushMetrics {
+    pub sends: AtomicU64,
+    pub delivered: AtomicU64,
+    pub failed: AtomicU64,
+    pub devices: AtomicU64,
+}
+
+impl PushMetrics {
+    const fn new() -> Self {
+        Self {
+            sends: AtomicU64::new(0),
+            delivered: AtomicU64::new(0),
+            failed: AtomicU64::new(0),
+            devices: AtomicU64::new(0),
+        }
+    }
+}
+
+static METRICS: PushMetrics = PushMetrics::new();
+
+pub(crate) fn metrics() -> &'static PushMetrics {
+    &METRICS
+}
+
+/// Resolved APNs credentials for one app, ready to build an `ApnsSink`.
+pub(crate) struct ResolvedApnsCreds {
+    pub creds: apns::ApnsCredentials,
+    pub topic: String,
+    pub environment: String,
+}
+
+// ---------------------------------------------------------------------------
+// Device registry
+// ---------------------------------------------------------------------------
+
+/// Register (or refresh) a device token for `user_id`. A token is unique across
+/// the registry: re-registering an existing token re-points it at the current
+/// user and re-activates it rather than duplicating. Returns the device id.
+pub(crate) fn register_device(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    user_id: &str,
+    token: &str,
+    platform: &str,
+    app_id: &str,
+    now: Instant,
+) -> Result<String, String> {
+    let now_s = unix_seconds().to_string();
+    if let Some(existing) = find_row_by_field(store, cache, DEVICES_TABLE, "token", token, now)? {
+        let id = existing.get("id").cloned().unwrap_or_default();
+        durable_table_update_where(
+            store,
+            cache,
+            DEVICES_TABLE,
+            &[
+                ("user_id", user_id),
+                ("platform", platform),
+                ("app_id", app_id),
+                ("last_seen_at", now_s.as_str()),
+                ("disabled_at", "0"),
+            ],
+            &["id", "=", id.as_str()],
+            now,
+        )?;
+        return Ok(id);
+    }
+    let id = random_id("dev");
+    durable_table_insert(
+        store,
+        cache,
+        DEVICES_TABLE,
+        &[
+            ("id", id.as_str()),
+            ("user_id", user_id),
+            ("token", token),
+            ("platform", platform),
+            ("app_id", app_id),
+            ("created_at", now_s.as_str()),
+            ("last_seen_at", now_s.as_str()),
+            ("disabled_at", "0"),
+        ],
+        now,
+    )?;
+    metrics().devices.fetch_add(1, Ordering::Relaxed);
+    Ok(id)
+}
+
+/// List a user's active devices as JSON, omitting the raw token.
+pub(crate) fn list_devices(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    user_id: &str,
+    now: Instant,
+) -> Result<Vec<Value>, String> {
+    let rows = select_rows(
+        store,
+        cache,
+        DEVICES_TABLE,
+        vec![
+            WhereClause::single("user_id".into(), CmpOp::Eq, user_id.into()),
+            WhereClause::single("disabled_at".into(), CmpOp::Eq, "0".into()),
+        ],
+        None,
+        now,
+    )?;
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            let m: std::collections::HashMap<String, String> = row.into_iter().collect();
+            json!({
+                "id": m.get("id").cloned().unwrap_or_default(),
+                "platform": m.get("platform").cloned().unwrap_or_default(),
+                "app_id": m.get("app_id").cloned().unwrap_or_default(),
+                "created_at": m.get("created_at").cloned().unwrap_or_default(),
+                "last_seen_at": m.get("last_seen_at").cloned().unwrap_or_default(),
+            })
+        })
+        .collect())
+}
+
+/// Delete a user's own device by id. Returns whether a row was removed.
+pub(crate) fn delete_device(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    user_id: &str,
+    id: &str,
+    now: Instant,
+) -> Result<bool, String> {
+    let removed = durable_table_delete_where(
+        store,
+        cache,
+        DEVICES_TABLE,
+        &["id", "=", id, "AND", "user_id", "=", user_id],
+        now,
+    )?;
+    if removed > 0 {
+        metrics().devices.fetch_sub(1, Ordering::Relaxed);
+    }
+    Ok(removed > 0)
+}
+
+// ---------------------------------------------------------------------------
+// Credentials
+// ---------------------------------------------------------------------------
+
+/// Upsert an app's APNs credentials (operator only). Replaces any existing row.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn set_apns_credentials(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    app_id: &str,
+    team_id: &str,
+    key_id: &str,
+    p8_pem: &str,
+    topic: &str,
+    environment: &str,
+    now: Instant,
+) -> Result<(), String> {
+    durable_table_delete_where(
+        store,
+        cache,
+        PUSH_CREDENTIALS_TABLE,
+        &["app_id", "=", app_id],
+        now,
+    )?;
+    let now_s = unix_seconds().to_string();
+    durable_table_insert(
+        store,
+        cache,
+        PUSH_CREDENTIALS_TABLE,
+        &[
+            ("app_id", app_id),
+            ("platform", "ios"),
+            ("apns_team_id", team_id),
+            ("apns_key_id", key_id),
+            ("apns_p8_pem", p8_pem),
+            ("apns_topic", topic),
+            ("environment", environment),
+            ("created_at", now_s.as_str()),
+        ],
+        now,
+    )?;
+    Ok(())
+}
+
+pub(crate) fn get_apns_credentials(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    app_id: &str,
+    now: Instant,
+) -> Result<Option<ResolvedApnsCreds>, String> {
+    let Some(row) = find_row_by_field(store, cache, PUSH_CREDENTIALS_TABLE, "app_id", app_id, now)?
+    else {
+        return Ok(None);
+    };
+    let get = |k: &str| row.get(k).cloned().unwrap_or_default();
+    Ok(Some(ResolvedApnsCreds {
+        creds: apns::ApnsCredentials {
+            team_id: get("apns_team_id"),
+            key_id: get("apns_key_id"),
+            p8_pem: get("apns_p8_pem"),
+        },
+        topic: get("apns_topic"),
+        environment: get("environment"),
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Send / enqueue
+// ---------------------------------------------------------------------------
+
+/// Fan a notification out to all of `user_id`'s active devices by inserting one
+/// pending outbox row each. Returns the number enqueued. The worker delivers
+/// asynchronously.
+pub(crate) fn enqueue_send(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    user_id: &str,
+    notification: &Value,
+    now: Instant,
+) -> Result<usize, String> {
+    let rows = select_rows(
+        store,
+        cache,
+        DEVICES_TABLE,
+        vec![
+            WhereClause::single("user_id".into(), CmpOp::Eq, user_id.into()),
+            WhereClause::single("disabled_at".into(), CmpOp::Eq, "0".into()),
+        ],
+        None,
+        now,
+    )?;
+    let payload = serde_json::to_string(notification).unwrap_or_else(|_| "{}".to_string());
+    let now_s = unix_seconds().to_string();
+    let mut count = 0usize;
+    for row in rows {
+        let m: std::collections::HashMap<String, String> = row.into_iter().collect();
+        let token = m.get("token").cloned().unwrap_or_default();
+        if token.is_empty() {
+            continue;
+        }
+        let id = random_id("out");
+        durable_table_insert(
+            store,
+            cache,
+            PUSH_OUTBOX_TABLE,
+            &[
+                ("id", id.as_str()),
+                ("user_id", user_id),
+                ("app_id", m.get("app_id").map(String::as_str).unwrap_or("")),
+                ("target_token", token.as_str()),
+                (
+                    "platform",
+                    m.get("platform").map(String::as_str).unwrap_or(""),
+                ),
+                ("payload", payload.as_str()),
+                ("attempts", "0"),
+                ("next_attempt_at", now_s.as_str()),
+                ("state", "pending"),
+                ("last_error", ""),
+                ("created_at", now_s.as_str()),
+            ],
+            now,
+        )?;
+        count += 1;
+    }
+    metrics().sends.fetch_add(count as u64, Ordering::Relaxed);
+    Ok(count)
+}
+
+// ---------------------------------------------------------------------------
+// Shared select helper
+// ---------------------------------------------------------------------------
+
+pub(crate) fn select_rows(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    table: &str,
+    conditions: Vec<WhereClause>,
+    limit: Option<usize>,
+    now: Instant,
+) -> Result<Vec<Vec<(String, String)>>, String> {
+    let plan = SelectPlan {
+        table: table.to_string(),
+        alias: None,
+        projections: Vec::new(),
+        aggregates: Vec::new(),
+        joins: Vec::new(),
+        conditions,
+        group_by: Vec::new(),
+        having: Vec::new(),
+        near: None,
+        order_by: None,
+        limit,
+        offset: None,
+        decrypt_authorized: true,
+    };
+    match tables::table_select(store, cache, &plan, now)? {
+        SelectResult::Rows(rows) => Ok(rows),
+        SelectResult::Aggregate(_) => Ok(Vec::new()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// INFO
+// ---------------------------------------------------------------------------
+
+/// Append the `# Push` INFO block (scraped by the cloud monitor for metering).
+pub(crate) fn append_info(out: &mut String) {
+    let m = metrics();
+    out.push_str("# Push\r\n");
+    out.push_str(&format!(
+        "push_sends_total:{}\r\n",
+        m.sends.load(Ordering::Relaxed)
+    ));
+    out.push_str(&format!(
+        "push_delivered_total:{}\r\n",
+        m.delivered.load(Ordering::Relaxed)
+    ));
+    out.push_str(&format!(
+        "push_failed_total:{}\r\n",
+        m.failed.load(Ordering::Relaxed)
+    ));
+    out.push_str(&format!(
+        "push_devices:{}\r\n",
+        m.devices.load(Ordering::Relaxed)
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// RESP command: LUX PUSH ...
+// ---------------------------------------------------------------------------
+
+/// `LUX PUSH REGISTER <user_id> <token> <platform> <app_id>`
+/// `LUX PUSH SEND <user_id> <json>`
+/// `LUX PUSH CRED <app_id> <team_id> <key_id> <topic> <environment> <p8_pem>`
+/// `LUX PUSH DEVICES <user_id>`
+/// `LUX PUSH STATS`
+///
+/// Operator-level RESP parity for the HTTP surface (device registration also
+/// available over HTTP with a user JWT). Self-logs resolved `TINSERT auth.*`
+/// writes via the durable helpers.
+pub(crate) fn cmd_push(
+    args: &[&[u8]],
+    store: &Store,
+    cache: &SharedSchemaCache,
+    out: &mut BytesMut,
+    now: Instant,
+) {
+    // args[0] = "LUX", args[1] = "PUSH", args[2] = subcommand
+    if args.len() < 3 {
+        resp::write_error(out, "ERR usage: LUX PUSH <subcommand> ...");
+        return;
+    }
+    let sub = String::from_utf8_lossy(args[2]).to_ascii_uppercase();
+    let arg = |i: usize| -> &str {
+        args.get(i)
+            .map(|b| std::str::from_utf8(b).unwrap_or(""))
+            .unwrap_or("")
+    };
+    match sub.as_str() {
+        "REGISTER" if args.len() >= 7 => {
+            match register_device(store, cache, arg(3), arg(4), arg(5), arg(6), now) {
+                Ok(id) => resp::write_bulk(out, &id),
+                Err(e) => resp::write_error(out, &normalize_err(&e)),
+            }
+        }
+        "SEND" if args.len() >= 5 => {
+            let notification: Value = serde_json::from_str(arg(4)).unwrap_or(json!({}));
+            match enqueue_send(store, cache, arg(3), &notification, now) {
+                Ok(n) => resp::write_integer(out, n as i64),
+                Err(e) => resp::write_error(out, &normalize_err(&e)),
+            }
+        }
+        "CRED" if args.len() >= 9 => {
+            match set_apns_credentials(
+                store,
+                cache,
+                arg(3),
+                arg(4),
+                arg(5),
+                arg(7),
+                arg(6),
+                arg(8),
+                now,
+            ) {
+                Ok(()) => resp::write_ok(out),
+                Err(e) => resp::write_error(out, &normalize_err(&e)),
+            }
+        }
+        "DEVICES" if args.len() >= 4 => match list_devices(store, cache, arg(3), now) {
+            Ok(devices) => {
+                let items: Vec<String> = devices.iter().map(|d| d.to_string()).collect();
+                resp::write_bulk_array(out, &items);
+            }
+            Err(e) => resp::write_error(out, &normalize_err(&e)),
+        },
+        "STATS" => {
+            let m = metrics();
+            resp::write_bulk_array(
+                out,
+                &[
+                    "sends".into(),
+                    m.sends.load(Ordering::Relaxed).to_string(),
+                    "delivered".into(),
+                    m.delivered.load(Ordering::Relaxed).to_string(),
+                    "failed".into(),
+                    m.failed.load(Ordering::Relaxed).to_string(),
+                    "devices".into(),
+                    m.devices.load(Ordering::Relaxed).to_string(),
+                ],
+            );
+        }
+        _ => resp::write_error(out, "ERR unknown or malformed LUX PUSH subcommand"),
+    }
+}
+
+fn normalize_err(e: &str) -> String {
+    if e.starts_with("ERR") {
+        e.to_string()
+    } else {
+        format!("ERR {e}")
+    }
+}

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -8,6 +8,7 @@
 //! the APNs sink; WebPush/FCM/HTTP plug into the same `Sink` seam later.
 
 pub(crate) mod apns;
+pub(crate) mod webpush;
 pub(crate) mod worker;
 
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -195,6 +196,16 @@ pub(crate) struct ResolvedApnsCreds {
     pub creds: apns::ApnsCredentials,
     pub topic: String,
     pub environment: String,
+}
+
+/// Resolved VAPID credentials for one app, ready to build a `WebPushSink`.
+pub(crate) struct ResolvedVapidCreds {
+    /// base64url(uncompressed P-256 public key) — the browser `applicationServerKey`.
+    pub public_key: String,
+    /// PKCS8 PEM private key for signing the VAPID JWT.
+    pub private_pem: String,
+    /// `mailto:` or URL contact, per RFC 8292.
+    pub subject: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -391,7 +402,37 @@ pub(crate) fn list_dead_letters(
 // Credentials
 // ---------------------------------------------------------------------------
 
-/// Upsert an app's APNs credentials (operator only). Replaces any existing row.
+/// Upsert a subset of fields on the per-app credential row, preserving the rest.
+/// APNs and Web Push (VAPID) credentials share one row per `app_id`, so setting
+/// one must not clobber the other.
+fn upsert_credential_fields(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    app_id: &str,
+    fields: &[(&str, &str)],
+    now: Instant,
+) -> Result<(), String> {
+    ensure_tables(store, cache, now)?;
+    if find_row_by_field(store, cache, CREDENTIALS_TABLE, "app_id", app_id, now)?.is_some() {
+        durable_table_update_where(
+            store,
+            cache,
+            CREDENTIALS_TABLE,
+            fields,
+            &["app_id", "=", app_id],
+            now,
+        )?;
+    } else {
+        let now_s = unix_seconds().to_string();
+        let mut insert: Vec<(&str, &str)> =
+            vec![("app_id", app_id), ("created_at", now_s.as_str())];
+        insert.extend_from_slice(fields);
+        durable_table_insert(store, cache, CREDENTIALS_TABLE, &insert, now)?;
+    }
+    Ok(())
+}
+
+/// Upsert an app's APNs credentials (operator only). Preserves any VAPID creds.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn set_apns_credentials(
     store: &Store,
@@ -404,32 +445,75 @@ pub(crate) fn set_apns_credentials(
     environment: &str,
     now: Instant,
 ) -> Result<(), String> {
-    ensure_tables(store, cache, now)?;
-    durable_table_delete_where(
+    upsert_credential_fields(
         store,
         cache,
-        CREDENTIALS_TABLE,
-        &["app_id", "=", app_id],
-        now,
-    )?;
-    let now_s = unix_seconds().to_string();
-    durable_table_insert(
-        store,
-        cache,
-        CREDENTIALS_TABLE,
+        app_id,
         &[
-            ("app_id", app_id),
-            ("platform", "ios"),
             ("apns_team_id", team_id),
             ("apns_key_id", key_id),
             ("apns_p8_pem", p8_pem),
             ("apns_topic", topic),
             ("environment", environment),
-            ("created_at", now_s.as_str()),
         ],
         now,
-    )?;
-    Ok(())
+    )
+}
+
+/// Upsert an app's Web Push (VAPID) credentials (operator only). Preserves APNs.
+pub(crate) fn set_vapid_credentials(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    app_id: &str,
+    public_key: &str,
+    private_pem: &str,
+    subject: &str,
+    now: Instant,
+) -> Result<(), String> {
+    upsert_credential_fields(
+        store,
+        cache,
+        app_id,
+        &[
+            ("vapid_public", public_key),
+            ("vapid_private", private_pem),
+            ("vapid_subject", subject),
+        ],
+        now,
+    )
+}
+
+pub(crate) fn get_vapid_credentials(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    app_id: &str,
+    now: Instant,
+) -> Result<Option<ResolvedVapidCreds>, String> {
+    let Some(row) = find_row_by_field(store, cache, CREDENTIALS_TABLE, "app_id", app_id, now)?
+    else {
+        return Ok(None);
+    };
+    let get = |k: &str| row.get(k).cloned().unwrap_or_default();
+    let public_key = get("vapid_public");
+    let private_pem = get("vapid_private");
+    if public_key.is_empty() || private_pem.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(ResolvedVapidCreds {
+        public_key,
+        private_pem,
+        subject: get("vapid_subject"),
+    }))
+}
+
+/// The public VAPID key for an app, if configured (safe to expose to browsers).
+pub(crate) fn vapid_public_key(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    app_id: &str,
+    now: Instant,
+) -> Result<Option<String>, String> {
+    Ok(get_vapid_credentials(store, cache, app_id, now)?.map(|c| c.public_key))
 }
 
 pub(crate) fn get_apns_credentials(

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -168,6 +168,69 @@ pub(crate) fn delete_device(
 }
 
 // ---------------------------------------------------------------------------
+// Admin reads (operator) — for the cloud dashboard
+// ---------------------------------------------------------------------------
+
+/// List every device across all users (operator view). Tokens are omitted.
+pub(crate) fn list_all_devices(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    now: Instant,
+) -> Result<Vec<Value>, String> {
+    let rows = select_rows(store, cache, DEVICES_TABLE, Vec::new(), None, now)?;
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            let m: std::collections::HashMap<String, String> = row.into_iter().collect();
+            json!({
+                "id": m.get("id").cloned().unwrap_or_default(),
+                "user_id": m.get("user_id").cloned().unwrap_or_default(),
+                "platform": m.get("platform").cloned().unwrap_or_default(),
+                "app_id": m.get("app_id").cloned().unwrap_or_default(),
+                "created_at": m.get("created_at").cloned().unwrap_or_default(),
+                "last_seen_at": m.get("last_seen_at").cloned().unwrap_or_default(),
+                "disabled_at": m.get("disabled_at").cloned().unwrap_or_default(),
+            })
+        })
+        .collect())
+}
+
+/// List dead-lettered deliveries (operator view). Target tokens are omitted.
+pub(crate) fn list_dead_letters(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    now: Instant,
+) -> Result<Vec<Value>, String> {
+    let rows = select_rows(
+        store,
+        cache,
+        PUSH_OUTBOX_TABLE,
+        vec![WhereClause::single(
+            "state".into(),
+            CmpOp::Eq,
+            "dead".into(),
+        )],
+        Some(200),
+        now,
+    )?;
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            let m: std::collections::HashMap<String, String> = row.into_iter().collect();
+            json!({
+                "id": m.get("id").cloned().unwrap_or_default(),
+                "user_id": m.get("user_id").cloned().unwrap_or_default(),
+                "app_id": m.get("app_id").cloned().unwrap_or_default(),
+                "platform": m.get("platform").cloned().unwrap_or_default(),
+                "attempts": m.get("attempts").cloned().unwrap_or_default(),
+                "last_error": m.get("last_error").cloned().unwrap_or_default(),
+                "created_at": m.get("created_at").cloned().unwrap_or_default(),
+            })
+        })
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
 // Credentials
 // ---------------------------------------------------------------------------
 

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -99,6 +99,70 @@ pub(crate) fn ensure_tables(
     Ok(())
 }
 
+/// One-time migration from the pre-`push.*` layout, where push data lived under
+/// `auth.devices` / `auth.push_credentials` keyed by `user_id`. Copies any such
+/// rows into the `push.*` scope (`user_id` -> `subject_id`). Idempotent (skips
+/// rows already present) and a fast no-op when no legacy tables exist. All data
+/// stays inside the engine — plaintext never leaves the store layer.
+pub(crate) fn migrate_from_auth_scope(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    now: Instant,
+) -> Result<(), String> {
+    let legacy_creds = "auth.push_credentials";
+    let legacy_devices = "auth.devices";
+    let has_legacy = tables::table_schema(store, cache, legacy_creds, now).is_ok()
+        || tables::table_schema(store, cache, legacy_devices, now).is_ok();
+    if !has_legacy {
+        return Ok(());
+    }
+    ensure_tables(store, cache, now)?;
+
+    // Credentials: one row per app_id.
+    for row in select_rows(store, cache, legacy_creds, Vec::new(), None, now)? {
+        let m: std::collections::HashMap<String, String> = row.into_iter().collect();
+        let app_id = m.get("app_id").cloned().unwrap_or_default();
+        if app_id.is_empty()
+            || find_row_by_field(store, cache, CREDENTIALS_TABLE, "app_id", &app_id, now)?.is_some()
+        {
+            continue;
+        }
+        let g = |k: &str| m.get(k).cloned().unwrap_or_default();
+        set_apns_credentials(
+            store,
+            cache,
+            &app_id,
+            &g("apns_team_id"),
+            &g("apns_key_id"),
+            &g("apns_p8_pem"),
+            &g("apns_topic"),
+            &g("environment"),
+            now,
+        )?;
+    }
+
+    // Devices: user_id -> subject_id, re-keyed by token.
+    for row in select_rows(store, cache, legacy_devices, Vec::new(), None, now)? {
+        let m: std::collections::HashMap<String, String> = row.into_iter().collect();
+        let token = m.get("token").cloned().unwrap_or_default();
+        if token.is_empty()
+            || find_row_by_field(store, cache, DEVICES_TABLE, "token", &token, now)?.is_some()
+        {
+            continue;
+        }
+        register_device(
+            store,
+            cache,
+            &m.get("user_id").cloned().unwrap_or_default(),
+            &token,
+            &m.get("platform").cloned().unwrap_or_else(|| "ios".into()),
+            &m.get("app_id").cloned().unwrap_or_else(|| "default".into()),
+            now,
+        )?;
+    }
+    Ok(())
+}
+
 /// Cumulative + gauge counters surfaced through `INFO` so the cloud monitor can
 /// scrape push activity like ops. `devices` is a live gauge; the rest are
 /// monotonic counters.

--- a/src/push/webpush.rs
+++ b/src/push/webpush.rs
@@ -1,0 +1,325 @@
+//! Web Push message encryption (RFC 8291) with the `aes128gcm` content coding
+//! (RFC 8188). This is the wire format browsers' push services require:
+//! ephemeral P-256 ECDH against the subscription key, HKDF-SHA256 to a
+//! content-encryption key + nonce, then a single AES-128-GCM record.
+//!
+//! Validated against the RFC 8291 Appendix A test vector (see tests).
+
+use std::time::Duration;
+
+use base64::Engine as _;
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use p256::ecdh::diffie_hellman;
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::{PublicKey, SecretKey};
+use rand_core::{OsRng, RngCore};
+use ring::{aead, hmac};
+use serde::{Deserialize, Serialize};
+
+use super::apns::{DeliveryError, DeliveryTarget, Sink};
+
+const AUTH_INFO: &[u8] = b"WebPush: info\0";
+const CEK_INFO: &[u8] = b"Content-Encoding: aes128gcm\0";
+const NONCE_INFO: &[u8] = b"Content-Encoding: nonce\0";
+/// Advertised record size in the aes128gcm header. Our payloads are a single
+/// small record; any value larger than the plaintext + 17 works.
+const RECORD_SIZE: u32 = 4096;
+
+const B64: base64::engine::general_purpose::GeneralPurpose =
+    base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+/// Decode a base64url (no-pad) subscription field.
+pub(crate) fn b64url_decode(s: &str) -> Result<Vec<u8>, String> {
+    B64.decode(s.trim())
+        .map_err(|e| format!("invalid base64url: {e}"))
+}
+
+fn hkdf_extract(salt: &[u8], ikm: &[u8]) -> [u8; 32] {
+    let tag = hmac::sign(&hmac::Key::new(hmac::HMAC_SHA256, salt), ikm);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(tag.as_ref());
+    out
+}
+
+/// Single-block HKDF-Expand (valid for `len <= 32`, which covers all our uses).
+fn hkdf_expand(prk: &[u8], info: &[u8], len: usize) -> Vec<u8> {
+    let key = hmac::Key::new(hmac::HMAC_SHA256, prk);
+    let mut ctx = hmac::Context::with_key(&key);
+    ctx.update(info);
+    ctx.update(&[0x01u8]);
+    ctx.sign().as_ref()[..len].to_vec()
+}
+
+/// Derive the AES-128-GCM content-encryption key + nonce for one message
+/// (RFC 8291 §3.4 combined with RFC 8188 key derivation).
+fn derive_content_keys(
+    ua_public: &[u8],
+    as_public: &[u8],
+    auth_secret: &[u8],
+    salt: &[u8],
+    ecdh_secret: &[u8],
+) -> ([u8; 16], [u8; 12]) {
+    // Combine the shared secret with the auth secret, bound to both public keys.
+    let prk_key = hkdf_extract(auth_secret, ecdh_secret);
+    let mut key_info = Vec::with_capacity(AUTH_INFO.len() + ua_public.len() + as_public.len());
+    key_info.extend_from_slice(AUTH_INFO);
+    key_info.extend_from_slice(ua_public);
+    key_info.extend_from_slice(as_public);
+    let ikm = hkdf_expand(&prk_key, &key_info, 32);
+
+    // Content-encryption key + nonce, salted by the per-message salt.
+    let prk = hkdf_extract(salt, &ikm);
+    let cek: [u8; 16] = hkdf_expand(&prk, CEK_INFO, 16).try_into().unwrap();
+    let nonce: [u8; 12] = hkdf_expand(&prk, NONCE_INFO, 12).try_into().unwrap();
+    (cek, nonce)
+}
+
+/// Encrypt `plaintext` for a subscription with a fixed salt + sender key. The
+/// returned bytes are the full `aes128gcm` message body (header + record), ready
+/// to POST with `Content-Encoding: aes128gcm`. Deterministic — used by the
+/// vector test; production callers use [`seal`].
+fn encrypt_with(
+    plaintext: &[u8],
+    ua_public: &[u8],
+    auth_secret: &[u8],
+    salt: &[u8; 16],
+    as_secret: &SecretKey,
+) -> Result<Vec<u8>, String> {
+    let ua_pk = PublicKey::from_sec1_bytes(ua_public)
+        .map_err(|e| format!("invalid subscription p256dh key: {e}"))?;
+    let as_public_pt = as_secret.public_key().to_encoded_point(false);
+    let as_public = as_public_pt.as_bytes(); // 65-byte uncompressed point
+
+    let shared = diffie_hellman(as_secret.to_nonzero_scalar(), ua_pk.as_affine());
+    let (cek, nonce) = derive_content_keys(
+        ua_public,
+        as_public,
+        auth_secret,
+        salt,
+        shared.raw_secret_bytes(),
+    );
+
+    // Single record: plaintext || 0x02 (last-record delimiter), then AEAD-sealed.
+    let mut record = Vec::with_capacity(plaintext.len() + 1 + 16);
+    record.extend_from_slice(plaintext);
+    record.push(0x02);
+    let unbound = aead::UnboundKey::new(&aead::AES_128_GCM, &cek)
+        .map_err(|_| "aead key init failed".to_string())?;
+    let key = aead::LessSafeKey::new(unbound);
+    key.seal_in_place_append_tag(
+        aead::Nonce::assume_unique_for_key(nonce),
+        aead::Aad::empty(),
+        &mut record,
+    )
+    .map_err(|_| "aead seal failed".to_string())?;
+
+    // Header: salt(16) || record_size(4, BE) || idlen(1) || keyid(=as_public).
+    let mut body = Vec::with_capacity(16 + 4 + 1 + as_public.len() + record.len());
+    body.extend_from_slice(salt);
+    body.extend_from_slice(&RECORD_SIZE.to_be_bytes());
+    body.push(as_public.len() as u8);
+    body.extend_from_slice(as_public);
+    body.extend_from_slice(&record);
+    Ok(body)
+}
+
+/// Encrypt `plaintext` for a subscription, generating a fresh salt + ephemeral
+/// sender key. Returns the `aes128gcm` message body.
+pub(crate) fn seal(
+    plaintext: &[u8],
+    ua_public: &[u8],
+    auth_secret: &[u8],
+) -> Result<Vec<u8>, String> {
+    let as_secret = SecretKey::random(&mut OsRng);
+    let mut salt = [0u8; 16];
+    OsRng.fill_bytes(&mut salt);
+    encrypt_with(plaintext, ua_public, auth_secret, &salt, &as_secret)
+}
+
+// ---------------------------------------------------------------------------
+// WebPushSink — deliver an encrypted message to a browser push service with a
+// VAPID-authenticated POST.
+// ---------------------------------------------------------------------------
+
+/// A browser `PushSubscription`, the "token" for a web device.
+#[derive(Deserialize)]
+struct Subscription {
+    endpoint: String,
+    keys: SubscriptionKeys,
+}
+
+#[derive(Deserialize)]
+struct SubscriptionKeys {
+    /// base64url uncompressed P-256 public key.
+    p256dh: String,
+    /// base64url 16-byte auth secret.
+    auth: String,
+}
+
+#[derive(Serialize)]
+struct VapidClaims {
+    aud: String,
+    exp: u64,
+    sub: String,
+}
+
+pub(crate) struct WebPushSink {
+    client: reqwest::Client,
+    /// base64url public key, sent as the `k=` VAPID parameter.
+    public_key: String,
+    private_pem: String,
+    subject: String,
+}
+
+impl WebPushSink {
+    pub fn new(creds: super::ResolvedVapidCreds) -> Result<Self, String> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .map_err(|e| format!("web push client setup failed: {e}"))?;
+        let subject = if creds.subject.trim().is_empty() {
+            "mailto:push@luxdb.dev".to_string()
+        } else {
+            creds.subject
+        };
+        Ok(Self {
+            client,
+            public_key: creds.public_key,
+            private_pem: creds.private_pem,
+            subject,
+        })
+    }
+
+    /// Sign a VAPID JWT (RFC 8292) scoped to the push service origin.
+    fn vapid_jwt(&self, endpoint: &str) -> Result<String, DeliveryError> {
+        let aud = origin_of(endpoint)
+            .ok_or_else(|| DeliveryError::Terminal(format!("bad push endpoint: {endpoint}")))?;
+        let claims = VapidClaims {
+            aud,
+            exp: crate::auth::unix_seconds() + 12 * 3600,
+            sub: self.subject.clone(),
+        };
+        let key = EncodingKey::from_ec_pem(self.private_pem.as_bytes())
+            .map_err(|e| DeliveryError::Terminal(format!("invalid VAPID key: {e}")))?;
+        encode(&Header::new(Algorithm::ES256), &claims, &key)
+            .map_err(|e| DeliveryError::Terminal(format!("VAPID JWT sign failed: {e}")))
+    }
+}
+
+impl Sink for WebPushSink {
+    async fn deliver(&self, target: &DeliveryTarget, payload: &[u8]) -> Result<(), DeliveryError> {
+        // The web "token" is the serialized browser PushSubscription.
+        let sub: Subscription = serde_json::from_str(&target.token)
+            .map_err(|e| DeliveryError::Terminal(format!("invalid web push subscription: {e}")))?;
+        let p256dh = b64url_decode(&sub.keys.p256dh).map_err(DeliveryError::Terminal)?;
+        let auth = b64url_decode(&sub.keys.auth).map_err(DeliveryError::Terminal)?;
+        let body = seal(payload, &p256dh, &auth).map_err(DeliveryError::Terminal)?;
+        let jwt = self.vapid_jwt(&sub.endpoint)?;
+
+        let resp = self
+            .client
+            .post(&sub.endpoint)
+            .header("Content-Encoding", "aes128gcm")
+            .header("Content-Type", "application/octet-stream")
+            .header("TTL", "86400")
+            .header(
+                "Authorization",
+                format!("vapid t={jwt}, k={}", self.public_key),
+            )
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| DeliveryError::Retryable(format!("web push transport: {e}")))?;
+        classify_web_push(resp.status().as_u16())
+    }
+}
+
+/// Push-service response classification. 404/410 mean the subscription is gone
+/// (prune it); 429/5xx are retryable.
+fn classify_web_push(status: u16) -> Result<(), DeliveryError> {
+    match status {
+        200..=202 => Ok(()),
+        404 | 410 => Err(DeliveryError::Terminal(format!(
+            "subscription gone ({status})"
+        ))),
+        400 | 401 | 403 => Err(DeliveryError::Terminal(format!("rejected ({status})"))),
+        429 => Err(DeliveryError::Retryable("throttled".to_string())),
+        500..=599 => Err(DeliveryError::Retryable(format!(
+            "push service error ({status})"
+        ))),
+        other => Err(DeliveryError::Retryable(format!(
+            "unexpected push status {other}"
+        ))),
+    }
+}
+
+/// `scheme://host[:port]` of a URL (the VAPID audience).
+fn origin_of(url: &str) -> Option<String> {
+    let scheme_end = url.find("://")?;
+    let rest = &url[scheme_end + 3..];
+    let host_len = rest.find('/').unwrap_or(rest.len());
+    Some(format!("{}://{}", &url[..scheme_end], &rest[..host_len]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // RFC 8291 Appendix A.
+    const PLAINTEXT: &str = "V2hlbiBJIGdyb3cgdXAsIEkgd2FudCB0byBiZSBhIHdhdGVybWVsb24";
+    const SALT: &str = "DGv6ra1nlYgDCS1FRnbzlw";
+    const AUTH: &str = "BTBZMqHH6r4Tts7J_aSIgg";
+    const UA_PUBLIC: &str =
+        "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
+    const AS_PRIVATE: &str = "yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw";
+    const SHARED: &str = "kyrL1jIIOHEzg3sM2ZWRHDRB62YACZhhSlknJ672kSs";
+    const CEK: &str = "oIhVW04MRdy2XN9CiKLxTg";
+    const NONCE: &str = "4h_95klXJ5E_qnoN";
+    const CIPHERTEXT: &str =
+        "8pfeW0KbunFT06SuDKoJH9Ql87S1QUrdirN6GcG7sFz1y1sqLgVi1VhjVkHsUoEsbI_0LpXMuGvnzQ";
+
+    fn enc(b: &[u8]) -> String {
+        B64.encode(b)
+    }
+
+    #[test]
+    fn rfc8291_appendix_a_vector() {
+        let plaintext = b64url_decode(PLAINTEXT).unwrap();
+        let salt: [u8; 16] = b64url_decode(SALT).unwrap().try_into().unwrap();
+        let auth = b64url_decode(AUTH).unwrap();
+        let ua_public = b64url_decode(UA_PUBLIC).unwrap();
+        let as_secret = SecretKey::from_slice(&b64url_decode(AS_PRIVATE).unwrap()).unwrap();
+
+        // ECDH shared secret matches the RFC.
+        let ua_pk = PublicKey::from_sec1_bytes(&ua_public).unwrap();
+        let shared = diffie_hellman(as_secret.to_nonzero_scalar(), ua_pk.as_affine());
+        assert_eq!(enc(shared.raw_secret_bytes()), SHARED, "ecdh secret");
+
+        // Derived CEK + nonce match the RFC.
+        let as_public_pt = as_secret.public_key().to_encoded_point(false);
+        let (cek, nonce) = derive_content_keys(
+            &ua_public,
+            as_public_pt.as_bytes(),
+            &auth,
+            &salt,
+            shared.raw_secret_bytes(),
+        );
+        assert_eq!(enc(&cek), CEK, "content encryption key");
+        assert_eq!(enc(&nonce), NONCE, "nonce");
+
+        // Full ciphertext (record after the header) matches the RFC.
+        let body = encrypt_with(&plaintext, &ua_public, &auth, &salt, &as_secret).unwrap();
+        let header_len = 16 + 4 + 1 + as_public_pt.as_bytes().len();
+        assert_eq!(enc(&body[header_len..]), CIPHERTEXT, "aes128gcm ciphertext");
+    }
+
+    #[test]
+    fn seal_produces_a_wellformed_body() {
+        let ua_public = b64url_decode(UA_PUBLIC).unwrap();
+        let auth = b64url_decode(AUTH).unwrap();
+        let body = seal(b"hello", &ua_public, &auth).unwrap();
+        // header = salt(16) + rs(4) + idlen(1) + keyid(65); record = 5 + 1 + 16 tag.
+        assert_eq!(body.len(), 16 + 4 + 1 + 65 + (5 + 1 + 16));
+        assert_eq!(body[16 + 4], 65, "keyid length byte");
+    }
+}

--- a/src/push/worker.rs
+++ b/src/push/worker.rs
@@ -1,0 +1,321 @@
+//! Delivery worker: drains the durable `auth.push_outbox` and delivers each
+//! pending row through the platform sink, applying at-least-once retry/backoff,
+//! dead-lettering, and dead-token pruning. All state transitions go through the
+//! durable table helpers so they are WAL-logged and survive restart.
+
+use std::collections::HashMap;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::auth::{durable_table_delete_where, durable_table_update_where, unix_seconds};
+use crate::auth::{DEVICES_TABLE, PUSH_OUTBOX_TABLE};
+use crate::store::Store;
+use crate::tables::{CmpOp, SharedSchemaCache, WhereClause};
+
+use super::apns::{ApnsSink, DeliveryError, DeliveryTarget, Sink};
+use super::{get_apns_credentials, metrics, select_rows};
+
+const TICK: Duration = Duration::from_millis(500);
+const BATCH: usize = 100;
+const MAX_ATTEMPTS: i64 = 6;
+const BACKOFF_BASE_SECS: u64 = 30;
+const BACKOFF_CAP_SECS: u64 = 3600;
+
+/// Exponential backoff for the `n`-th attempt (1-indexed), capped at 1h.
+fn backoff_secs(n: i64) -> u64 {
+    let shift = (n.max(1) - 1).min(20) as u32;
+    (BACKOFF_BASE_SECS.saturating_mul(1u64 << shift)).min(BACKOFF_CAP_SECS)
+}
+
+/// The state transition for one delivery attempt. Pure and unit-tested; the
+/// worker applies it via durable writes.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Action {
+    Delivered,
+    Retry {
+        attempts: i64,
+        next_at: u64,
+        error: String,
+    },
+    Dead {
+        attempts: i64,
+        error: String,
+    },
+    DisableDevice {
+        error: String,
+    },
+}
+
+/// Decide what to do with an outbox row given its current attempt count and the
+/// delivery result. Terminal errors prune the device; retryable errors back off
+/// until `MAX_ATTEMPTS`, then dead-letter.
+pub(crate) fn decide(attempts: i64, result: Result<(), DeliveryError>, now_secs: u64) -> Action {
+    match result {
+        Ok(()) => Action::Delivered,
+        Err(e) if e.is_terminal() => Action::DisableDevice {
+            error: e.message().to_string(),
+        },
+        Err(e) => {
+            let n = attempts + 1;
+            if n >= MAX_ATTEMPTS {
+                Action::Dead {
+                    attempts: n,
+                    error: e.message().to_string(),
+                }
+            } else {
+                Action::Retry {
+                    attempts: n,
+                    next_at: now_secs + backoff_secs(n),
+                    error: e.message().to_string(),
+                }
+            }
+        }
+    }
+}
+
+struct AppSink {
+    sink: ApnsSink,
+    topic: String,
+}
+
+/// Spawned once in `Runtime::start`. Loops forever, delivering pending rows.
+pub(crate) async fn run_delivery_worker(store: Arc<Store>, cache: SharedSchemaCache) {
+    let mut sinks: HashMap<String, Arc<AppSink>> = HashMap::new();
+    let mut ticker = tokio::time::interval(TICK);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        ticker.tick().await;
+        if let Err(e) = process_pending(&store, &cache, &mut sinks).await {
+            eprintln!("push delivery worker error: {e}");
+        }
+    }
+}
+
+async fn process_pending(
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+    sinks: &mut HashMap<String, Arc<AppSink>>,
+) -> Result<(), String> {
+    let now = Instant::now();
+    let now_secs = unix_seconds();
+    let rows = select_rows(
+        store,
+        cache,
+        PUSH_OUTBOX_TABLE,
+        vec![
+            WhereClause::single("state".into(), CmpOp::Eq, "pending".into()),
+            WhereClause::single("next_attempt_at".into(), CmpOp::Le, now_secs.to_string()),
+        ],
+        Some(BATCH),
+        now,
+    )?;
+
+    for row in rows {
+        let m: HashMap<String, String> = row.into_iter().collect();
+        let id = m.get("id").cloned().unwrap_or_default();
+        let token = m.get("target_token").cloned().unwrap_or_default();
+        let app_id = m.get("app_id").cloned().unwrap_or_default();
+        let payload = m.get("payload").cloned().unwrap_or_default();
+        let attempts: i64 = m.get("attempts").and_then(|a| a.parse().ok()).unwrap_or(0);
+        if id.is_empty() {
+            continue;
+        }
+
+        let app_sink = match resolve_sink(store, cache, sinks, &app_id, now) {
+            Ok(Some(s)) => s,
+            Ok(None) => {
+                apply(
+                    store,
+                    cache,
+                    &Action::Dead {
+                        attempts,
+                        error: format!("no push credentials for app '{app_id}'"),
+                    },
+                    &id,
+                    &token,
+                    now,
+                )?;
+                continue;
+            }
+            Err(e) => {
+                apply(
+                    store,
+                    cache,
+                    &Action::Dead { attempts, error: e },
+                    &id,
+                    &token,
+                    now,
+                )?;
+                continue;
+            }
+        };
+
+        let target = DeliveryTarget {
+            token: token.clone(),
+            topic: app_sink.topic.clone(),
+        };
+        let result = app_sink.sink.deliver(&target, payload.as_bytes()).await;
+        let action = decide(attempts, result, unix_seconds());
+        apply(store, cache, &action, &id, &token, now)?;
+    }
+    Ok(())
+}
+
+/// Build (or reuse a cached) sink for an app from its stored credentials.
+/// `Ok(None)` means no credentials are configured; `Err` means the credential
+/// material is unusable (bad `.p8`) and the row should dead-letter.
+fn resolve_sink(
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+    sinks: &mut HashMap<String, Arc<AppSink>>,
+    app_id: &str,
+    now: Instant,
+) -> Result<Option<Arc<AppSink>>, String> {
+    if let Some(existing) = sinks.get(app_id) {
+        return Ok(Some(existing.clone()));
+    }
+    let Some(resolved) = get_apns_credentials(store, cache, app_id, now)? else {
+        return Ok(None);
+    };
+    let base_url = ApnsSink::resolve_base_url(&resolved.environment);
+    let sink = ApnsSink::new(base_url, resolved.creds)?;
+    let app_sink = Arc::new(AppSink {
+        sink,
+        topic: resolved.topic,
+    });
+    sinks.insert(app_id.to_string(), app_sink.clone());
+    Ok(Some(app_sink))
+}
+
+fn apply(
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+    action: &Action,
+    id: &str,
+    token: &str,
+    now: Instant,
+) -> Result<(), String> {
+    match action {
+        Action::Delivered => {
+            durable_table_delete_where(store, cache, PUSH_OUTBOX_TABLE, &["id", "=", id], now)?;
+            metrics().delivered.fetch_add(1, Ordering::Relaxed);
+        }
+        Action::Retry {
+            attempts,
+            next_at,
+            error,
+        } => {
+            let attempts_s = attempts.to_string();
+            let next_s = next_at.to_string();
+            durable_table_update_where(
+                store,
+                cache,
+                PUSH_OUTBOX_TABLE,
+                &[
+                    ("attempts", attempts_s.as_str()),
+                    ("next_attempt_at", next_s.as_str()),
+                    ("last_error", error.as_str()),
+                ],
+                &["id", "=", id],
+                now,
+            )?;
+        }
+        Action::Dead { attempts, error } => {
+            let attempts_s = attempts.to_string();
+            durable_table_update_where(
+                store,
+                cache,
+                PUSH_OUTBOX_TABLE,
+                &[
+                    ("state", "dead"),
+                    ("attempts", attempts_s.as_str()),
+                    ("last_error", error.as_str()),
+                ],
+                &["id", "=", id],
+                now,
+            )?;
+            metrics().failed.fetch_add(1, Ordering::Relaxed);
+        }
+        Action::DisableDevice { error } => {
+            let now_s = unix_seconds().to_string();
+            durable_table_update_where(
+                store,
+                cache,
+                DEVICES_TABLE,
+                &[("disabled_at", now_s.as_str())],
+                &["token", "=", token],
+                now,
+            )?;
+            durable_table_update_where(
+                store,
+                cache,
+                PUSH_OUTBOX_TABLE,
+                &[("state", "dead"), ("last_error", error.as_str())],
+                &["id", "=", id],
+                now,
+            )?;
+            metrics().failed.fetch_add(1, Ordering::Relaxed);
+            // Best-effort gauge: a pruned device is no longer active.
+            let m = metrics();
+            let cur = m.devices.load(Ordering::Relaxed);
+            if cur > 0 {
+                m.devices.fetch_sub(1, Ordering::Relaxed);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_is_exponential_and_capped() {
+        assert_eq!(backoff_secs(1), 30);
+        assert_eq!(backoff_secs(2), 60);
+        assert_eq!(backoff_secs(3), 120);
+        assert_eq!(backoff_secs(4), 240);
+        assert!(backoff_secs(20) <= BACKOFF_CAP_SECS);
+    }
+
+    #[test]
+    fn ok_delivers() {
+        assert_eq!(decide(0, Ok(()), 1000), Action::Delivered);
+    }
+
+    #[test]
+    fn terminal_disables_device() {
+        let action = decide(0, Err(DeliveryError::Terminal("unregistered".into())), 1000);
+        assert_eq!(
+            action,
+            Action::DisableDevice {
+                error: "unregistered".into()
+            }
+        );
+    }
+
+    #[test]
+    fn retryable_backs_off_then_dead() {
+        // Early attempt: schedule a retry with backoff.
+        match decide(0, Err(DeliveryError::Retryable("503".into())), 1000) {
+            Action::Retry {
+                attempts, next_at, ..
+            } => {
+                assert_eq!(attempts, 1);
+                assert_eq!(next_at, 1000 + 30);
+            }
+            other => panic!("expected retry, got {other:?}"),
+        }
+        // At the cap: dead-letter instead of retrying forever.
+        match decide(
+            MAX_ATTEMPTS - 1,
+            Err(DeliveryError::Retryable("503".into())),
+            1000,
+        ) {
+            Action::Dead { attempts, .. } => assert_eq!(attempts, MAX_ATTEMPTS),
+            other => panic!("expected dead, got {other:?}"),
+        }
+    }
+}

--- a/src/push/worker.rs
+++ b/src/push/worker.rs
@@ -13,7 +13,10 @@ use crate::store::Store;
 use crate::tables::{CmpOp, SharedSchemaCache, WhereClause};
 
 use super::apns::{ApnsSink, DeliveryError, DeliveryTarget, Sink};
-use super::{get_apns_credentials, metrics, select_rows, DEVICES_TABLE, OUTBOX_TABLE};
+use super::webpush::WebPushSink;
+use super::{
+    get_apns_credentials, get_vapid_credentials, metrics, select_rows, DEVICES_TABLE, OUTBOX_TABLE,
+};
 
 const TICK: Duration = Duration::from_millis(500);
 const BATCH: usize = 100;
@@ -73,9 +76,11 @@ pub(crate) fn decide(attempts: i64, result: Result<(), DeliveryError>, now_secs:
     }
 }
 
-struct AppSink {
-    sink: ApnsSink,
-    topic: String,
+/// A per-(app, platform) delivery sink. The trait uses RPITIT so it isn't
+/// object-safe; an enum lets the worker hold either concrete sink.
+enum AppSink {
+    Apns { sink: ApnsSink, topic: String },
+    Web(WebPushSink),
 }
 
 /// Spawned once in `Runtime::start`. Loops forever, delivering pending rows.
@@ -115,13 +120,17 @@ async fn process_pending(
         let id = m.get("id").cloned().unwrap_or_default();
         let token = m.get("target_token").cloned().unwrap_or_default();
         let app_id = m.get("app_id").cloned().unwrap_or_default();
+        let platform = m
+            .get("platform")
+            .cloned()
+            .unwrap_or_else(|| "ios".to_string());
         let payload = m.get("payload").cloned().unwrap_or_default();
         let attempts: i64 = m.get("attempts").and_then(|a| a.parse().ok()).unwrap_or(0);
         if id.is_empty() {
             continue;
         }
 
-        let app_sink = match resolve_sink(store, cache, sinks, &app_id, now) {
+        let app_sink = match resolve_sink(store, cache, sinks, &app_id, &platform, now) {
             Ok(Some(s)) => s,
             Ok(None) => {
                 apply(
@@ -150,11 +159,23 @@ async fn process_pending(
             }
         };
 
-        let target = DeliveryTarget {
-            token: token.clone(),
-            topic: app_sink.topic.clone(),
+        let result = match &*app_sink {
+            AppSink::Apns { sink, topic } => {
+                let target = DeliveryTarget {
+                    token: token.clone(),
+                    topic: topic.clone(),
+                };
+                sink.deliver(&target, payload.as_bytes()).await
+            }
+            AppSink::Web(sink) => {
+                // The web token is the subscription JSON; topic is unused.
+                let target = DeliveryTarget {
+                    token: token.clone(),
+                    topic: String::new(),
+                };
+                sink.deliver(&target, payload.as_bytes()).await
+            }
         };
-        let result = app_sink.sink.deliver(&target, payload.as_bytes()).await;
         let action = decide(attempts, result, unix_seconds());
         apply(store, cache, &action, &id, &token, now)?;
     }
@@ -169,21 +190,33 @@ fn resolve_sink(
     cache: &SharedSchemaCache,
     sinks: &mut HashMap<String, Arc<AppSink>>,
     app_id: &str,
+    platform: &str,
     now: Instant,
 ) -> Result<Option<Arc<AppSink>>, String> {
-    if let Some(existing) = sinks.get(app_id) {
+    let cache_key = format!("{app_id}:{platform}");
+    if let Some(existing) = sinks.get(&cache_key) {
         return Ok(Some(existing.clone()));
     }
-    let Some(resolved) = get_apns_credentials(store, cache, app_id, now)? else {
-        return Ok(None);
+    let app_sink = match platform {
+        "web" | "desktop" => {
+            let Some(vapid) = get_vapid_credentials(store, cache, app_id, now)? else {
+                return Ok(None);
+            };
+            AppSink::Web(WebPushSink::new(vapid)?)
+        }
+        _ => {
+            let Some(resolved) = get_apns_credentials(store, cache, app_id, now)? else {
+                return Ok(None);
+            };
+            let base_url = ApnsSink::resolve_base_url(&resolved.environment);
+            AppSink::Apns {
+                sink: ApnsSink::new(base_url, resolved.creds)?,
+                topic: resolved.topic,
+            }
+        }
     };
-    let base_url = ApnsSink::resolve_base_url(&resolved.environment);
-    let sink = ApnsSink::new(base_url, resolved.creds)?;
-    let app_sink = Arc::new(AppSink {
-        sink,
-        topic: resolved.topic,
-    });
-    sinks.insert(app_id.to_string(), app_sink.clone());
+    let app_sink = Arc::new(app_sink);
+    sinks.insert(cache_key, app_sink.clone());
     Ok(Some(app_sink))
 }
 

--- a/src/push/worker.rs
+++ b/src/push/worker.rs
@@ -1,4 +1,4 @@
-//! Delivery worker: drains the durable `auth.push_outbox` and delivers each
+//! Delivery worker: drains the durable `push.outbox` and delivers each
 //! pending row through the platform sink, applying at-least-once retry/backoff,
 //! dead-lettering, and dead-token pruning. All state transitions go through the
 //! durable table helpers so they are WAL-logged and survive restart.
@@ -9,12 +9,11 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::auth::{durable_table_delete_where, durable_table_update_where, unix_seconds};
-use crate::auth::{DEVICES_TABLE, PUSH_OUTBOX_TABLE};
 use crate::store::Store;
 use crate::tables::{CmpOp, SharedSchemaCache, WhereClause};
 
 use super::apns::{ApnsSink, DeliveryError, DeliveryTarget, Sink};
-use super::{get_apns_credentials, metrics, select_rows};
+use super::{get_apns_credentials, metrics, select_rows, DEVICES_TABLE, OUTBOX_TABLE};
 
 const TICK: Duration = Duration::from_millis(500);
 const BATCH: usize = 100;
@@ -102,7 +101,7 @@ async fn process_pending(
     let rows = select_rows(
         store,
         cache,
-        PUSH_OUTBOX_TABLE,
+        OUTBOX_TABLE,
         vec![
             WhereClause::single("state".into(), CmpOp::Eq, "pending".into()),
             WhereClause::single("next_attempt_at".into(), CmpOp::Le, now_secs.to_string()),
@@ -198,7 +197,7 @@ fn apply(
 ) -> Result<(), String> {
     match action {
         Action::Delivered => {
-            durable_table_delete_where(store, cache, PUSH_OUTBOX_TABLE, &["id", "=", id], now)?;
+            durable_table_delete_where(store, cache, OUTBOX_TABLE, &["id", "=", id], now)?;
             metrics().delivered.fetch_add(1, Ordering::Relaxed);
         }
         Action::Retry {
@@ -211,7 +210,7 @@ fn apply(
             durable_table_update_where(
                 store,
                 cache,
-                PUSH_OUTBOX_TABLE,
+                OUTBOX_TABLE,
                 &[
                     ("attempts", attempts_s.as_str()),
                     ("next_attempt_at", next_s.as_str()),
@@ -226,7 +225,7 @@ fn apply(
             durable_table_update_where(
                 store,
                 cache,
-                PUSH_OUTBOX_TABLE,
+                OUTBOX_TABLE,
                 &[
                     ("state", "dead"),
                     ("attempts", attempts_s.as_str()),
@@ -250,7 +249,7 @@ fn apply(
             durable_table_update_where(
                 store,
                 cache,
-                PUSH_OUTBOX_TABLE,
+                OUTBOX_TABLE,
                 &[("state", "dead"), ("last_error", error.as_str())],
                 &["id", "=", id],
                 now,

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -1,0 +1,518 @@
+//! Integration tests for lux push (engine PR1): device registry, reserved-table
+//! guards, durable outbox delivery through a mock APNs server, dead-token
+//! pruning, and WAL-replay durability.
+
+mod common;
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::Child;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value};
+
+// ── engine harness ─────────────────────────────────────────────────────────
+
+struct PushServer {
+    child: Child,
+    dir: std::path::PathBuf,
+    keep_dir: bool,
+}
+
+impl Drop for PushServer {
+    fn drop(&mut self) {
+        common::terminate_child(&mut self.child);
+        if !self.keep_dir {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+}
+
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn start(dir: &std::path::Path, resp_port: u16, http_port: u16, keep_dir: bool) -> PushServer {
+    let bin = common::find_lux_binary();
+    std::fs::create_dir_all(dir).unwrap();
+    let mut cmd = common::lux_command(&bin);
+    cmd.env("LUX_PORT", resp_port.to_string())
+        .env("LUX_HTTP_PORT", http_port.to_string())
+        .env("LUX_SHARDS", "4")
+        .env("LUX_SAVE_INTERVAL", "0")
+        .env("LUX_DATA_DIR", dir.to_str().unwrap())
+        // Tiered storage enables the WAL, so the registry survives restart.
+        .env("LUX_STORAGE_MODE", "tiered")
+        .env("LUX_STORAGE_DIR", dir.join("storage").to_str().unwrap())
+        .env("LUX_PASSWORD", "rootsecret")
+        .env("LUX_AUTH_ENABLED", "true")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let child = cmd.spawn().expect("spawn lux");
+    let server = PushServer {
+        child,
+        dir: dir.to_path_buf(),
+        keep_dir,
+    };
+    for _ in 0..80 {
+        if TcpStream::connect(("127.0.0.1", http_port)).is_ok()
+            && TcpStream::connect(("127.0.0.1", resp_port)).is_ok()
+        {
+            std::thread::sleep(Duration::from_millis(150));
+            return server;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("lux did not start");
+}
+
+fn http(port: u16, method: &str, path: &str, body: &str, auth: Option<&str>) -> (u16, Value) {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(3)))
+        .unwrap();
+    let auth_header = auth
+        .map(|t| format!("Authorization: Bearer {t}\r\n"))
+        .unwrap_or_default();
+    let req = format!(
+        "{method} {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\n{auth_header}Content-Length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(req.as_bytes()).unwrap();
+    let mut resp = Vec::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                resp.extend_from_slice(&buf[..n]);
+                if let Some(he) = resp.windows(4).position(|w| w == b"\r\n\r\n") {
+                    let headers = String::from_utf8_lossy(&resp[..he]);
+                    if let Some(len) = headers
+                        .lines()
+                        .find(|l| l.to_ascii_lowercase().starts_with("content-length:"))
+                        .and_then(|l| l.split(':').nth(1))
+                        .and_then(|v| v.trim().parse::<usize>().ok())
+                    {
+                        if resp.len() >= he + 4 + len {
+                            break;
+                        }
+                    }
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    let text = String::from_utf8_lossy(&resp);
+    let status = text
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|c| c.parse::<u16>().ok())
+        .unwrap_or(0);
+    let body = text.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
+    (
+        status,
+        serde_json::from_str(body).unwrap_or_else(|_| json!({})),
+    )
+}
+
+fn resp_cmd(port: u16, args: &[&str]) -> String {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(3)))
+        .unwrap();
+    // The push-test engine sets a password; authenticate on the same connection
+    // (pipelined) before the command.
+    let mut req = String::from("*2\r\n$4\r\nAUTH\r\n$10\r\nrootsecret\r\n");
+    req.push_str(&format!("*{}\r\n", args.len()));
+    for a in args {
+        req.push_str(&format!("${}\r\n{}\r\n", a.len(), a));
+    }
+    stream.write_all(req.as_bytes()).unwrap();
+    let mut resp = Vec::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                resp.extend_from_slice(&buf[..n]);
+                if n < buf.len() {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    String::from_utf8_lossy(&resp).to_string()
+}
+
+fn exec(port: u16, command: Value) -> (u16, Value) {
+    http(
+        port,
+        "POST",
+        "/v1/exec",
+        &json!({ "command": command }).to_string(),
+        Some("rootsecret"),
+    )
+}
+
+// ── mock APNs server (HTTP/1.1; reqwest talks cleartext h1 to localhost) ─────
+
+#[derive(Clone, Default)]
+struct Captured {
+    path: String,
+    authorization: String,
+    apns_topic: String,
+    body: String,
+}
+
+struct MockApns {
+    port: u16,
+    requests: Arc<Mutex<Vec<Captured>>>,
+}
+
+impl MockApns {
+    fn start(status: u16) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let reqs = requests.clone();
+        std::thread::spawn(move || {
+            for conn in listener.incoming() {
+                let Ok(mut stream) = conn else { continue };
+                let mut buf = Vec::new();
+                let mut tmp = [0u8; 4096];
+                // Read headers.
+                let header_end = loop {
+                    match stream.read(&mut tmp) {
+                        Ok(0) => break None,
+                        Ok(n) => {
+                            buf.extend_from_slice(&tmp[..n]);
+                            if let Some(p) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                                break Some(p);
+                            }
+                        }
+                        Err(_) => break None,
+                    }
+                };
+                let Some(he) = header_end else { continue };
+                let head = String::from_utf8_lossy(&buf[..he]).to_string();
+                let mut cap = Captured::default();
+                for (i, line) in head.lines().enumerate() {
+                    if i == 0 {
+                        cap.path = line.split_whitespace().nth(1).unwrap_or("").to_string();
+                    } else if let Some((k, v)) = line.split_once(':') {
+                        match k.trim().to_ascii_lowercase().as_str() {
+                            "authorization" => cap.authorization = v.trim().to_string(),
+                            "apns-topic" => cap.apns_topic = v.trim().to_string(),
+                            _ => {}
+                        }
+                    }
+                }
+                let content_len = head
+                    .lines()
+                    .find(|l| l.to_ascii_lowercase().starts_with("content-length:"))
+                    .and_then(|l| l.split(':').nth(1))
+                    .and_then(|v| v.trim().parse::<usize>().ok())
+                    .unwrap_or(0);
+                let mut body = buf[he + 4..].to_vec();
+                while body.len() < content_len {
+                    match stream.read(&mut tmp) {
+                        Ok(0) => break,
+                        Ok(n) => body.extend_from_slice(&tmp[..n]),
+                        Err(_) => break,
+                    }
+                }
+                cap.body = String::from_utf8_lossy(&body).to_string();
+                reqs.lock().unwrap().push(cap);
+                let reason = if status == 200 {
+                    "{}"
+                } else {
+                    "{\"reason\":\"Unregistered\"}"
+                };
+                let response = format!(
+                    "HTTP/1.1 {status} X\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{reason}",
+                    reason.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        MockApns { port, requests }
+    }
+
+    fn url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+
+    fn wait_for_request(&self, timeout: Duration) -> Option<Captured> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if let Some(c) = self.requests.lock().unwrap().first().cloned() {
+                return Some(c);
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        None
+    }
+}
+
+fn test_p8() -> String {
+    use p256::pkcs8::{EncodePrivateKey, LineEnding};
+    use p256::SecretKey;
+    SecretKey::random(&mut rand_core::OsRng)
+        .to_pkcs8_pem(LineEnding::LF)
+        .unwrap()
+        .to_string()
+}
+
+fn set_creds(http_port: u16, environment: &str) {
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/credentials",
+        &json!({
+            "app_id": "default",
+            "team_id": "TEAM123456",
+            "key_id": "KEY7890AB",
+            "p8_pem": test_p8(),
+            "topic": "com.example.app",
+            "environment": environment,
+        })
+        .to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "set creds: {b}");
+}
+
+fn anon_login(http_port: u16) -> (String, String) {
+    let (s, sess) = http(http_port, "POST", "/auth/v1/signin/anonymous", "{}", None);
+    assert_eq!(s, 200, "anon signin: {sess}");
+    (
+        sess["access_token"].as_str().unwrap().to_string(),
+        sess["user"]["id"].as_str().unwrap().to_string(),
+    )
+}
+
+fn info_field(port: u16, field: &str) -> i64 {
+    let info = resp_cmd(port, &["INFO", "push"]);
+    for line in info.lines() {
+        if let Some(rest) = line.trim().strip_prefix(&format!("{field}:")) {
+            return rest.trim().parse().unwrap_or(-1);
+        }
+    }
+    -1
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn push_end_to_end_delivers_to_apns_mock() {
+    let mock = MockApns::start(200);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start(dir.path(), resp_port, http_port, false);
+
+    set_creds(http_port, &mock.url());
+    let (token, uid) = anon_login(http_port);
+
+    // Register a device as the current user (user_id derived from the JWT).
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"token":"devtoken-abc","platform":"ios","app_id":"default"}).to_string(),
+        Some(&token),
+    );
+    assert_eq!(s, 200, "register: {b}");
+
+    // Operator send fans out to the user's devices.
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({"user_id": uid, "notification": {"title":"Hi","body":"There"}}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "send: {b}");
+    assert_eq!(b["enqueued"], 1);
+
+    let got = mock
+        .wait_for_request(Duration::from_secs(5))
+        .expect("APNs mock should receive a delivery");
+    assert_eq!(got.path, "/3/device/devtoken-abc");
+    assert!(
+        got.authorization.starts_with("bearer "),
+        "auth header: {}",
+        got.authorization
+    );
+    assert_eq!(got.apns_topic, "com.example.app");
+    let body: Value = serde_json::from_str(&got.body).unwrap();
+    assert_eq!(body["aps"]["alert"]["title"], "Hi");
+    assert_eq!(body["aps"]["alert"]["body"], "There");
+
+    // Delivered: the outbox drains and the counter increments.
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while info_field(resp_port, "push_delivered_total") < 1 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(info_field(resp_port, "push_delivered_total") >= 1);
+    drop(server);
+}
+
+#[test]
+fn push_unregistered_token_disables_device() {
+    let mock = MockApns::start(410);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start(dir.path(), resp_port, http_port, false);
+
+    set_creds(http_port, &mock.url());
+    let (token, uid) = anon_login(http_port);
+    let (s, _) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"token":"dead-token","platform":"ios","app_id":"default"}).to_string(),
+        Some(&token),
+    );
+    assert_eq!(s, 200);
+
+    let (s, _) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({"user_id": uid, "notification": {"title":"x","body":"y"}}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200);
+
+    assert!(
+        mock.wait_for_request(Duration::from_secs(5)).is_some(),
+        "mock should receive the attempt"
+    );
+
+    // 410 Unregistered prunes the token: the device disappears from the list.
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let (_, list) = http(http_port, "GET", "/v1/push/devices", "", Some(&token));
+        let n = list["devices"].as_array().map(|a| a.len()).unwrap_or(0);
+        if n == 0 || Instant::now() >= deadline {
+            assert_eq!(n, 0, "unregistered device should be disabled: {list}");
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    drop(server);
+}
+
+#[test]
+fn push_devices_scoped_and_reserved_guarded() {
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start(dir.path(), resp_port, http_port, false);
+
+    let (token_a, _uid_a) = anon_login(http_port);
+    let (token_b, _uid_b) = anon_login(http_port);
+
+    // User A registers a device; user B cannot see it.
+    let (s, _) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"token":"a-token","platform":"ios","app_id":"default"}).to_string(),
+        Some(&token_a),
+    );
+    assert_eq!(s, 200);
+    let (_, list_a) = http(http_port, "GET", "/v1/push/devices", "", Some(&token_a));
+    assert_eq!(list_a["devices"].as_array().unwrap().len(), 1);
+    let (_, list_b) = http(http_port, "GET", "/v1/push/devices", "", Some(&token_b));
+    assert_eq!(list_b["devices"].as_array().unwrap().len(), 0);
+
+    // Anonymous (no JWT) registration is rejected.
+    let (s, _) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"token":"x"}).to_string(),
+        None,
+    );
+    assert_eq!(s, 401);
+
+    // Reserved-table guard: clients cannot touch auth.devices directly.
+    let (_, ins) = exec(
+        http_port,
+        json!([
+            "TINSERT",
+            "auth.devices",
+            "id",
+            "hax",
+            "user_id",
+            "evil",
+            "token",
+            "t"
+        ]),
+    );
+    assert!(
+        ins["error"].as_str().unwrap_or("").contains("Lux Auth"),
+        "direct insert should be blocked: {ins}"
+    );
+    let (_, sel) = exec(http_port, json!(["TSELECT", "*", "FROM", "auth.devices"]));
+    assert!(
+        sel["error"].as_str().unwrap_or("").contains("Lux Auth"),
+        "direct select should be blocked: {sel}"
+    );
+    drop(server);
+}
+
+#[test]
+fn push_registry_survives_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+
+    // Register via the RESP operator form, then hard-restart on the same dir.
+    {
+        let server = start(dir.path(), resp_port, http_port, true);
+        let reply = resp_cmd(
+            resp_port,
+            &[
+                "LUX",
+                "PUSH",
+                "REGISTER",
+                "11111111-1111-1111-1111-111111111111",
+                "persist-token",
+                "ios",
+                "default",
+            ],
+        );
+        assert!(reply.contains("dev_"), "register reply: {reply}");
+        drop(server);
+    }
+
+    let resp_port2 = free_port();
+    let http_port2 = free_port();
+    let server = start(dir.path(), resp_port2, http_port2, false);
+    let reply = resp_cmd(
+        resp_port2,
+        &[
+            "LUX",
+            "PUSH",
+            "DEVICES",
+            "11111111-1111-1111-1111-111111111111",
+        ],
+    );
+    assert!(
+        reply.contains("persist-token") || reply.contains("dev_"),
+        "device should survive restart: {reply}"
+    );
+    drop(server);
+}

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -337,7 +337,7 @@ fn push_end_to_end_delivers_to_apns_mock() {
         http_port,
         "POST",
         "/v1/push/send",
-        &json!({"user_id": uid, "notification": {"title":"Hi","body":"There"}}).to_string(),
+        &json!({"subject_id": uid, "notification": {"title":"Hi","body":"There"}}).to_string(),
         Some("rootsecret"),
     );
     assert_eq!(s, 200, "send: {b}");
@@ -389,7 +389,7 @@ fn push_unregistered_token_disables_device() {
         http_port,
         "POST",
         "/v1/push/send",
-        &json!({"user_id": uid, "notification": {"title":"x","body":"y"}}).to_string(),
+        &json!({"subject_id": uid, "notification": {"title":"x","body":"y"}}).to_string(),
         Some("rootsecret"),
     );
     assert_eq!(s, 200);
@@ -447,27 +447,27 @@ fn push_devices_scoped_and_reserved_guarded() {
     );
     assert_eq!(s, 401);
 
-    // Reserved-table guard: clients cannot touch auth.devices directly.
+    // Reserved-table guard: clients cannot touch push.devices directly.
     let (_, ins) = exec(
         http_port,
         json!([
             "TINSERT",
-            "auth.devices",
+            "push.devices",
             "id",
             "hax",
-            "user_id",
+            "subject_id",
             "evil",
             "token",
             "t"
         ]),
     );
     assert!(
-        ins["error"].as_str().unwrap_or("").contains("Lux Auth"),
+        ins["error"].as_str().unwrap_or("").contains("Lux Push"),
         "direct insert should be blocked: {ins}"
     );
-    let (_, sel) = exec(http_port, json!(["TSELECT", "*", "FROM", "auth.devices"]));
+    let (_, sel) = exec(http_port, json!(["TSELECT", "*", "FROM", "push.devices"]));
     assert!(
-        sel["error"].as_str().unwrap_or("").contains("Lux Auth"),
+        sel["error"].as_str().unwrap_or("").contains("Lux Push"),
         "direct select should be blocked: {sel}"
     );
     drop(server);
@@ -513,6 +513,135 @@ fn push_registry_survives_restart() {
     assert!(
         reply.contains("persist-token") || reply.contains("dev_"),
         "device should survive restart: {reply}"
+    );
+    drop(server);
+}
+
+/// Same as `start` but WITHOUT Lux auth — push is a standalone scope and must
+/// work with `LUX_AUTH_ENABLED` unset.
+fn start_no_auth(dir: &std::path::Path, resp_port: u16, http_port: u16) -> PushServer {
+    let bin = common::find_lux_binary();
+    std::fs::create_dir_all(dir).unwrap();
+    let mut cmd = common::lux_command(&bin);
+    cmd.env("LUX_PORT", resp_port.to_string())
+        .env("LUX_HTTP_PORT", http_port.to_string())
+        .env("LUX_SHARDS", "4")
+        .env("LUX_SAVE_INTERVAL", "0")
+        .env("LUX_DATA_DIR", dir.to_str().unwrap())
+        .env("LUX_STORAGE_MODE", "tiered")
+        .env("LUX_STORAGE_DIR", dir.join("storage").to_str().unwrap())
+        .env("LUX_PASSWORD", "rootsecret")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let child = cmd.spawn().expect("spawn lux");
+    let server = PushServer {
+        child,
+        dir: dir.to_path_buf(),
+        keep_dir: false,
+    };
+    for _ in 0..80 {
+        if TcpStream::connect(("127.0.0.1", http_port)).is_ok()
+            && TcpStream::connect(("127.0.0.1", resp_port)).is_ok()
+        {
+            std::thread::sleep(Duration::from_millis(150));
+            return server;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("lux did not start");
+}
+
+/// The Pompeii case: Lux auth OFF, a trusted secret-key caller registers a token
+/// under an arbitrary external subject id and sends by it. No Lux users exist.
+#[test]
+fn push_works_with_auth_disabled_via_secret_key() {
+    let mock = MockApns::start(200);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start_no_auth(dir.path(), resp_port, http_port);
+
+    set_creds(http_port, &mock.url());
+
+    // Operator (secret key) registers a device under an opaque external subject.
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"subject_id":"ext-user-123","token":"tok-ext","platform":"ios","app_id":"default"})
+            .to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "secret-key register: {b}");
+
+    // A user JWT is NOT available (auth off); anonymous register is rejected.
+    let (s, _) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"token":"x"}).to_string(),
+        None,
+    );
+    assert_eq!(s, 401);
+
+    // Send by the external subject id.
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({"subject_id":"ext-user-123","notification":{"title":"Hi","body":"no lux auth"}})
+            .to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "send: {b}");
+    assert_eq!(b["enqueued"], 1);
+
+    let got = mock
+        .wait_for_request(Duration::from_secs(5))
+        .expect("APNs mock should receive a delivery");
+    assert_eq!(got.path, "/3/device/tok-ext");
+    drop(server);
+}
+
+/// Batch: one send to many subjects enqueues + delivers to each.
+#[test]
+fn push_batch_send_to_many_subjects() {
+    let mock = MockApns::start(200);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start_no_auth(dir.path(), resp_port, http_port);
+    set_creds(http_port, &mock.url());
+
+    for (subj, tok) in [("s1", "tok1"), ("s2", "tok2")] {
+        let (s, _) = http(
+            http_port,
+            "POST",
+            "/v1/push/devices",
+            &json!({"subject_id":subj,"token":tok,"platform":"ios"}).to_string(),
+            Some("rootsecret"),
+        );
+        assert_eq!(s, 200);
+    }
+
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({"subject_ids":["s1","s2"],"notification":{"title":"batch","body":"x"}}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "batch send: {b}");
+    assert_eq!(b["enqueued"], 2);
+
+    let deadline = Instant::now() + Duration::from_secs(6);
+    while mock.requests.lock().unwrap().len() < 2 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert_eq!(
+        mock.requests.lock().unwrap().len(),
+        2,
+        "both subjects should deliver"
     );
     drop(server);
 }

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -169,6 +169,7 @@ struct Captured {
     path: String,
     authorization: String,
     apns_topic: String,
+    content_encoding: String,
     body: String,
 }
 
@@ -211,6 +212,7 @@ impl MockApns {
                         match k.trim().to_ascii_lowercase().as_str() {
                             "authorization" => cap.authorization = v.trim().to_string(),
                             "apns-topic" => cap.apns_topic = v.trim().to_string(),
+                            "content-encoding" => cap.content_encoding = v.trim().to_string(),
                             _ => {}
                         }
                     }
@@ -643,5 +645,86 @@ fn push_batch_send_to_many_subjects() {
         2,
         "both subjects should deliver"
     );
+    drop(server);
+}
+
+/// Web Push: register a browser subscription (platform=web), configure VAPID,
+/// send, and assert the mock push service got an aes128gcm + VAPID-authenticated
+/// encrypted POST.
+#[test]
+fn push_web_push_delivers_encrypted() {
+    let mock = MockApns::start(201);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start_no_auth(dir.path(), resp_port, http_port);
+
+    // Configure VAPID. The private key is any valid P-256 PKCS8 PEM (used to
+    // sign the JWT); the public key is passed through as the `k=` param.
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/credentials",
+        &json!({
+            "app_id":"default",
+            "vapid_public":"BExamplePublicKeyForTestingOnly_notvalidated_1234567890abcdefgh",
+            "vapid_private": test_p8(),
+            "vapid_subject":"mailto:test@luxdb.dev"
+        })
+        .to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "set vapid: {b}");
+
+    // Public VAPID key endpoint is readable.
+    let (s, vk) = http(http_port, "GET", "/v1/push/vapid", "", Some("rootsecret"));
+    assert_eq!(s, 200, "get vapid: {vk}");
+    assert!(vk["public_key"]
+        .as_str()
+        .unwrap_or("")
+        .starts_with("BExample"));
+
+    // Register a browser subscription as the device token (P-256 keys from the
+    // RFC 8291 vector — any valid point works, the mock doesn't decrypt).
+    let subscription = json!({
+        "endpoint": format!("{}/wp/device-1", mock.url()),
+        "keys": {
+            "p256dh":"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4",
+            "auth":"BTBZMqHH6r4Tts7J_aSIgg"
+        }
+    })
+    .to_string();
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"subject_id":"web-user","token":subscription,"platform":"web","app_id":"default"})
+            .to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "register web device: {b}");
+
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({"subject_id":"web-user","notification":{"title":"web","body":"hello browser"}})
+            .to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "send: {b}");
+
+    let got = mock
+        .wait_for_request(Duration::from_secs(5))
+        .expect("push service should receive a delivery");
+    assert_eq!(got.path, "/wp/device-1");
+    assert_eq!(got.content_encoding, "aes128gcm");
+    assert!(
+        got.authorization.starts_with("vapid t="),
+        "VAPID auth header: {}",
+        got.authorization
+    );
+    assert!(got.authorization.contains("k="), "VAPID k= param missing");
+    assert!(!got.body.is_empty(), "encrypted body should be non-empty");
     drop(server);
 }

--- a/tests/redis_parity_inventory.rs
+++ b/tests/redis_parity_inventory.rs
@@ -290,6 +290,7 @@ const INVENTORY: &[CommandInventory] = &[
     lux_native("GRANT"),
     lux_native("KSUB"),
     lux_native("KUNSUB"),
+    lux_native("LUX"),
     lux_native("PFDEBUG"),
     lux_native("TALTER"),
     lux_native("TCOUNT"),


### PR DESCRIPTION
## Summary

Native push notifications built into the engine — APNs for iOS and Web Push (VAPID) for browsers/desktop, so apps don't need OneSignal or Firebase.

Push is a standalone reserved `push.*` scope, decoupled from Lux Auth: a device registers against an opaque `subject_id` (any string — a Lux Auth user id, an external user id, whatever you key users by), and you send by that id. Works with auth on or off.

## What's included

- **`push.*` scope**: `push.devices`, `push.credentials`, `push.outbox`, lazily created on first write and protected from client `T*`/raw-KV access (tokens + private keys redacted on operator reads).
- **APNs sink**: ES256 `.p8` JWT with a provider-token cache, HTTP/2, and rich payload mapping (`subtitle`, `thread_id`, `category`, `sound`, `badge`, `image`, `content_available`, arbitrary `data`) with push-type/priority derivation.
- **Web Push sink**: RFC 8291 message encryption (P-256 ECDH + HKDF-SHA256 + AES-128-GCM, RFC 8188 `aes128gcm`) with VAPID (RFC 8292) authorization.
- **Delivery pipeline**: durable WAL-backed outbox + background worker; at-least-once with exponential backoff, dead-letter, and automatic dead-token pruning (APNs `410` / browser unsubscribe).
- **Batch send** to many subjects in one call.
- **HTTP API**: register (secret-key with explicit `subject_id`, or JWT self-register), send, list devices, credentials, and operator admin endpoints.
- **SDK** (`@luxdb/sdk`): `db.push.registerFor / register / send / devices / unregister / getVapidPublicKey / subscribeWebPush`.
- One-time migration of any legacy `auth.*` push rows into `push.*` on startup.

## Testing

- Web Push encryption validated against the RFC 8291 Appendix A test vector, and independently by decrypting live output with `http_ece`.
- `tests/push.rs` (730 lines): register/send with auth off, batch fan-out, reserved-scope guards, rich APNs body mapping, dead-token handling.
- End-to-end on real devices: APNs to a physical iPhone, Web Push to Chrome.
- `cargo fmt` + `clippy -D warnings` + full suite green.

Merge and release this before the cloud control-plane PR — cloud calls the new `/push/credentials` endpoint and ships the `2.9.0` SDK.
