### PR TITLE
fix(zset): overflow-safe numkeys guards (fixes nightly fuzz panic)

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -3981,6 +3981,34 @@ mod tests {
         String::from_utf8_lossy(&exec(store, args)).to_string()
     }
 
+    // Regression: the zset set-ops built their length guards as `const + numkeys`,
+    // which overflows usize and panics when numkeys is huge (the `command` fuzz
+    // target found this nightly, e.g. sorted_sets.rs:975). They must reject it
+    // with an error, not crash.
+    #[test]
+    fn zset_setops_reject_overflowing_numkeys() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().to_string(),
+            ..ServerConfig::default()
+        });
+        let store = Store::new_with_config(config);
+        let n = b"18446744073709551615"; // u64::MAX
+
+        for reply in [
+            exec_str(&store, &[b"ZUNION", n, b"k"]),
+            exec_str(&store, &[b"ZINTER", n, b"k"]),
+            exec_str(&store, &[b"ZDIFF", n, b"k"]),
+            exec_str(&store, &[b"ZUNIONSTORE", b"d", n, b"k"]),
+            exec_str(&store, &[b"ZINTERSTORE", b"d", n, b"k"]),
+            exec_str(&store, &[b"ZDIFFSTORE", b"d", n, b"k"]),
+            exec_str(&store, &[b"ZMPOP", n, b"k", b"MIN"]),
+            exec_str(&store, &[b"BZMPOP", b"0", n, b"k", b"MIN"]),
+        ] {
+            assert!(reply.contains("ERR"), "expected error, got: {reply}");
+        }
+    }
+
     fn exec_wal(store: &Store, args: &[&[u8]]) -> BytesMut {
         let broker = Broker::new();
         let cache =

--- a/src/cmd/sorted_sets.rs
+++ b/src/cmd/sorted_sets.rs
@@ -115,7 +115,7 @@ fn parse_zstore_options(
     while i < args.len() {
         if cmd_eq(args[i], b"WEIGHTS") {
             i += 1;
-            if i + numkeys > args.len() {
+            if numkeys > args.len().saturating_sub(i) {
                 resp::write_error(out, "ERR syntax error");
                 return None;
             }
@@ -865,7 +865,7 @@ pub fn cmd_zunionstore(
         Some(numkeys) => numkeys,
         None => return CmdResult::Written,
     };
-    if 3 + numkeys > args.len() {
+    if numkeys > args.len().saturating_sub(3) {
         resp::write_error(out, "ERR syntax error");
         return CmdResult::Written;
     }
@@ -901,7 +901,7 @@ pub fn cmd_zinterstore(
         Some(numkeys) => numkeys,
         None => return CmdResult::Written,
     };
-    if 3 + numkeys > args.len() {
+    if numkeys > args.len().saturating_sub(3) {
         resp::write_error(out, "ERR syntax error");
         return CmdResult::Written;
     }
@@ -937,11 +937,11 @@ pub fn cmd_zdiffstore(
         Some(numkeys) => numkeys,
         None => return CmdResult::Written,
     };
-    if 3 + numkeys > args.len() {
+    if numkeys > args.len().saturating_sub(3) {
         resp::write_error(out, "ERR syntax error");
         return CmdResult::Written;
     }
-    if 3 + numkeys != args.len() {
+    if numkeys != args.len().saturating_sub(3) {
         resp::write_error(out, "ERR syntax error");
         return CmdResult::Written;
     }
@@ -972,7 +972,7 @@ fn parse_zset_setop<'a>(
     allow_options: bool,
 ) -> Option<ZSetSetOp<'a>> {
     let numkeys = parse_zstore_numkeys(args[1], out)?;
-    if 2 + numkeys > args.len() {
+    if numkeys > args.len().saturating_sub(2) {
         resp::write_error(out, "ERR syntax error");
         return None;
     }
@@ -1086,7 +1086,7 @@ pub fn cmd_zintercard(
         Some(n) => n,
         None => return CmdResult::Written,
     };
-    if 2 + numkeys > args.len() {
+    if numkeys > args.len().saturating_sub(2) {
         resp::write_error(out, "ERR syntax error");
         return CmdResult::Written;
     }
@@ -1180,7 +1180,7 @@ pub fn cmd_zmpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instant
         None => return CmdResult::Written,
     };
     // Need at least the MIN|MAX token after the keys.
-    if 2 + numkeys >= args.len() {
+    if numkeys >= args.len().saturating_sub(2) {
         resp::write_error(out, "ERR syntax error");
         return CmdResult::Written;
     }
@@ -1535,7 +1535,7 @@ pub fn cmd_bzmpop(args: &[&[u8]], store: &Store, out: &mut BytesMut, now: Instan
         Some(n) => n,
         None => return CmdResult::Written,
     };
-    if 3 + numkeys >= args.len() {
+    if numkeys >= args.len().saturating_sub(3) {
         resp::write_error(out, "ERR syntax error");
         return CmdResult::Written;
     }


### PR DESCRIPTION
## The nightly Fuzz failures
The scheduled `Fuzz` job's `command` target has been failing ~every other night — each run panics somewhere in the zset set-ops. Yesterday's: `thread panicked at src/cmd/sorted_sets.rs:975`, `libFuzzer: deadly signal` (seed 3252596387).

## Root cause
`parse_zstore_numkeys` accepts any `u64` as `numkeys`, and every length guard was written `const + numkeys > args.len()`. With `numkeys` near `usize::MAX`, the **addition overflows** (fuzz/debug builds have overflow checks on) and panics *before* the comparison can reject it. Eight guards across ZUNION/ZINTER/ZDIFF, their `*STORE` variants, ZMPOP, and BZMPOP had this — which is why a different seed trips a different one each night.

## Fix
Compare without the overflowing add: `numkeys > args.len().saturating_sub(N)`. Once a guard passes, `numkeys` is bounded, so the subsequent `args[N..N+numkeys]` slices can't overflow either. A malformed huge-numkeys command now returns `ERR syntax error` instead of crashing the engine.

Regression test added (`zset_setops_reject_overflowing_numkeys`) feeding `u64::MAX` to all eight commands.

## Checklist
cargo fmt ✓ · clippy clean ✓ · full lib suite 584 pass ✓ · `cargo build --release` ✓