### PR TITLE
fix(auth): honor allow-listed custom schemes; derive the auth base URL

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -7479,7 +7479,7 @@ mod redirect_validation_tests {
     /// The allow list used to accept a custom scheme that `authorize` then
     /// refused, so the setting looked configured and failed at sign-in on a
     /// phone. Native OAuth needs custom schemes, and the allow list is the
-    /// security boundary, so an explicitly listed one is honoured.
+    /// security boundary, so an explicitly listed one is honored.
     #[test]
     fn allow_listed_custom_scheme_is_accepted() {
         let s = settings("http://localhost:5990", &["vigil://auth/callback"]);

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3747,7 +3747,22 @@ fn validate_auth_redirect(redirect: &str, settings: &AuthSettings) -> Result<Str
         return Ok(redirect);
     }
     let Some(target_origin) = url_origin(&redirect) else {
-        return Err("redirect URL must be relative or absolute http(s) URL".to_string());
+        // A custom scheme (`myapp://auth/callback`) has no http(s) origin, so it
+        // can only ever match an allow-list entry exactly. Native OAuth needs
+        // one of these or a universal link, and the allow list is the security
+        // boundary: an unlisted scheme is still refused. Without this the allow
+        // list accepted a value that `authorize` then rejected at sign-in time.
+        if settings
+            .redirect_allow_list
+            .iter()
+            .any(|allowed| allowed.trim() == redirect)
+        {
+            return Ok(redirect);
+        }
+        return Err(
+            "redirect URL must be relative, http(s), or a custom scheme on the redirect allow list"
+                .to_string(),
+        );
     };
     if url_origin(&settings.site_url).as_deref() == Some(target_origin.as_str()) {
         return Ok(redirect);
@@ -7438,5 +7453,77 @@ mod tests {
             user.get("email").map(String::as_str),
             Some("wal@example.com")
         );
+    }
+}
+
+#[cfg(test)]
+mod redirect_validation_tests {
+    use super::*;
+
+    fn settings(site_url: &str, allow: &[&str]) -> AuthSettings {
+        AuthSettings {
+            email_confirmation_required: false,
+            flow_token_ttl: Duration::from_secs(3600),
+            site_url: site_url.to_string(),
+            redirect_allow_list: allow.iter().map(|s| s.to_string()).collect(),
+            email_provider: "console".to_string(),
+            email_from: None,
+            email_reply_to: None,
+            email_postmark_server_token: None,
+            email_postmark_message_stream: "outbound".to_string(),
+            email_app_name: "Lux".to_string(),
+            email_from_name: None,
+        }
+    }
+
+    /// The allow list used to accept a custom scheme that `authorize` then
+    /// refused, so the setting looked configured and failed at sign-in on a
+    /// phone. Native OAuth needs custom schemes, and the allow list is the
+    /// security boundary, so an explicitly listed one is honoured.
+    #[test]
+    fn allow_listed_custom_scheme_is_accepted() {
+        let s = settings("http://localhost:5990", &["vigil://auth/callback"]);
+        assert_eq!(
+            validate_auth_redirect("vigil://auth/callback", &s).unwrap(),
+            "vigil://auth/callback"
+        );
+    }
+
+    #[test]
+    fn unlisted_custom_scheme_is_still_refused() {
+        let s = settings("http://localhost:5990", &["vigil://auth/callback"]);
+        let err = validate_auth_redirect("evil://auth/callback", &s).unwrap_err();
+        assert!(err.contains("allow list"), "unexpected error: {err}");
+
+        // And with no allow list at all.
+        let s = settings("http://localhost:5990", &[]);
+        assert!(validate_auth_redirect("vigil://auth/callback", &s).is_err());
+    }
+
+    /// A custom scheme matches only exactly: it has no origin to compare, so
+    /// prefix games must not get through.
+    #[test]
+    fn custom_scheme_matches_exactly_not_by_prefix() {
+        let s = settings("http://localhost:5990", &["vigil://auth/callback"]);
+        for attempt in [
+            "vigil://auth/callback/../elsewhere",
+            "vigil://auth/callbackevil",
+            "vigil://evil",
+            "vigil://auth",
+        ] {
+            assert!(
+                validate_auth_redirect(attempt, &s).is_err(),
+                "{attempt} must not match the allow-listed scheme"
+            );
+        }
+    }
+
+    #[test]
+    fn http_and_relative_redirects_still_behave() {
+        let s = settings("http://localhost:5990", &["http://localhost:3000/cb"]);
+        assert!(validate_auth_redirect("/dashboard", &s).is_ok());
+        assert!(validate_auth_redirect("http://localhost:5990/anything", &s).is_ok());
+        assert!(validate_auth_redirect("http://localhost:3000/cb", &s).is_ok());
+        assert!(validate_auth_redirect("http://evil.example/cb", &s).is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,14 +177,14 @@ impl Default for AuthConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            issuer: "http://localhost:7379/auth/v1".to_string(),
+            issuer: "http://localhost:5890/auth/v1".to_string(),
             access_token_ttl: Duration::from_secs(3600),
             refresh_token_ttl: Duration::from_secs(30 * 24 * 60 * 60),
             email_password_enabled: true,
             email_confirmation_required: false,
             anonymous_enabled: true,
             flow_token_ttl: Duration::from_secs(24 * 60 * 60),
-            site_url: "http://localhost:7379".to_string(),
+            site_url: "http://localhost:5890".to_string(),
             initial_publishable_key: None,
             initial_secret_key: None,
             managed_email: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,16 @@ async fn async_main() -> std::io::Result<()> {
 
     let encryption = encryption_config_from_env()?;
 
+    // `site_url` and `issuer` default to the address this engine actually serves
+    // HTTP on. They used to hardcode port 7379, which is not the RESP port, the
+    // HTTP port, or the Studio port -- a default that looked derived and was not.
+    let auth_http_port = std::env::var("LUX_HTTP_PORT")
+        .ok()
+        .and_then(|s| s.parse::<u16>().ok())
+        .filter(|port| *port != 0)
+        .unwrap_or(5890);
+    let auth_base_url = format!("http://localhost:{auth_http_port}");
+
     let config = lux::ServerConfig {
         bind_host: std::env::var("LUX_BIND_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
         port: std::env::var("LUX_PORT")
@@ -119,7 +129,7 @@ async fn async_main() -> std::io::Result<()> {
         auth: lux::AuthConfig {
             enabled: auth_enabled,
             issuer: std::env::var("LUX_AUTH_ISSUER")
-                .unwrap_or_else(|_| "http://localhost:7379/auth/v1".to_string()),
+                .unwrap_or_else(|_| format!("{auth_base_url}/auth/v1")),
             access_token_ttl: std::time::Duration::from_secs(auth_access_token_ttl),
             refresh_token_ttl: std::time::Duration::from_secs(auth_refresh_token_ttl),
             email_password_enabled: std::env::var("LUX_AUTH_EMAIL_PASSWORD").map_or(true, |v| {
@@ -141,8 +151,7 @@ async fn async_main() -> std::io::Result<()> {
                     .and_then(|v| v.parse().ok())
                     .unwrap_or(24 * 60 * 60),
             ),
-            site_url: std::env::var("LUX_AUTH_SITE_URL")
-                .unwrap_or_else(|_| "http://localhost:7379".to_string()),
+            site_url: std::env::var("LUX_AUTH_SITE_URL").unwrap_or_else(|_| auth_base_url.clone()),
             initial_publishable_key: std::env::var("LUX_AUTH_PUBLISHABLE_KEY").ok(),
             initial_secret_key: std::env::var("LUX_AUTH_SECRET_KEY").ok(),
             managed_email,


### PR DESCRIPTION
`redirect_allow_list` accepted `vigil://auth/callback` and stored it, then `authorize` returned 400 on it at sign-in. `validate_auth_redirect` returned early on anything without an http(s) origin, so it never looked at the allow list. Allow-listed schemes pass now, exact match only, so `vigil://auth/callbackevil`, path traversal and unlisted schemes still fail.

`site_url` and `issuer` defaulted to `http://localhost:7379`, which isn't the RESP port, the HTTP port or the Studio port. Both derive from the HTTP port now.

Unknown routes already return 404 when you're authenticated so there's nothing to fix there. Pre-auth stays 401, otherwise anyone can enumerate routes.

1048 tests, clippy clean, both checked against a running engine.
