### PR TITLE
chore: bump version to 0.33.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "lux"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "argon2",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lux"
-version = "0.32.2"
+version = "0.33.0"
 edition = "2021"
 description = "An open-source application database engine with tables, cache, vectors, auth, realtime, queues, time series, and Redis-compatible commands."
 license = "MIT"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@luxdb/sdk",
-    "version": "2.10.0",
+    "version": "3.0.0",
     "description": "Official Lux TypeScript SDK for app data, auth, tables, vectors, realtime, and Redis-compatible direct access",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",


### PR DESCRIPTION
Version bump for #53 and #55.

engine 0.32.2 -> 0.33.0. Minor not patch: key-only engines now require AUTH on RESP, they didn't before. Release notes should say so for self-hosted; Cloud and `lux start` both set a password so neither is affected.

sdk 2.10.0 -> 3.0.0. Drops the `TableSubscription` and `table().subscribe()` exports.

fmt, clippy and 1044 tests pass on this tree.

`release.yml` runs `cargo test --all-targets` without `--no-fail-fast`, and `push_web_push_delivers_encrypted` flakes on a startup timeout under load. Re-run if the release job goes red on that.
