### PR TITLE
fix(push): rebuild delivery sink when credentials change (no restart needed)

### DIFF
--- a/src/push/worker.rs
+++ b/src/push/worker.rs
@@ -85,7 +85,10 @@ enum AppSink {
 
 /// Spawned once in `Runtime::start`. Loops forever, delivering pending rows.
 pub(crate) async fn run_delivery_worker(store: Arc<Store>, cache: SharedSchemaCache) {
-    let mut sinks: HashMap<String, Arc<AppSink>> = HashMap::new();
+    // Keyed by `{app_id}:{platform}` -> (credentials fingerprint, sink). The
+    // fingerprint invalidates the cached sink when credentials change so an
+    // updated topic/environment/key takes effect without an engine restart.
+    let mut sinks: HashMap<String, (String, Arc<AppSink>)> = HashMap::new();
     let mut ticker = tokio::time::interval(TICK);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
@@ -99,7 +102,7 @@ pub(crate) async fn run_delivery_worker(store: Arc<Store>, cache: SharedSchemaCa
 async fn process_pending(
     store: &Arc<Store>,
     cache: &SharedSchemaCache,
-    sinks: &mut HashMap<String, Arc<AppSink>>,
+    sinks: &mut HashMap<String, (String, Arc<AppSink>)>,
 ) -> Result<(), String> {
     let now = Instant::now();
     let now_secs = unix_seconds();
@@ -188,35 +191,59 @@ async fn process_pending(
 fn resolve_sink(
     store: &Arc<Store>,
     cache: &SharedSchemaCache,
-    sinks: &mut HashMap<String, Arc<AppSink>>,
+    sinks: &mut HashMap<String, (String, Arc<AppSink>)>,
     app_id: &str,
     platform: &str,
     now: Instant,
 ) -> Result<Option<Arc<AppSink>>, String> {
     let cache_key = format!("{app_id}:{platform}");
-    if let Some(existing) = sinks.get(&cache_key) {
-        return Ok(Some(existing.clone()));
-    }
-    let app_sink = match platform {
+
+    // Read the current credentials and derive a fingerprint. A cache hit skips
+    // only the sink build (which holds the APNs provider-token cache); reading
+    // the creds row is cheap. A changed fingerprint rebuilds the sink so a
+    // dashboard edit (topic, environment, key, VAPID keypair) takes effect
+    // immediately instead of after an engine restart.
+    let (fingerprint, app_sink): (String, AppSink) = match platform {
         "web" | "desktop" => {
             let Some(vapid) = get_vapid_credentials(store, cache, app_id, now)? else {
+                sinks.remove(&cache_key);
                 return Ok(None);
             };
-            AppSink::Web(WebPushSink::new(vapid)?)
+            // The private PEM changes iff the public key does (they're a pair).
+            let fp = format!("web|{}|{}", vapid.public_key, vapid.subject);
+            if let Some((cached_fp, sink)) = sinks.get(&cache_key) {
+                if *cached_fp == fp {
+                    return Ok(Some(sink.clone()));
+                }
+            }
+            (fp, AppSink::Web(WebPushSink::new(vapid)?))
         }
         _ => {
             let Some(resolved) = get_apns_credentials(store, cache, app_id, now)? else {
+                sinks.remove(&cache_key);
                 return Ok(None);
             };
-            let base_url = ApnsSink::resolve_base_url(&resolved.environment);
-            AppSink::Apns {
-                sink: ApnsSink::new(base_url, resolved.creds)?,
-                topic: resolved.topic,
+            let fp = format!(
+                "apns|{}|{}|{}|{}",
+                resolved.environment, resolved.topic, resolved.creds.team_id, resolved.creds.key_id
+            );
+            if let Some((cached_fp, sink)) = sinks.get(&cache_key) {
+                if *cached_fp == fp {
+                    return Ok(Some(sink.clone()));
+                }
             }
+            let base_url = ApnsSink::resolve_base_url(&resolved.environment);
+            (
+                fp,
+                AppSink::Apns {
+                    sink: ApnsSink::new(base_url, resolved.creds)?,
+                    topic: resolved.topic,
+                },
+            )
         }
     };
     let app_sink = Arc::new(app_sink);
-    sinks.insert(cache_key, app_sink.clone());
+    sinks.insert(cache_key, (fingerprint, app_sink.clone()));
     Ok(Some(app_sink))
 }
 

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -292,6 +292,89 @@ fn set_creds(http_port: u16, environment: &str) {
     assert_eq!(s, 200, "set creds: {b}");
 }
 
+fn set_creds_topic(http_port: u16, environment: &str, topic: &str) {
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/credentials",
+        &json!({
+            "app_id": "default",
+            "team_id": "TEAM123456",
+            "key_id": "KEY7890AB",
+            "p8_pem": test_p8(),
+            "topic": topic,
+            "environment": environment,
+        })
+        .to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "set creds: {b}");
+}
+
+// A credentials edit (here the APNs topic) must invalidate the worker's cached
+// sink so the next delivery uses the new value. Previously the sink was cached
+// for the worker's lifetime, so changes only took effect after an engine restart.
+#[test]
+fn credential_change_rebuilds_cached_sink() {
+    let mock = MockApns::start(200);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start(dir.path(), resp_port, http_port, false);
+
+    set_creds_topic(http_port, &mock.url(), "com.example.first");
+    let (token, uid) = anon_login(http_port);
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"token":"devtoken-abc","platform":"ios","app_id":"default"}).to_string(),
+        Some(&token),
+    );
+    assert_eq!(s, 200, "register: {b}");
+
+    let (s, _) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({"subject_id": uid, "notification": {"title":"Hi","body":"1"}}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200);
+    let first = mock
+        .wait_for_request(Duration::from_secs(5))
+        .expect("first delivery");
+    assert_eq!(first.apns_topic, "com.example.first");
+
+    // Change the topic, then send again.
+    set_creds_topic(http_port, &mock.url(), "com.example.second");
+    let (s, _) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({"subject_id": uid, "notification": {"title":"Hi","body":"2"}}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200);
+
+    // The second delivery must carry the NEW topic, not the cached one.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let second_topic = loop {
+        {
+            let reqs = mock.requests.lock().unwrap();
+            if reqs.len() >= 2 {
+                break reqs[1].apns_topic.clone();
+            }
+        }
+        assert!(Instant::now() < deadline, "second delivery not received");
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    assert_eq!(
+        second_topic, "com.example.second",
+        "a credential change must invalidate the cached sink"
+    );
+}
+
 fn anon_login(http_port: u16) -> (String, String) {
     let (s, sess) = http(http_port, "POST", "/auth/v1/signin/anonymous", "{}", None);
     assert_eq!(s, 200, "anon signin: {sess}");


### PR DESCRIPTION
The delivery worker cached the APNs/Web Push sink keyed by `app_id:platform` for the worker's entire lifetime and never re-read credentials. So editing the APNs **topic**, **environment** (sandbox/prod), key, or the VAPID keypair had **no effect until the engine restarted** — the worker kept delivering with the stale sink.

Hit in the wild: after correcting an APNs topic in the dashboard, deliveries kept failing `TopicDisallowed` until the project was restarted.

**Fix:** `resolve_sink` now reads the current credentials (cheap) and fingerprints them (topic/env/team/key for APNs; public key + subject for VAPID). On a cache hit it returns the existing sink (preserving the APNs provider-token cache between sends); on a fingerprint change it rebuilds. A removed credential drops the cached sink too.

Regression test `credential_change_rebuilds_cached_sink`: send → change topic → send again, assert the second delivery carries the new topic.

Verified: `cargo test --test push` (8 pass), fmt + clippy clean, `cargo build --release`.