### PR TITLE
feat(push): unregister-by-token + admin stats endpoint

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@luxdb/sdk",
-    "version": "2.9.0",
+    "version": "2.10.0",
     "description": "Official Lux TypeScript SDK for app data, auth, tables, vectors, realtime, and Redis-compatible direct access",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",

--- a/sdk/src/push.ts
+++ b/sdk/src/push.ts
@@ -79,6 +79,12 @@ export class LuxPushNamespace {
 		return this.client.request('DELETE', `/push/devices/${encodeURIComponent(id)}`);
 	}
 
+	/** Remove a device by its push token (secret key). Use at logout, where the
+	 *  client has the token but not the internal device id. */
+	async unregisterByToken(token: string): Promise<LuxResult<{ deleted: boolean }>> {
+		return this.client.request('DELETE', '/push/devices', { token });
+	}
+
 	/** List a subject's active devices. With a user session, omit `subjectId` to
 	 *  list your own; with a secret key, pass the subject. */
 	async devices(subjectId?: string): Promise<LuxResult<LuxPushDevice[]>> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -2632,10 +2632,12 @@ fn route_request_with_auth(
         ("POST", ["push", "devices"]) => push_register(body, store, cache, auth),
         ("GET", ["push", "devices"]) => push_list_devices(params, store, cache, auth),
         ("DELETE", ["push", "devices", id]) => push_delete_device(id, store, cache, auth),
+        ("DELETE", ["push", "devices"]) => push_delete_device_by_token(body, store, cache),
         ("POST", ["push", "send"]) => push_send(body, store, cache),
         ("POST", ["push", "credentials"]) => push_set_credentials(body, store, cache),
         ("GET", ["push", "admin", "devices"]) => push_admin_devices(store, cache),
         ("GET", ["push", "admin", "outbox"]) => push_admin_outbox(store, cache),
+        ("GET", ["push", "admin", "stats"]) => push_admin_stats(),
         ("GET", ["push", "vapid"]) => push_vapid_public(params, store, cache),
 
         // ── KV routes ──
@@ -3014,8 +3016,10 @@ fn route_requires_operator(method: &str, base: &[&str]) -> bool {
             | ("DELETE", ["vectors", _])
             | ("POST", ["push", "send"])
             | ("POST", ["push", "credentials"])
+            | ("DELETE", ["push", "devices"])
             | ("GET", ["push", "admin", "devices"])
             | ("GET", ["push", "admin", "outbox"])
+            | ("GET", ["push", "admin", "stats"])
     )
 }
 
@@ -3190,6 +3194,40 @@ fn push_admin_outbox(store: &Arc<Store>, cache: &SharedSchemaCache) -> (u16, &'s
         Ok(dead) => ok(json!({ "dead_letters": dead }).to_string()),
         Err(e) => push_json_error(400, "Bad Request", &e),
     }
+}
+
+/// `DELETE /v1/push/devices` (operator) — remove a device by its token. For
+/// logout-time unregister, where the client has the token but not the id.
+fn push_delete_device_by_token(
+    body: &str,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> (u16, &'static str, String) {
+    let parsed: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(_) => return push_json_error(400, "Bad Request", "invalid json"),
+    };
+    let Some(token) = parsed["token"].as_str().filter(|s| !s.is_empty()) else {
+        return push_json_error(400, "Bad Request", "token is required");
+    };
+    match crate::push::delete_device_by_token(store, cache, token, Instant::now()) {
+        Ok(deleted) => ok(json!({ "deleted": deleted }).to_string()),
+        Err(e) => push_json_error(400, "Bad Request", &e),
+    }
+}
+
+/// `GET /v1/push/admin/stats` (operator) — process-level delivery counters
+/// (reset on engine restart): sends, delivered, failed, and live device count.
+fn push_admin_stats() -> (u16, &'static str, String) {
+    use std::sync::atomic::Ordering;
+    let m = crate::push::metrics();
+    ok(json!({
+        "sends": m.sends.load(Ordering::Relaxed),
+        "delivered": m.delivered.load(Ordering::Relaxed),
+        "failed": m.failed.load(Ordering::Relaxed),
+        "devices": m.devices.load(Ordering::Relaxed),
+    })
+    .to_string())
 }
 
 /// `POST /v1/push/credentials` (operator) — set an app's APNs credentials.

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -335,6 +335,22 @@ pub(crate) fn delete_device_by_id(
     Ok(removed > 0)
 }
 
+/// Delete any device by its token (operator). Used for logout-time unregister,
+/// where the caller has the token but not the internal device id.
+pub(crate) fn delete_device_by_token(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    token: &str,
+    now: Instant,
+) -> Result<bool, String> {
+    let removed =
+        durable_table_delete_where(store, cache, DEVICES_TABLE, &["token", "=", token], now)?;
+    if removed > 0 {
+        metrics().devices.fetch_sub(1, Ordering::Relaxed);
+    }
+    Ok(removed > 0)
+}
+
 // ---------------------------------------------------------------------------
 // Admin reads (operator) — for the cloud dashboard
 // ---------------------------------------------------------------------------

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -431,6 +431,111 @@ fn unregister_by_token_and_admin_stats() {
     assert_eq!(b["enqueued"], 0);
 }
 
