### PR TITLE
feat(auth): one secret key for every surface (re-target to main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Lux Cloud is the fastest path when you want to build an app backend around Lux w
 - **Zero-copy parser** -- RESP arguments are byte slices into the read buffer
 - **Pipeline batching** -- consecutive same-shard commands batched under a single lock
 - **Persistence** -- automatic snapshots, write-ahead log (WAL) with CRC32 checksums, tiered hot/cold storage with automatic eviction to disk
-- **Auth** -- password authentication via `LUX_PASSWORD`, plus optional app auth with users, identities, sessions, OAuth providers, JWTs, auth-owned system tables, and per-table row-level grants (`GRANT read, write ON t WHERE user_id = auth.uid()`) that gate reads, writes, and `.live()`
+- **Auth** -- project secret/publishable keys or the `LUX_PASSWORD` operator credential, plus optional app auth with users, identities, sessions, OAuth providers, JWTs, auth-owned system tables, and per-table row-level grants (`GRANT read, write ON t WHERE user_id = auth.uid()`) that gate reads, writes, and `.live()`
 - **Pub/Sub** -- SUBSCRIBE, PSUBSCRIBE, PUBLISH, plus KSUB/KUNSUB for realtime key change events
 - **TTL support** -- EX, PX, EXPIRE, PEXPIRE, PERSIST, TTL, PTTL
 - **MIT licensed** -- no license rug-pulls, unlike Redis (RSALv2/SSPL)
@@ -512,16 +512,23 @@ curl -X POST http://localhost:5890/v1/exec \
   -d '{"command":["HSET","user:1","name","alice"]}'
 ```
 
-Auth via `Authorization: Bearer <password>` when `LUX_PASSWORD` is set. CORS enabled by default. 174K ops/sec at 256 concurrent connections with keep-alive.
+Auth via `Authorization: Bearer <credential>` where the credential is a project secret key (`lux_sec_*`) or the operator password. CORS enabled by default. 174K ops/sec at 256 concurrent connections with keep-alive.
 
 ### App Auth
 
-Lux can also expose a Supabase-style app auth surface. This is optional and is separate from the database password:
+Lux can also expose a Supabase-style app auth surface. Project keys are engine
+credentials in their own right, so one secret key covers auth, data, native
+commands, vectors, pubsub, lua and `.live()`:
 
-- `LUX_PASSWORD` protects direct RESP/admin HTTP access.
+- `LUX_PASSWORD` is the operator/break-glass credential; it still works everywhere.
 - `LUX_AUTH_ENABLED=true` creates and serves app auth endpoints.
 - `LUX_AUTH_PUBLISHABLE_KEY` is safe for browser/client auth calls.
-- `LUX_AUTH_SECRET_KEY` is for trusted servers and admin auth operations.
+- `LUX_AUTH_SECRET_KEY` is the server-side credential: full project access on
+  every surface, including RESP.
+
+An engine is credential-gated once it has a password *or* project keys.
+Publishable keys never reach RESP and, on HTTP, reach only `/auth/v1/*` until a
+signed-in user's JWT accompanies them; grants then decide which rows.
 
 ```bash
 LUX_HTTP_PORT=5890 \
@@ -567,7 +574,7 @@ curl -X PUT http://localhost:5890/auth/v1/admin/providers/google \
   }'
 ```
 
-Use `createBrowserClient(url, publishableKey)` in browsers and `createClient(url, secretKey)` on trusted servers. Browser live subscriptions use the publishable key plus the signed-in user's JWT; direct RESP access still uses the database password.
+Use `createBrowserClient(url, publishableKey)` in browsers and `createClient(url, secretKey)` on trusted servers. Browser live subscriptions use the publishable key plus the signed-in user's JWT. Direct RESP access takes the secret key (`AUTH lux_sec_...`) or the operator password.
 
 #### Grants (row-level access)
 
@@ -593,7 +600,7 @@ redis-cli GRANT read, write ON messages WHERE workspace_id IN ( SELECT workspace
 |----------|---------|-------------|
 | `LUX_PORT` | `6379` | RESP (Redis-compatible) TCP port |
 | `LUX_HTTP_PORT` | (disabled) | HTTP API port (set to enable; `lux start` defaults it to `5890`) |
-| `LUX_PASSWORD` | (none) | Enable AUTH (applies to both RESP and HTTP) |
+| `LUX_PASSWORD` | (none) | Operator/break-glass AUTH (RESP and HTTP). Project keys also gate the engine |
 | `LUX_DATA_DIR` | `.` | Snapshot directory |
 | `LUX_SAVE_INTERVAL` | `60` | Snapshot interval in seconds (0 to disable) |
 | `LUX_SHARDS` | auto | Shard count (default: num_cpus * 16) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,9 @@ unauthenticated Lux ports directly to the public internet.
 These surfaces are security-sensitive and treated as release-blocking when
 regressions are found:
 
-- Operator authentication and `LUX_PASSWORD`.
+- Credential resolution (`resolve_credential`): the single path every surface
+  uses to turn a presented secret key, publishable key, end-user token or
+  `LUX_PASSWORD` into an identity.
 - App auth, sessions, refresh tokens, OAuth provider configuration, project
   keys, and row-level grants.
 - Reserved auth tables (`_t:auth.*`) and the raw-KV guard that protects them.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2567,7 +2567,11 @@ fn admin_revoke_key(
         now,
     ) {
         Ok(0) => error(404, "Not Found", "key not found"),
-        Ok(_) => ok(json!({"result":"OK"})),
+        Ok(_) => {
+            // Revocation must take effect now, not when the cache entry ages out.
+            invalidate_api_key_cache();
+            ok(json!({"result":"OK"}))
+        }
         Err(e) => error(400, "Bad Request", &e),
     }
 }
@@ -2749,6 +2753,9 @@ fn insert_api_key(
         ],
         now,
     )?;
+    // A negative result for this key may already be cached (something tried it
+    // before it existed); drop it so the new key works immediately.
+    invalidate_api_key_cache();
     Ok(json!({
         "id": key_id,
         "name": name,
@@ -2761,15 +2768,134 @@ fn insert_api_key(
     }))
 }
 
+/// Which surface a credential is being presented to. The resolver enforces the
+/// surface rule itself so no call site has to remember it: a publishable key is
+/// browser-embedded and must never reach the raw command protocol, where lua,
+/// FLUSHALL and raw KV live and no grant can contain the blast radius.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Surface {
+    /// RESP command protocol. Secret keys and the operator password only.
+    Resp,
+    /// HTTP data routes and the `/live` websocket handshake.
+    Http,
+    /// `/auth/v1/*`, which publishable keys legitimately reach.
+    AuthApi,
+}
+
+/// What a presented credential turned out to be.
+///
+/// This is the *identity* of the caller, not their permissions: `Publishable`
+/// and `User` still answer to grants for every row they touch. Only `Secret` and
+/// `Operator` carry blanket project access.
+#[derive(Clone, Debug)]
+pub(crate) enum Credential {
+    /// No credential presented.
+    Anonymous,
+    /// Browser-safe project key. Reaches auth; reaches data only when an
+    /// end-user token rides along and supplies a principal.
+    Publishable,
+    /// Server-side project key: full project access.
+    Secret,
+    /// End-user access token: subject to grants.
+    User(AuthPrincipal),
+    /// `LUX_PASSWORD`. Break-glass and control-plane operations.
+    Operator,
+}
+
+/// Turn a presented credential into an identity, for any surface.
+///
+/// Every entry point (RESP `AUTH`, HTTP, `/live`, `/auth/v1/*`) funnels through
+/// here. The `_t:` namespace bug was two dispatch paths that had to agree and
+/// silently didn't; one resolver is what keeps that from recurring for auth.
+///
+/// `presented` is the api key or bearer token. `user_token` is a separate
+/// end-user access token when one accompanies a project key (the browser case:
+/// `apikey=lux_pub_...` plus `Authorization: Bearer <jwt>`).
+pub(crate) fn resolve_credential(
+    presented: &str,
+    user_token: &str,
+    surface: Surface,
+    store: &Store,
+    cache: &SharedSchemaCache,
+) -> Result<Credential, String> {
+    let password = &store.config().password;
+
+    // Operator first: the password is the break-glass path and must keep working
+    // even if auth.keys is unreadable.
+    if !password.is_empty()
+        && !presented.is_empty()
+        && constant_time_eq(presented.as_bytes(), password.as_bytes())
+    {
+        return Ok(Credential::Operator);
+    }
+
+    if !presented.is_empty() {
+        if let Some(kind) = lookup_api_key(presented, store, cache)? {
+            return match (kind, surface) {
+                (ApiKeyKind::Publishable, Surface::Resp) => Err(
+                    "publishable keys cannot use the RESP protocol; use a secret key".to_string(),
+                ),
+                (ApiKeyKind::Publishable, _) => {
+                    // A publishable key alone is an identity of the project, not
+                    // of a person. Data access needs a principal on top.
+                    match resolve_user(user_token, store, cache)? {
+                        Some(principal) => Ok(Credential::User(principal)),
+                        None => Ok(Credential::Publishable),
+                    }
+                }
+                (ApiKeyKind::Secret, _) => Ok(Credential::Secret),
+            };
+        }
+    }
+
+    // No project key matched. An end-user token can still stand on its own.
+    if let Some(principal) = resolve_user(user_token, store, cache)? {
+        return Ok(Credential::User(principal));
+    }
+    if let Some(principal) = resolve_user(presented, store, cache)? {
+        return Ok(Credential::User(principal));
+    }
+
+    Ok(Credential::Anonymous)
+}
+
+/// Validate an end-user access token, if one was supplied and auth is on.
+fn resolve_user(
+    token: &str,
+    store: &Store,
+    cache: &SharedSchemaCache,
+) -> Result<Option<AuthPrincipal>, String> {
+    if token.is_empty() || !store.config().auth.enabled {
+        return Ok(None);
+    }
+    // A project key in this slot is not a user token; don't report it as a bad
+    // JWT.
+    if token.starts_with("lux_pub_") || token.starts_with("lux_sec_") {
+        return Ok(None);
+    }
+    match authenticate_access_token(token, store, cache) {
+        Ok(principal) => Ok(Some(principal)),
+        Err(e) => Err(e),
+    }
+}
+
+/// The project credential presented on an `/auth/v1/*` request.
+fn presented_key(headers: &[(String, String)]) -> &str {
+    header_value(headers, "apikey")
+        .or_else(|| bearer_token(headers))
+        .unwrap_or("")
+}
+
 fn require_publishable_or_secret(
     headers: &[(String, String)],
     store: &Store,
     cache: &SharedSchemaCache,
 ) -> Result<(), (u16, &'static str, String)> {
-    match api_key_kind(headers, store, cache) {
-        Ok(Some(ApiKeyKind::Publishable | ApiKeyKind::Secret)) => Ok(()),
-        Ok(None) if no_project_keys_configured(store, cache) => Ok(()),
-        Ok(None) => Err(error(
+    match resolve_credential(presented_key(headers), "", Surface::AuthApi, store, cache) {
+        Ok(Credential::Publishable | Credential::Secret | Credential::Operator) => Ok(()),
+        // An engine with no keys configured yet is still open, as before.
+        Ok(_) if no_project_keys_configured(store, cache) => Ok(()),
+        Ok(_) => Err(error(
             401,
             "Unauthorized",
             "missing or invalid auth api key",
@@ -2783,45 +2909,98 @@ fn require_secret(
     store: &Store,
     cache: &SharedSchemaCache,
 ) -> Result<(), (u16, &'static str, String)> {
-    if let Some(password) = bearer_token(headers) {
-        if !store.config().password.is_empty()
-            && constant_time_eq(password.as_bytes(), store.config().password.as_bytes())
-        {
-            return Ok(());
-        }
-    }
-    match api_key_kind(headers, store, cache) {
-        Ok(Some(ApiKeyKind::Secret)) => Ok(()),
+    match resolve_credential(presented_key(headers), "", Surface::AuthApi, store, cache) {
+        Ok(Credential::Secret | Credential::Operator) => Ok(()),
         _ => Err(error(401, "Unauthorized", "secret key required")),
     }
 }
 
-fn api_key_kind(
-    headers: &[(String, String)],
+/// Resolve a raw key string to its kind, or `None` if unknown or revoked. The
+/// single place `auth.keys` is consulted, shared by [`resolve_credential`] and
+/// the `/auth/v1/*` guards.
+fn lookup_api_key(
+    key: &str,
     store: &Store,
     cache: &SharedSchemaCache,
 ) -> Result<Option<ApiKeyKind>, String> {
-    let Some(key) = header_value(headers, "apikey").or_else(|| bearer_token(headers)) else {
-        return Ok(None);
-    };
-
-    let hash = hash_secret(key);
-    let Some(row) = find_row_by_field(store, cache, KEYS_TABLE, "key_hash", &hash, Instant::now())?
-    else {
-        return Ok(None);
-    };
-    if row
-        .get("revoked_at")
-        .map(|v| !v.is_empty() && v != "0")
-        .unwrap_or(false)
-    {
+    if key.is_empty() {
         return Ok(None);
     }
-    Ok(match row.get("kind").map(String::as_str) {
-        Some("publishable") => Some(ApiKeyKind::Publishable),
-        Some("secret") => Some(ApiKeyKind::Secret),
-        _ => None,
-    })
+    let hash = hash_secret(key);
+
+    // HTTP authenticates per request, so an uncached lookup puts a hash plus a
+    // table read on the hot path (measured at roughly +5us/req against the
+    // password memcmp). Cache the resolution briefly. Misses are cached too, so
+    // a client looping with a bad key cannot turn into a read storm.
+    if let Some(kind) = cached_api_key(&hash) {
+        return Ok(kind);
+    }
+
+    let resolved =
+        match find_row_by_field(store, cache, KEYS_TABLE, "key_hash", &hash, Instant::now())? {
+            Some(row)
+                if row
+                    .get("revoked_at")
+                    .map(|v| !v.is_empty() && v != "0")
+                    .unwrap_or(false) =>
+            {
+                None
+            }
+            Some(row) => match row.get("kind").map(String::as_str) {
+                Some("publishable") => Some(ApiKeyKind::Publishable),
+                Some("secret") => Some(ApiKeyKind::Secret),
+                _ => None,
+            },
+            None => None,
+        };
+    store_cached_api_key(hash, resolved);
+    Ok(resolved)
+}
+
+/// How long a resolved key stays cached. The ceiling on revocation latency for
+/// anything that does not go through [`invalidate_api_key_cache`], not the
+/// normal path: minting and revoking both clear the cache outright.
+const API_KEY_CACHE_TTL: Duration = Duration::from_secs(5);
+
+type ApiKeyCache = parking_lot::RwLock<HashMap<String, (Option<ApiKeyKind>, Instant)>>;
+
+fn api_key_cache() -> &'static ApiKeyCache {
+    static CACHE: OnceLock<ApiKeyCache> = OnceLock::new();
+    CACHE.get_or_init(|| parking_lot::RwLock::new(HashMap::new()))
+}
+
+/// `Some(kind)` on a live cache hit, `None` when the caller must do the lookup.
+fn cached_api_key(hash: &str) -> Option<Option<ApiKeyKind>> {
+    let cache = api_key_cache().read();
+    let (kind, stored_at) = cache.get(hash)?;
+    if stored_at.elapsed() >= API_KEY_CACHE_TTL {
+        return None;
+    }
+    Some(*kind)
+}
+
+fn store_cached_api_key(hash: String, kind: Option<ApiKeyKind>) {
+    let mut cache = api_key_cache().write();
+    // Bounded so an attacker spraying distinct keys cannot grow it without
+    // limit; the working set is a handful of real keys.
+    if cache.len() > 1024 {
+        cache.retain(|_, (_, stored_at)| stored_at.elapsed() < API_KEY_CACHE_TTL);
+        if cache.len() > 1024 {
+            cache.clear();
+        }
+    }
+    cache.insert(hash, (kind, Instant::now()));
+}
+
+/// Drop every cached resolution. Called whenever a key is minted or revoked so
+/// the TTL is a backstop rather than the mechanism.
+pub(crate) fn invalidate_api_key_cache() {
+    api_key_cache().write().clear();
+}
+
+/// Whether this engine has project keys, i.e. whether key-based auth is in play.
+pub(crate) fn project_keys_configured(store: &Store, cache: &SharedSchemaCache) -> bool {
+    !no_project_keys_configured(store, cache)
 }
 
 fn no_project_keys_configured(store: &Store, cache: &SharedSchemaCache) -> bool {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1646,7 +1646,7 @@ pub fn execute(
     };
 
     if cmd_eq(cmd, b"AUTH") {
-        return server::cmd_auth(args, store, out, now);
+        return server::cmd_auth(args, store, cache, out, now);
     }
 
     // Reserve the internal table-storage namespace ("_t:") from direct command

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -186,21 +186,41 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
-pub fn cmd_auth(args: &[&[u8]], store: &Store, out: &mut BytesMut, _now: Instant) -> CmdResult {
+pub fn cmd_auth(
+    args: &[&[u8]],
+    store: &Store,
+    cache: &crate::tables::SharedSchemaCache,
+    out: &mut BytesMut,
+    _now: Instant,
+) -> CmdResult {
     if args.len() < 2 {
         resp::write_error(out, "ERR wrong number of arguments for 'auth' command");
         return CmdResult::Written;
     }
-    let expected = &store.config().password;
-    if expected.is_empty() {
+    // RESP accepts the operator password or a secret key. A publishable key is
+    // browser-embedded and must never reach this protocol, so the resolver
+    // rejects it for `Surface::Resp` and we surface that reason verbatim.
+    let presented = arg_str(args[1]);
+    let no_credentials =
+        store.config().password.is_empty() && !crate::auth::project_keys_configured(store, cache);
+    if no_credentials {
         resp::write_error(out, "ERR Client sent AUTH, but no password is set");
-    } else if constant_time_eq(arg_str(args[1]).as_bytes(), expected.as_bytes()) {
-        resp::write_ok(out);
-        return CmdResult::Authenticated;
-    } else {
-        resp::write_error(out, "WRONGPASS invalid password");
+        return CmdResult::Written;
     }
-    CmdResult::Written
+    match crate::auth::resolve_credential(presented, "", crate::auth::Surface::Resp, store, cache) {
+        Ok(crate::auth::Credential::Operator | crate::auth::Credential::Secret) => {
+            resp::write_ok(out);
+            CmdResult::Authenticated
+        }
+        Err(e) => {
+            resp::write_error(out, &format!("WRONGPASS {e}"));
+            CmdResult::Written
+        }
+        Ok(_) => {
+            resp::write_error(out, "WRONGPASS invalid password");
+            CmdResult::Written
+        }
+    }
 }
 
 pub fn cmd_config(args: &[&[u8]], _store: &Store, out: &mut BytesMut, _now: Instant) -> CmdResult {

--- a/src/http.rs
+++ b/src/http.rs
@@ -22,6 +22,12 @@ const WEBSOCKET_ACCEPT_GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 enum HttpAuthContext {
     Anonymous,
+    /// Browser-safe project key with no end-user token behind it. Reaches
+    /// `/auth/v1/*` only; it identifies the project, not a person.
+    Publishable,
+    /// Server-side project key: full project access, same reach as the operator
+    /// password for data.
+    Secret,
     Operator,
     User(crate::auth::AuthPrincipal),
 }
@@ -31,26 +37,12 @@ enum HttpAuthContext {
 /// principals cannot (encrypted columns are omitted from their reads).
 fn decrypt_authorized(ctx: &HttpAuthContext) -> bool {
     match ctx {
-        HttpAuthContext::Operator => true,
+        // A secret key is a server-side credential with full project access, so
+        // it sees plaintext exactly as the operator does.
+        HttpAuthContext::Operator | HttpAuthContext::Secret => true,
         HttpAuthContext::User(p) => !p.is_anonymous,
-        HttpAuthContext::Anonymous => false,
+        HttpAuthContext::Anonymous | HttpAuthContext::Publishable => false,
     }
-}
-
-/// Constant-time byte comparison to prevent timing attacks on auth tokens.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        let mut _acc = 0u8;
-        for &byte in a {
-            _acc |= byte;
-        }
-        return false;
-    }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
 }
 
 /// Runtime options for the HTTP API listener.
@@ -240,38 +232,70 @@ async fn handle_request(
     } else {
         ""
     };
-    let password_ok = !password.is_empty()
-        && (constant_time_eq(bearer.as_bytes(), password.as_bytes())
-            || constant_time_eq(query_token.as_bytes(), password.as_bytes()));
-    let user_token = if !bearer.is_empty() {
+    // The project credential: `apikey` header, then the /live query param, then
+    // the bearer. The bearer is overloaded -- it can be the operator password, a
+    // project key, or an end-user JWT -- so the resolver sorts it out.
+    let apikey_header = headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("apikey"))
+        .map(|(_, v)| v.as_str())
+        .unwrap_or("");
+    let presented = if !apikey_header.is_empty() {
+        apikey_header
+    } else if !query_token.is_empty() {
+        query_token
+    } else {
+        bearer
+    };
+    // An end-user token rides *alongside* a project key (the browser case:
+    // `apikey=lux_pub_...` + `Authorization: Bearer <jwt>`). When the bearer is
+    // itself the presented credential, the resolver falls back to trying it as a
+    // user token on its own.
+    let user_token = if !query_access_token.is_empty() {
+        query_access_token
+    } else if presented != bearer {
         bearer
     } else {
-        query_access_token
+        ""
     };
-    let auth_context = if password_ok {
-        HttpAuthContext::Operator
-    } else if store.config().auth.enabled && !user_token.is_empty() {
-        match crate::auth::authenticate_access_token(user_token, store, cache) {
-            Ok(principal) => HttpAuthContext::User(principal),
-            Err(e) => {
-                let body = format!(r#"{{"error":"{}"}}"#, escape_json(&e));
-                return send_json(socket, 401, "Unauthorized", &body).await;
-            }
+
+    let auth_context = match crate::auth::resolve_credential(
+        presented,
+        user_token,
+        crate::auth::Surface::Http,
+        store,
+        cache,
+    ) {
+        Ok(crate::auth::Credential::Operator) => HttpAuthContext::Operator,
+        Ok(crate::auth::Credential::Secret) => HttpAuthContext::Secret,
+        Ok(crate::auth::Credential::Publishable) => HttpAuthContext::Publishable,
+        Ok(crate::auth::Credential::User(principal)) => HttpAuthContext::User(principal),
+        Ok(crate::auth::Credential::Anonymous) => HttpAuthContext::Anonymous,
+        Err(e) => {
+            let body = format!(r#"{{"error":"{}"}}"#, escape_json(&e));
+            return send_json(socket, 401, "Unauthorized", &body).await;
         }
-    } else {
-        HttpAuthContext::Anonymous
     };
-    if !password.is_empty() {
-        if !password_ok && !matches!(auth_context, HttpAuthContext::User(_)) {
-            let body = r#"{"error":"unauthorized"}"#;
+
+    // An engine is credential-gated once it has either a password or project
+    // keys. Before that (a bare local engine) it stays open, as it always has.
+    if !password.is_empty() || crate::auth::project_keys_configured(store, cache) {
+        let permitted = match &auth_context {
+            HttpAuthContext::Operator | HttpAuthContext::Secret | HttpAuthContext::User(_) => true,
+            // A publishable key identifies the project, not a person. It reaches
+            // auth (that is how a person is obtained) and nothing else until an
+            // end-user token makes it a User.
+            HttpAuthContext::Publishable => path.starts_with("/auth/v1"),
+            HttpAuthContext::Anonymous => false,
+        };
+        if !permitted {
+            let body = if matches!(auth_context, HttpAuthContext::Publishable) {
+                r#"{"error":"publishable key cannot access this route without an end-user token"}"#
+            } else {
+                r#"{"error":"unauthorized"}"#
+            };
             return send_json(socket, 401, "Unauthorized", body).await;
         }
-    } else if path == "/live"
-        && store.config().auth.enabled
-        && !matches!(auth_context, HttpAuthContext::User(_))
-    {
-        let body = r#"{"error":"unauthorized"}"#;
-        return send_json(socket, 401, "Unauthorized", body).await;
     }
 
     if method == "GET" && path == "/live" {
@@ -786,7 +810,12 @@ fn get_param<'a>(params: &'a [(String, String)], key: &str) -> Option<&'a str> {
 fn live_auth_principal(auth: &HttpAuthContext) -> Option<crate::auth::AuthPrincipal> {
     match auth {
         HttpAuthContext::User(principal) => Some(principal.clone()),
-        HttpAuthContext::Anonymous | HttpAuthContext::Operator => None,
+        // No principal: Operator/Secret are unfiltered, and Publishable never
+        // reaches /live without an end-user token (rejected at the gate).
+        HttpAuthContext::Anonymous
+        | HttpAuthContext::Operator
+        | HttpAuthContext::Secret
+        | HttpAuthContext::Publishable => None,
     }
 }
 
@@ -805,8 +834,11 @@ fn enforce_table_read(
         return Ok(None);
     }
     match auth {
-        HttpAuthContext::Operator => Ok(None),
-        HttpAuthContext::Anonymous => Err((
+        // Full project access: no row filter.
+        HttpAuthContext::Operator | HttpAuthContext::Secret => Ok(None),
+        // Publishable is refused at the gate; deny here too rather than trust
+        // that an upstream caller got it right.
+        HttpAuthContext::Anonymous | HttpAuthContext::Publishable => Err((
             401,
             "Unauthorized",
             r#"{"error":"unauthorized"}"#.to_string(),
@@ -839,8 +871,11 @@ fn enforce_table_insert(
         return Ok(());
     }
     match auth {
-        HttpAuthContext::Operator => Ok(()),
-        HttpAuthContext::Anonymous => Err((
+        // Full project access: no row filter.
+        HttpAuthContext::Operator | HttpAuthContext::Secret => Ok(()),
+        // Publishable is refused at the gate; deny here too rather than trust
+        // that an upstream caller got it right.
+        HttpAuthContext::Anonymous | HttpAuthContext::Publishable => Err((
             401,
             "Unauthorized",
             r#"{"error":"unauthorized"}"#.to_string(),
@@ -879,8 +914,11 @@ fn enforce_table_write_where(
         return Ok(None);
     }
     match auth {
-        HttpAuthContext::Operator => Ok(None),
-        HttpAuthContext::Anonymous => Err((
+        // Full project access: no row filter.
+        HttpAuthContext::Operator | HttpAuthContext::Secret => Ok(None),
+        // Publishable is refused at the gate; deny here too rather than trust
+        // that an upstream caller got it right.
+        HttpAuthContext::Anonymous | HttpAuthContext::Publishable => Err((
             401,
             "Unauthorized",
             r#"{"error":"unauthorized"}"#.to_string(),
@@ -913,8 +951,11 @@ fn enforce_table_update_check(
         return Ok(());
     }
     match auth {
-        HttpAuthContext::Operator => Ok(()),
-        HttpAuthContext::Anonymous => Err((
+        // Full project access: no row filter.
+        HttpAuthContext::Operator | HttpAuthContext::Secret => Ok(()),
+        // Publishable is refused at the gate; deny here too rather than trust
+        // that an upstream caller got it right.
+        HttpAuthContext::Anonymous | HttpAuthContext::Publishable => Err((
             401,
             "Unauthorized",
             r#"{"error":"unauthorized"}"#.to_string(),
@@ -965,7 +1006,7 @@ fn params_with_where(params: &[(String, String)], where_value: &str) -> Vec<(Str
 /// Gate an operator-only route. Under the grant model, token principals have no
 /// access to privileged routes (raw KV, exec, catalog, etc.); only an operator
 /// credential passes. Auth-disabled instances are open.
-fn require_operator(
+fn require_project_access(
     store: &Arc<Store>,
     auth: &HttpAuthContext,
 ) -> Result<(), (u16, &'static str, String)> {
@@ -973,8 +1014,11 @@ fn require_operator(
         return Ok(());
     }
     match auth {
-        HttpAuthContext::Operator => Ok(()),
-        HttpAuthContext::Anonymous => Err((
+        // A secret key is the project's server-side credential; these routes
+        // (exec, raw kv, tables, ts, vectors) are exactly what it exists to
+        // reach. The operator password remains valid as break-glass.
+        HttpAuthContext::Operator | HttpAuthContext::Secret => Ok(()),
+        HttpAuthContext::Anonymous | HttpAuthContext::Publishable => Err((
             401,
             "Unauthorized",
             r#"{"error":"unauthorized"}"#.to_string(),
@@ -982,7 +1026,7 @@ fn require_operator(
         HttpAuthContext::User(_) => Err((
             403,
             "Forbidden",
-            r#"{"error":"operator credentials required"}"#.to_string(),
+            r#"{"error":"a secret key is required for this route"}"#.to_string(),
         )),
     }
 }
@@ -2625,8 +2669,8 @@ fn route_request_with_auth(
         &segments[..]
     };
 
-    if route_requires_operator(method, base) {
-        if let Err(response) = require_operator(store, auth) {
+    if route_requires_project_access(method, base) {
+        if let Err(response) = require_project_access(store, auth) {
             return response;
         }
     }
@@ -2997,7 +3041,7 @@ fn route_request_with_auth(
 /// exec, time-series, vectors, table catalog) is off-limits to them. Per-table
 /// data routes (`/tables/{table}` GET/POST/PATCH/DELETE) deliberately return
 /// `false` here so the generic gate defers to the inline grant check.
-fn route_requires_operator(method: &str, base: &[&str]) -> bool {
+fn route_requires_project_access(method: &str, base: &[&str]) -> bool {
     matches!(
         (method, base),
         ("POST", ["exec"])
@@ -3071,7 +3115,7 @@ fn push_register(
     }
     let subject_id = match auth {
         HttpAuthContext::User(principal) => principal.user_id.clone(),
-        HttpAuthContext::Operator => {
+        HttpAuthContext::Operator | HttpAuthContext::Secret => {
             let s = parsed["subject_id"].as_str().unwrap_or("");
             if s.is_empty() {
                 return push_json_error(
@@ -3082,7 +3126,7 @@ fn push_register(
             }
             s.to_string()
         }
-        HttpAuthContext::Anonymous => {
+        HttpAuthContext::Anonymous | HttpAuthContext::Publishable => {
             return push_json_error(401, "Unauthorized", "authentication required")
         }
     };
@@ -3112,14 +3156,14 @@ fn push_list_devices(
 ) -> (u16, &'static str, String) {
     let subject_id = match auth {
         HttpAuthContext::User(principal) => principal.user_id.clone(),
-        HttpAuthContext::Operator => {
+        HttpAuthContext::Operator | HttpAuthContext::Secret => {
             let s = get_param(params, "subject_id").unwrap_or("");
             if s.is_empty() {
                 return push_json_error(400, "Bad Request", "subject_id query param is required");
             }
             s.to_string()
         }
-        HttpAuthContext::Anonymous => {
+        HttpAuthContext::Anonymous | HttpAuthContext::Publishable => {
             return push_json_error(401, "Unauthorized", "authentication required")
         }
     };
@@ -3141,10 +3185,10 @@ fn push_delete_device(
         HttpAuthContext::User(principal) => {
             crate::push::delete_device(store, cache, &principal.user_id, id, Instant::now())
         }
-        HttpAuthContext::Operator => {
+        HttpAuthContext::Operator | HttpAuthContext::Secret => {
             crate::push::delete_device_by_id(store, cache, id, Instant::now())
         }
-        HttpAuthContext::Anonymous => {
+        HttpAuthContext::Anonymous | HttpAuthContext::Publishable => {
             return push_json_error(401, "Unauthorized", "authentication required")
         }
     };
@@ -3733,7 +3777,7 @@ fn route_table_delete(
     // is a schema operation, not row access: operator-only.
     if let Some(val) = get_param(params, "drop") {
         if val == "true" {
-            if let Err((status, status_text, body)) = require_operator(store, auth) {
+            if let Err((status, status_text, body)) = require_project_access(store, auth) {
                 return (status, status_text, body);
             }
             return ok(exec_json(
@@ -4759,7 +4803,7 @@ mod tests {
             ("DELETE", vec!["tables", "messages"]),
         ] {
             assert!(
-                !route_requires_operator(m, &base),
+                !route_requires_project_access(m, &base),
                 "{m} /{} should be grant-gated, not operator-only",
                 base.join("/")
             );
@@ -4786,7 +4830,7 @@ mod tests {
             ("DELETE", vec!["vectors", "idx"]),
         ] {
             assert!(
-                route_requires_operator(m, &base),
+                route_requires_project_access(m, &base),
                 "{m} /{} must be operator-only",
                 base.join("/")
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,9 +418,21 @@ fn validate_listener_security(config: &ServerConfig) -> std::io::Result<()> {
         return Ok(());
     }
 
-    let resp_exposed_without_auth =
-        config.enable_resp && (config.password.is_empty() || !config.require_auth);
-    let http_exposed_without_auth = config.http_port != 0 && config.password.is_empty();
+    // A project key is a credential in its own right, so a key-only engine (one
+    // with no LUX_PASSWORD) is authenticated and may bind a public interface.
+    // Judging this by the password alone would refuse to start exactly the
+    // configuration the unified credential model is moving towards.
+    //
+    // Publishable keys do not count for RESP: they can never use that protocol,
+    // so a publishable-only engine really would be unauthenticated there.
+    let resp_authenticated = (!config.password.is_empty() && config.require_auth)
+        || config.auth.initial_secret_key.is_some();
+    let http_authenticated = !config.password.is_empty()
+        || config.auth.initial_secret_key.is_some()
+        || config.auth.initial_publishable_key.is_some();
+
+    let resp_exposed_without_auth = config.enable_resp && !resp_authenticated;
+    let http_exposed_without_auth = config.http_port != 0 && !http_authenticated;
     if resp_exposed_without_auth || http_exposed_without_auth {
         return Err(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
@@ -4039,7 +4051,14 @@ async fn handle_connection(
     let mut write_buf = BytesMut::with_capacity(65536);
     let mut pending = BytesMut::new();
     let max_resp_request = runtime.config.max_resp_request;
-    let mut session = CommandSession::new(runtime.config.require_auth);
+    // An engine is credential-gated by a password *or* by project keys. Checked
+    // per connection rather than per command: `require_auth` is fixed at startup,
+    // so without this a key-only engine (no LUX_PASSWORD) would leave RESP wide
+    // open, and keys minted at runtime would never start gating it.
+    let mut session = CommandSession::new(
+        runtime.config.require_auth
+            || crate::auth::project_keys_configured(&runtime.store, &runtime.schema_cache),
+    );
     let executor = CommandExecutor::new(
         runtime.store.clone(),
         runtime.broker.clone(),
@@ -4924,5 +4943,72 @@ mod tx_tests {
             assert!(tx_error, "{command} should mark the transaction dirty");
             assert!(tx_queue.is_empty(), "{command} should not be queued");
         }
+    }
+}
+
+#[cfg(test)]
+mod listener_security_tests {
+    use super::*;
+
+    /// A public-interface config with no credentials at all.
+    fn public_config() -> ServerConfig {
+        ServerConfig {
+            bind_host: "0.0.0.0".to_string(),
+            enable_resp: true,
+            http_port: 8080,
+            password: String::new(),
+            require_auth: false,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn refuses_public_listener_with_no_credentials() {
+        assert!(validate_listener_security(&public_config()).is_err());
+    }
+
+    #[test]
+    fn allows_public_listener_with_a_password() {
+        let mut config = public_config();
+        config.password = "s3cret".to_string();
+        config.require_auth = true;
+        assert!(validate_listener_security(&config).is_ok());
+    }
+
+    /// The key-only shape the credential model moves towards: a secret key and
+    /// no password. Judging this by the password alone would refuse to boot a
+    /// perfectly authenticated engine.
+    #[test]
+    fn allows_public_listener_with_only_a_secret_key() {
+        let mut config = public_config();
+        config.auth.initial_secret_key = Some("lux_sec_listener".to_string());
+        assert!(
+            validate_listener_security(&config).is_ok(),
+            "a secret key is a credential; key-only engines must be able to bind"
+        );
+    }
+
+    /// Publishable keys cannot use RESP, so a publishable-only engine really is
+    /// unauthenticated there and must still be refused.
+    #[test]
+    fn refuses_public_resp_listener_with_only_a_publishable_key() {
+        let mut config = public_config();
+        config.auth.initial_publishable_key = Some("lux_pub_listener".to_string());
+        assert!(validate_listener_security(&config).is_err());
+
+        // HTTP alone is fine: publishable is a real credential there.
+        config.enable_resp = false;
+        assert!(validate_listener_security(&config).is_ok());
+    }
+
+    #[test]
+    fn loopback_and_explicit_opt_out_still_bypass_the_check() {
+        let mut config = public_config();
+        config.bind_host = "127.0.0.1".to_string();
+        assert!(validate_listener_security(&config).is_ok());
+
+        let mut config = public_config();
+        config.allow_insecure_no_auth = true;
+        assert!(validate_listener_security(&config).is_ok());
     }
 }

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -154,3 +154,317 @@ fn hello_with_wrong_password_rejected() {
     let resp = send_and_read(&mut conn, &["SET", "k", "v"]);
     assert!(resp.contains("NOAUTH"), "still locked out: {resp}");
 }
+
+// --- Unified credential model -------------------------------------------------
+//
+// One `lux_sec_*` is meant to reach every surface: auth, data, native commands,
+// vectors, pubsub, lua. A `lux_pub_*` is browser-embedded, so it identifies the
+// project and nothing more: it reaches `/auth/v1/*` (that is how you obtain a
+// person) and is refused everywhere else until an end-user token makes it a
+// principal. The operator password stays valid as break-glass.
+//
+// The matrix is spelled out per surface because the failure mode for this kind
+// of change is one entry point disagreeing with the others.
+
+const SECRET: &str = "lux_sec_matrixtest";
+const PUBLISHABLE: &str = "lux_pub_matrixtest";
+
+fn keyed_server() -> LuxServer {
+    LuxServer::builder()
+        .http()
+        .env("LUX_AUTH_ENABLED", "1")
+        .env("LUX_AUTH_SECRET_KEY", SECRET)
+        .env("LUX_AUTH_PUBLISHABLE_KEY", PUBLISHABLE)
+        .start()
+}
+
+#[test]
+fn resp_auth_accepts_secret_key_and_refuses_publishable() {
+    let server = keyed_server();
+
+    let mut conn = server.conn();
+    let resp = send_and_read(&mut conn, &["AUTH", SECRET]);
+    assert!(
+        resp.starts_with("+OK"),
+        "secret key should authenticate: {resp}"
+    );
+    let pong = send_and_read(&mut conn, &["PING"]);
+    assert!(pong.contains("PONG"), "session usable after AUTH: {pong}");
+
+    // A publishable key is public by construction; RESP exposes lua, FLUSHALL
+    // and raw KV, which no grant can contain.
+    let mut conn = server.conn();
+    let resp = send_and_read(&mut conn, &["AUTH", PUBLISHABLE]);
+    assert!(
+        resp.starts_with("-WRONGPASS") && resp.contains("RESP"),
+        "publishable must be refused on RESP with a reason: {resp}"
+    );
+
+    let mut conn = server.conn();
+    let resp = send_and_read(&mut conn, &["AUTH", "lux_sec_not_a_real_key"]);
+    assert!(resp.starts_with("-WRONGPASS"), "unknown key: {resp}");
+}
+
+#[test]
+fn resp_refuses_commands_until_authenticated() {
+    let server = keyed_server();
+    let mut conn = server.conn();
+    let resp = send_and_read(&mut conn, &["DBSIZE"]);
+    assert!(resp.contains("NOAUTH"), "unauthenticated RESP: {resp}");
+}
+
+#[test]
+fn secret_key_reaches_every_http_surface() {
+    let server = keyed_server();
+    let port = server.http_port();
+
+    // Native commands, raw KV, tables and vectors were all operator-only. One
+    // secret key is the whole point of the model.
+    for (method, path, body) in [
+        ("POST", "/v1/exec", Some(r#"{"command":["PING"]}"#)),
+        ("GET", "/v1/dbsize", None),
+        ("PUT", "/v1/kv/matrix", Some(r#"{"value":"v"}"#)),
+        ("GET", "/v1/kv/matrix", None),
+        ("GET", "/v1/tables", None),
+    ] {
+        let (status, resp) = common::http_request(port, method, path, body, Some(SECRET));
+        assert!(
+            status < 400,
+            "{method} {path} with a secret key: {status} {resp}"
+        );
+    }
+}
+
+#[test]
+fn publishable_key_alone_reaches_auth_and_nothing_else() {
+    let server = keyed_server();
+    let port = server.http_port();
+
+    // Auth is reachable: it is how a publishable client obtains a principal.
+    let (status, resp) = common::http_request_with_headers(
+        port,
+        "POST",
+        "/auth/v1/signup",
+        Some(r#"{"email":"matrix@example.com","password":"hunter2hunter2"}"#),
+        None,
+        &[&format!("apikey: {PUBLISHABLE}")],
+    );
+    assert!(
+        status < 400,
+        "publishable must reach /auth/v1/signup: {status} {resp}"
+    );
+
+    // Data is not, on any shape of route.
+    for (method, path, body) in [
+        ("POST", "/v1/exec", Some(r#"{"command":["PING"]}"#)),
+        ("GET", "/v1/dbsize", None),
+        ("GET", "/v1/kv/matrix", None),
+        ("GET", "/v1/tables", None),
+    ] {
+        let (status, resp) = common::http_request_with_headers(
+            port,
+            method,
+            path,
+            body,
+            None,
+            &[&format!("apikey: {PUBLISHABLE}")],
+        );
+        assert_eq!(
+            status, 401,
+            "publishable must not reach {method} {path}: {status} {resp}"
+        );
+    }
+}
+
+#[test]
+fn operator_password_still_works_as_break_glass() {
+    let server = LuxServer::builder()
+        .http()
+        .password("breakglass")
+        .env("LUX_AUTH_ENABLED", "1")
+        .env("LUX_AUTH_SECRET_KEY", SECRET)
+        .start();
+
+    // Both credentials are live during and after the migration.
+    for credential in ["breakglass", SECRET] {
+        let (status, resp) = common::http_request(
+            server.http_port(),
+            "GET",
+            "/v1/dbsize",
+            None,
+            Some(credential),
+        );
+        assert!(status < 400, "{credential} on /v1/dbsize: {status} {resp}");
+    }
+
+    let mut conn = server.conn();
+    let resp = send_and_read(&mut conn, &["AUTH", "breakglass"]);
+    assert!(resp.starts_with("+OK"), "password on RESP: {resp}");
+}
+
+#[test]
+fn unknown_and_revoked_credentials_are_refused() {
+    let server = keyed_server();
+    let port = server.http_port();
+
+    for credential in ["lux_sec_wrong", "lux_pub_wrong", "not-a-key", ""] {
+        let (status, _) = common::http_request(port, "GET", "/v1/dbsize", None, Some(credential));
+        assert_eq!(status, 401, "credential {credential:?} must be refused");
+    }
+}
+
+#[test]
+fn revoking_a_key_takes_effect_immediately() {
+    let server = keyed_server();
+    let port = server.http_port();
+
+    // Mint a second secret key using the bootstrap one.
+    let (status, created) = common::http_request(
+        port,
+        "POST",
+        "/auth/v1/admin/keys",
+        Some(r#"{"kind":"secret","name":"revoke-me"}"#),
+        Some(SECRET),
+    );
+    assert!(status < 400, "create key: {status} {created}");
+    let minted = created
+        .split("\"plain_key\":\"")
+        .nth(1)
+        .and_then(|rest| rest.split('"').next())
+        .expect("minted key in response")
+        .to_string();
+    let key_id = created
+        .split("\"id\":\"")
+        .nth(1)
+        .and_then(|rest| rest.split('"').next())
+        .expect("key id in response")
+        .to_string();
+
+    // It works, which also warms the resolution cache.
+    for _ in 0..3 {
+        let (status, _) = common::http_request(port, "GET", "/v1/dbsize", None, Some(&minted));
+        assert_eq!(status, 200, "minted key should work");
+    }
+
+    let (status, body) = common::http_request(
+        port,
+        "DELETE",
+        &format!("/auth/v1/admin/keys/{key_id}"),
+        None,
+        Some(SECRET),
+    );
+    assert!(status < 400, "revoke: {status} {body}");
+
+    // Immediately, not after the cache TTL expires.
+    let (status, _) = common::http_request(port, "GET", "/v1/dbsize", None, Some(&minted));
+    assert_eq!(status, 401, "revoked key must stop working at once");
+
+    let mut conn = server.conn();
+    let resp = send_and_read(&mut conn, &["AUTH", &minted]);
+    assert!(
+        resp.starts_with("-WRONGPASS"),
+        "revoked key must not authenticate RESP: {resp}"
+    );
+}
+
+// The browser shape, and the reason publishable is not capped at read: a live
+// cursors app signs in anonymously (or as a user) and writes its own row
+// directly from the browser. `apikey: lux_pub_*` + `Authorization: Bearer <jwt>`
+// must read AND write exactly what the grant allows, and nothing else.
+#[test]
+fn publishable_with_end_user_token_reads_and_writes_per_grants() {
+    let server = keyed_server();
+    let port = server.http_port();
+
+    let exec = |cmd: &str| {
+        common::http_request(
+            port,
+            "POST",
+            "/v1/exec",
+            Some(&format!(r#"{{"command":{cmd}}}"#)),
+            Some(SECRET),
+        )
+    };
+    let (status, out) =
+        exec(r#"["TCREATE","cursors","id STR PRIMARY KEY,","owner_id STR,","x STR"]"#);
+    assert!(status < 400, "create table: {status} {out}");
+    let (status, out) =
+        exec(r#"["GRANT","read","write","ON","cursors","WHERE","owner_id","=","auth.uid()"]"#);
+    assert!(
+        status < 400 && !out.contains("error"),
+        "grant: {status} {out}"
+    );
+
+    let (status, signup) = common::http_request_with_headers(
+        port,
+        "POST",
+        "/auth/v1/signup",
+        Some(r#"{"email":"cursor@example.com","password":"hunter2hunter2"}"#),
+        None,
+        &[&format!("apikey: {PUBLISHABLE}")],
+    );
+    assert!(status < 400, "signup: {status} {signup}");
+    let field = |body: &str, key: &str| -> String {
+        body.split(&format!("\"{key}\":\""))
+            .nth(1)
+            .and_then(|rest| rest.split('"').next())
+            .unwrap_or_default()
+            .to_string()
+    };
+    let jwt = field(&signup, "access_token");
+    let uid = field(&signup, "id");
+    assert!(
+        !jwt.is_empty() && !uid.is_empty(),
+        "signup payload: {signup}"
+    );
+
+    let browser = [
+        format!("apikey: {PUBLISHABLE}"),
+        format!("Authorization: Bearer {jwt}"),
+    ];
+    let browser: Vec<&str> = browser.iter().map(String::as_str).collect();
+
+    // Writes its own row.
+    let (status, body) = common::http_request_with_headers(
+        port,
+        "POST",
+        "/v1/tables/cursors",
+        Some(&format!(r#"{{"id":"c1","owner_id":"{uid}","x":"10"}}"#)),
+        None,
+        &browser,
+    );
+    assert!(
+        status < 400,
+        "publishable+jwt must write its own row: {status} {body}"
+    );
+
+    // Reads it back.
+    let (status, body) =
+        common::http_request_with_headers(port, "GET", "/v1/tables/cursors", None, None, &browser);
+    assert!(
+        status < 400 && body.contains("c1"),
+        "publishable+jwt must read its own row: {status} {body}"
+    );
+
+    // The grant predicate still binds: someone else's row is refused.
+    let (status, body) = common::http_request_with_headers(
+        port,
+        "POST",
+        "/v1/tables/cursors",
+        Some(r#"{"id":"c2","owner_id":"someone-else","x":"99"}"#),
+        None,
+        &browser,
+    );
+    assert!(
+        status >= 400,
+        "grant predicate must block another user's row: {status} {body}"
+    );
+
+    // And a principal never reaches the secret-key routes.
+    let (status, body) =
+        common::http_request_with_headers(port, "GET", "/v1/dbsize", None, None, &browser);
+    assert!(
+        status >= 400,
+        "end-user principal must not reach secret-key routes: {status} {body}"
+    );
+}

--- a/tests/live_ws.rs
+++ b/tests/live_ws.rs
@@ -1199,3 +1199,102 @@ async fn live_websocket_rejects_wrong_query_param_key() {
         assert!(err.contains("401"), "{query}: unexpected error: {err}");
     }
 }
+
+// --- Secret key on /live ------------------------------------------------------
+//
+// A secret key is the server-side credential, so it must reach the live socket
+// on its own. Before the unified model the engine only knew the password, so a
+// server-side client could not subscribe at all and had to be given a session
+// (or hand-roll RESP pub/sub) instead.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_websocket_accepts_secret_key() {
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start_lux_with_env(
+        resp_port,
+        http_port,
+        None,
+        &[
+            ("LUX_AUTH_ENABLED", "1"),
+            ("LUX_AUTH_SECRET_KEY", "lux_sec_livetest"),
+            ("LUX_AUTH_PUBLISHABLE_KEY", "lux_pub_livetest"),
+        ],
+    );
+
+    // Both the header and the query-param handshake, since the SDK uses the
+    // latter and browsers cannot set headers.
+    let mut ws = connect_live(http_port, Some("lux_sec_livetest")).await;
+    assert_live_subscribes(&mut ws).await;
+
+    let mut ws = connect_live_query(http_port, "apikey=lux_sec_livetest")
+        .await
+        .expect("secret key should authenticate the /live handshake");
+    assert_live_subscribes(&mut ws).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_websocket_secret_key_subscribes_to_a_table() {
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start_lux_with_env(
+        resp_port,
+        http_port,
+        None,
+        &[
+            ("LUX_AUTH_ENABLED", "1"),
+            ("LUX_AUTH_SECRET_KEY", "lux_sec_livetest"),
+        ],
+    );
+
+    // Create the table over HTTP with the same key, which also demonstrates the
+    // point: one secret key covers both the data route and the live socket.
+    let (status, created) = http_json_request(
+        http_port,
+        "POST",
+        "/v1/tables",
+        r#"{"name":"notes","columns":[{"name":"id","type":"STR","primaryKey":true},{"name":"body","type":"STR"}]}"#,
+        Some("lux_sec_livetest"),
+    );
+    assert!(
+        status < 400,
+        "create table with secret key: {status} {created}"
+    );
+
+    let mut ws = connect_live_query(http_port, "apikey=lux_sec_livetest")
+        .await
+        .expect("secret key handshake");
+    send_json(
+        &mut ws,
+        json!({"type":"live.subscribe","id":"t","spec":{"kind":"table","table":"notes","select":"*"}}),
+    )
+    .await;
+    let subscribed = recv_json(&mut ws).await;
+    assert_eq!(
+        subscribed["type"], "live.subscribed",
+        "secret key must open a table subscription: {subscribed}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_websocket_refuses_publishable_key_without_a_user() {
+    let resp_port = free_port();
+    let http_port = free_port();
+    let _server = start_lux_with_env(
+        resp_port,
+        http_port,
+        None,
+        &[
+            ("LUX_AUTH_ENABLED", "1"),
+            ("LUX_AUTH_SECRET_KEY", "lux_sec_livetest"),
+            ("LUX_AUTH_PUBLISHABLE_KEY", "lux_pub_livetest"),
+        ],
+    );
+
+    // Publishable identifies the project, not a person. Without an end-user
+    // token there is no principal to evaluate grants against, so no data.
+    let err = connect_live_query(http_port, "apikey=lux_pub_livetest")
+        .await
+        .expect_err("publishable alone must not open a live socket");
+    assert!(err.contains("401"), "unexpected error: {err}");
+}


### PR DESCRIPTION
#54 was merged into `fix/live-auth-and-table-subscribe` instead of `main` because its base was never retargeted after #53 landed, so the credential work never reached main. Found it diffing main while preparing the release; tagging then would have shipped only the `/live` fix.

Cherry-pick of that merge commit onto main. `git diff` against the merged branch is empty, so the tree is identical and the review on #54 still holds.

`auth` 19, `live_ws` 21, `ksub` 9, `http` 34 green on top of main. Full suite and perf numbers are on #54.
