### PR TITLE
fix(cli): stop migrate status reporting applied migrations as pending

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -698,7 +698,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lux-cli"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lux-cli"
-version = "0.26.1"
+version = "0.26.2"
 edition = "2021"
 description = "CLI for Lux"
 license = "MIT"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3485,28 +3485,38 @@ async fn ensure_migrations_table(target: &mut MigrateTarget) {
     }
 }
 
+/// Only the filename is needed to decide what is pending. Selecting `*` also
+/// pulls `body`, the full source of every migration, which grows the response
+/// until the exec endpoint times out. That timeout used to be swallowed and
+/// reported as "0 applied", so every migration looked pending, re-running
+/// replayed them all and died on `table already exists`.
+const APPLIED_MIGRATIONS_QUERY: &str = "TSELECT filename FROM __migrations LIMIT 10000";
+
 async fn get_applied_migrations(target: &mut MigrateTarget) -> Result<HashSet<String>, String> {
-    // Probe reachability/auth first. A failing PING is fatal and must surface;
-    // errors from the TSELECT below are treated as "no __migrations table yet"
-    // (0 applied). Without this, an unreachable or unauthenticated target was
-    // silently reported as "all pending" (which masked a real control-plane bug).
+    // Probe reachability/auth first. A failing PING is fatal and must surface.
     target.exec("PING").await?;
+
+    // A missing table means nothing has been applied yet, which is a legitimate
+    // empty set. Any other read failure is fatal: reporting it as "0 applied" is
+    // what turns a transient error into a destructive replay.
+    if target.exec("TSCHEMA __migrations").await.is_err() {
+        return Ok(HashSet::new());
+    }
 
     let mut applied = HashSet::new();
 
     match target {
         MigrateTarget::Direct(conn) => {
-            if let Ok(rows) = conn
-                .exec_table_rows("TSELECT * FROM __migrations ORDER BY applied_at ASC LIMIT 1000")
-            {
-                // Each row: ["field", value, "field", value, ...]
-                for row in &rows {
-                    for i in 0..row.len().saturating_sub(1) {
-                        if row[i] == "filename" {
-                            let name = &row[i + 1];
-                            if !name.is_empty() {
-                                applied.insert(name.clone());
-                            }
+            let rows = conn
+                .exec_table_rows(APPLIED_MIGRATIONS_QUERY)
+                .map_err(|e| format!("could not read applied migrations: {e}"))?;
+            // Each row: ["field", value, "field", value, ...]
+            for row in &rows {
+                for i in 0..row.len().saturating_sub(1) {
+                    if row[i] == "filename" {
+                        let name = &row[i + 1];
+                        if !name.is_empty() {
+                            applied.insert(name.clone());
                         }
                     }
                 }
@@ -3518,25 +3528,24 @@ async fn get_applied_migrations(target: &mut MigrateTarget) -> Result<HashSet<St
             token,
             instance_id,
         } => {
-            if let Ok(body) = exec_command_json(
+            let body = exec_command_json(
                 client,
                 api_url,
                 token,
                 instance_id,
-                "TSELECT * FROM __migrations ORDER BY applied_at ASC LIMIT 1000",
+                APPLIED_MIGRATIONS_QUERY,
             )
             .await
-            {
-                // API returns [["field", "val", ...], ...]
-                if let Some(rows) = body.as_array() {
-                    for row in rows {
-                        if let Some(fields) = row.as_array() {
-                            for i in 0..fields.len().saturating_sub(1) {
-                                if fields[i].as_str() == Some("filename") {
-                                    if let Some(name) = fields[i + 1].as_str() {
-                                        if !name.is_empty() {
-                                            applied.insert(name.to_string());
-                                        }
+            .map_err(|e| format!("could not read applied migrations: {e}"))?;
+            // API returns [["field", "val", ...], ...]
+            if let Some(rows) = body.as_array() {
+                for row in rows {
+                    if let Some(fields) = row.as_array() {
+                        for i in 0..fields.len().saturating_sub(1) {
+                            if fields[i].as_str() == Some("filename") {
+                                if let Some(name) = fields[i + 1].as_str() {
+                                    if !name.is_empty() {
+                                        applied.insert(name.to_string());
                                     }
                                 }
                             }


### PR DESCRIPTION
`lux migrate run` applied migrations and `lux migrate status` then listed all of them as pending on the same target, so a second run replayed everything and died on `table already exists`. It looked like nothing was being recorded.

Migrations were being recorded the whole time. `get_applied_migrations` ran `TSELECT *` on `__migrations`, which pulls the `body` column holding the full source of every migration, and the response got big enough to time out the exec endpoint. The error was swallowed by an `if let Ok(...)`, so the applied set came back empty and everything read as pending. Each failed status led to a replay, which inserted duplicate rows, which made the response bigger.

Against the real cloud project:

```
TSELECT * FROM __migrations LIMIT 1000                       -> {"error":"timeout"}
TSELECT filename FROM __migrations ORDER BY applied_at ...   -> 7 rows
```

Selects `filename` only, since that is all the pending check needs. A read failure is now fatal rather than being reported as zero applied, because that is what turns a transient error into a destructive replay. A missing table is still a legitimate empty set.

Verified against the vigil cloud project, which has 7 migrations: all reported pending before, all applied after. CLI tests, fmt and clippy clean. Bumps to 0.26.2.

Doesn't touch the duplicate rows already in existing tables; the filename set dedupes them.