+#[test]
+fn delete_by_token_edge_cases() {
+    let mock = MockApns::start(200);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start(dir.path(), resp_port, http_port, false);
+
+    set_creds(http_port, &mock.url());
+    let (token, uid) = anon_login(http_port);
+    for t in ["keep-tok", "drop-tok"] {
+        let (s, b) = http(
+            http_port,
+            "POST",
+            "/v1/push/devices",
+            &json!({"token": t, "platform":"ios", "app_id":"default"}).to_string(),
+            Some(&token),
+        );
+        assert_eq!(s, 200, "register {t}: {b}");
+    }
+
+    // Missing token -> 400.
+    let (s, _) = http(
+        http_port,
+        "DELETE",
+        "/v1/push/devices",
+        "{}",
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 400);
+
+    // Unknown token -> 200 with deleted:false (idempotent, not an error).
+    let (s, b) = http(
+        http_port,
+        "DELETE",
+        "/v1/push/devices",
+        &json!({"token":"never-registered"}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "{b}");
+    assert_eq!(b["deleted"], false);
+
+    // Deleting one token leaves the other device intact (scoped to the token).
+    let (s, b) = http(
+        http_port,
+        "DELETE",
+        "/v1/push/devices",
+        &json!({"token":"drop-tok"}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "{b}");
+    assert_eq!(b["deleted"], true);
+
+    let (s, list) = http(
+        http_port,
+        "GET",
+        &format!("/v1/push/devices?subject_id={uid}"),
+        "",
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "{list}");
+    let devices = list["devices"].as_array().expect("devices array");
+    assert_eq!(
+        devices.len(),
+        1,
+        "only the un-deleted device remains: {list}"
+    );
+}
+
+#[test]
+fn push_admin_routes_require_operator() {
+    let mock = MockApns::start(200);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start(dir.path(), resp_port, http_port, false);
+    set_creds(http_port, &mock.url());
+    let (token, _uid) = anon_login(http_port);
+
+    // A signed-in user (non-operator) must not delete-by-token or read stats.
+    let (s, _) = http(
+        http_port,
+        "DELETE",
+        "/v1/push/devices",
+        &json!({"token":"x"}).to_string(),
+        Some(&token),
+    );
+    assert!(s == 401 || s == 403, "user delete-by-token denied, got {s}");
+    let (s, _) = http(http_port, "GET", "/v1/push/admin/stats", "", Some(&token));
+    assert!(s == 401 || s == 403, "user stats read denied, got {s}");
+
+    // No auth at all is denied too.
+    let (s, _) = http(
+        http_port,
+        "DELETE",
+        "/v1/push/devices",
+        &json!({"token":"x"}).to_string(),
+        None,
+    );
+    assert!(
+        s == 401 || s == 403,
+        "unauth delete-by-token denied, got {s}"
+    );
+}
+
 fn anon_login(http_port: u16) -> (String, String) {
     let (s, sess) = http(http_port, "POST", "/auth/v1/signin/anonymous", "{}", None);
     assert_eq!(s, 200, "anon signin: {sess}");

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -375,6 +375,62 @@ fn credential_change_rebuilds_cached_sink() {
     );
 }
 
+#[test]
+fn unregister_by_token_and_admin_stats() {
+    let mock = MockApns::start(200);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start(dir.path(), resp_port, http_port, false);
+
+    set_creds(http_port, &mock.url());
+    let (token, uid) = anon_login(http_port);
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"token":"tok-xyz","platform":"ios","app_id":"default"}).to_string(),
+        Some(&token),
+    );
+    assert_eq!(s, 200, "register: {b}");
+
+    // Admin stats endpoint (operator) reports the live device count.
+    let (s, stats) = http(
+        http_port,
+        "GET",
+        "/v1/push/admin/stats",
+        "",
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "stats: {stats}");
+    assert!(
+        stats["devices"].as_i64().unwrap_or(0) >= 1,
+        "stats: {stats}"
+    );
+
+    // Unregister by token (operator) removes the device.
+    let (s, b) = http(
+        http_port,
+        "DELETE",
+        "/v1/push/devices",
+        &json!({"token":"tok-xyz"}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "delete: {b}");
+    assert_eq!(b["deleted"], true);
+
+    // The subject now has no devices, so a send enqueues to zero.
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({"subject_id": uid, "notification": {"title":"x","body":"y"}}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "send: {b}");
+    assert_eq!(b["enqueued"], 0);
+}
+
 fn anon_login(http_port: u16) -> (String, String) {
     let (s, sess) = http(http_port, "POST", "/auth/v1/signin/anonymous", "{}", None);
     assert_eq!(s, 200, "anon signin: {sess}");


### PR DESCRIPTION
Push-polish groundwork (engine + SDK).

- **`DELETE /v1/push/devices { token }`** (operator): remove a device by its push token. Fixes logout-time unregister — clients hold the token, not the internal device id, so `DELETE /devices/:id` wasn't usable. `db.push.unregisterByToken(token)` in the SDK.
- **`GET /v1/push/admin/stats`** (operator): process-level `sends`/`delivered`/`failed`/`devices` counters (reset on restart) — feeds a delivery-health view on the cloud dashboard.
- SDK bumped to **2.10.0**.

Test `unregister_by_token_and_admin_stats` covers both. Full push suite 9/9 (single-threaded; one web-push flake under parallel load is the known harness issue). fmt + clippy clean.