### PR TITLE
feat(push): route each device to its own APNs host

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@luxdb/sdk",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "description": "Official Lux TypeScript SDK for app data, auth, tables, vectors, realtime, and Redis-compatible direct access",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",

--- a/sdk/src/push.ts
+++ b/sdk/src/push.ts
@@ -7,6 +7,9 @@ export interface LuxPushDevice {
 	subject_id?: string;
 	platform: string;
 	app_id: string;
+	/** The APNs host this token belongs to: `'sandbox'`, `'production'`, or
+	 *  `''` when the device did not say and the app credential decides. */
+	environment?: string;
 	created_at: string;
 	last_seen_at: string;
 }
@@ -18,6 +21,15 @@ export interface LuxPushRegisterOptions {
 	platform?: string;
 	/** App/credential set to route through. Defaults to `'default'`. */
 	app_id?: string;
+	/**
+	 * Which APNs host minted this token. Apple issues `'sandbox'` tokens to
+	 * development builds and `'production'` tokens to TestFlight and the App
+	 * Store, and a token only works against its own host, so a team that is
+	 * still developing while testers are on a build has both in use at once.
+	 * Read it from the `aps-environment` entitlement. Omit it and delivery falls
+	 * back to the environment on the app's credential.
+	 */
+	environment?: 'sandbox' | 'production';
 }
 
 /** A notification. `title`/`body` render the alert; the rest map to APNs `aps`
@@ -58,6 +70,7 @@ export class LuxPushNamespace {
 			token: options.token,
 			platform: options.platform ?? 'ios',
 			app_id: options.app_id ?? 'default',
+			environment: options.environment ?? '',
 		});
 	}
 
@@ -71,6 +84,7 @@ export class LuxPushNamespace {
 			token: options.token,
 			platform: options.platform ?? 'ios',
 			app_id: options.app_id ?? 'default',
+			environment: options.environment ?? '',
 		});
 	}
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2589,6 +2589,43 @@ pub(crate) fn create_table_if_missing(
     }
 }
 
+/// Add a column to an existing internal table if it isn't there already. The
+/// companion to `create_table_if_missing` for schema that arrives after a table
+/// has already shipped: new projects pick the column up from the CREATE, and
+/// projects created before it get it from here.
+///
+/// `tables::table_add_column` does not append to the WAL of its own accord. RESP
+/// and HTTP `TALTER` are raw-logged by `execute_with_wal`, which internal callers
+/// never reach, so log the resolved command here or the column is lost on replay.
+pub(crate) fn add_column_if_missing(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    table: &str,
+    field_spec: &str,
+    now: Instant,
+) -> Result<(), String> {
+    let mut tokens = field_spec.split_whitespace();
+    let Some(column) = tokens.next() else {
+        return Err("ERR empty column spec".to_string());
+    };
+    let schema = tables::table_schema(store, cache, table, now)?;
+    if schema
+        .iter()
+        .any(|field| field.split_whitespace().next() == Some(column))
+    {
+        return Ok(());
+    }
+
+    let mut args: Vec<Vec<u8>> = vec![
+        b"TALTER".to_vec(),
+        table.as_bytes().to_vec(),
+        b"ADD".to_vec(),
+    ];
+    args.extend(field_spec.split_whitespace().map(|t| t.as_bytes().to_vec()));
+    log_command(store, &args)?;
+    tables::table_add_column(store, cache, table, field_spec, now)
+}
+
 pub(crate) fn durable_table_insert(
     store: &Store,
     cache: &SharedSchemaCache,
@@ -5514,6 +5551,88 @@ mod tests {
             op: o.into(),
             value: v.into(),
         }
+    }
+
+    #[test]
+    fn add_column_if_missing_is_idempotent_and_leaves_existing_schema_alone() {
+        let store = Store::new();
+        let cache = Arc::new(RwLock::new(SchemaCache::new()));
+        let now = Instant::now();
+
+        create_table_if_missing(
+            &store,
+            &cache,
+            "widgets",
+            &["id STR PRIMARY KEY,", "name STR"],
+            now,
+        )
+        .unwrap();
+        crate::tables::table_insert(
+            &store,
+            &cache,
+            "widgets",
+            &[("id", "w1"), ("name", "bolt")],
+            now,
+        )
+        .unwrap();
+
+        add_column_if_missing(&store, &cache, "widgets", "environment STR", now).unwrap();
+        let schema = crate::tables::table_schema(&store, &cache, "widgets", now).unwrap();
+        assert!(
+            schema.iter().any(|f| f.starts_with("environment ")),
+            "column not added: {schema:?}"
+        );
+
+        // Called on every `ensure_tables`, so a second call must be a no-op
+        // rather than the "field already exists" error `table_add_column` raises.
+        add_column_if_missing(&store, &cache, "widgets", "environment STR", now).unwrap();
+        let after = crate::tables::table_schema(&store, &cache, "widgets", now).unwrap();
+        assert_eq!(schema, after);
+
+        // The existing row survives the backfill.
+        let row = find_row_by_field(&store, &cache, "widgets", "id", "w1", now)
+            .unwrap()
+            .expect("row should survive the column add");
+        assert_eq!(row.get("name").map(String::as_str), Some("bolt"));
+    }
+
+    // `table_add_column` does not log itself, and internal callers never reach
+    // `execute_with_wal`, so without the explicit log in `add_column_if_missing`
+    // the column would vanish on any restart that replays from the WAL.
+    #[test]
+    fn add_column_if_missing_survives_wal_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(crate::ServerConfig {
+            storage: crate::StorageConfig {
+                mode: crate::StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..crate::ServerConfig::default()
+        });
+        let store = Arc::new(Store::new_with_config(config.clone()));
+        let cache = Arc::new(RwLock::new(SchemaCache::new()));
+        let now = Instant::now();
+
+        create_table_if_missing(
+            &store,
+            &cache,
+            "widgets",
+            &["id STR PRIMARY KEY,", "name STR"],
+            now,
+        )
+        .unwrap();
+        add_column_if_missing(&store, &cache, "widgets", "environment STR", now).unwrap();
+        store.fsync_wal();
+
+        let restored = Arc::new(Store::new_with_config(config));
+        restored.replay_wal(&crate::pubsub::Broker::new());
+        let restored_cache = Arc::new(RwLock::new(SchemaCache::new()));
+        let schema =
+            crate::tables::table_schema(&restored, &restored_cache, "widgets", now).unwrap();
+        assert!(
+            schema.iter().any(|f| f.starts_with("environment ")),
+            "column lost on replay: {schema:?}"
+        );
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -3132,13 +3132,19 @@ fn push_register(
     };
     let platform = parsed["platform"].as_str().unwrap_or("ios");
     let app_id = parsed["app_id"].as_str().unwrap_or("default");
+    // "sandbox" or "production". Optional: an app that omits it keeps the old
+    // behaviour of routing by the project's credential.
+    let environment = parsed["environment"].as_str().unwrap_or("");
     match crate::push::register_device(
         store,
         cache,
-        &subject_id,
-        token,
-        platform,
-        app_id,
+        crate::push::DeviceRegistration {
+            subject_id: &subject_id,
+            token,
+            platform,
+            app_id,
+            environment,
+        },
         Instant::now(),
     ) {
         Ok(id) => ok(format!(r#"{{"id":{}}}"#, serde_json::Value::String(id))),

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -307,6 +307,35 @@ mod tests {
             .to_string()
     }
 
+    // The two hosts are the whole reason a device carries an environment: one
+    // `.p8` signs for both, and a token minted for one is rejected by the other.
+    #[test]
+    fn base_url_splits_sandbox_from_production() {
+        assert_eq!(
+            ApnsSink::resolve_base_url("production"),
+            "https://api.push.apple.com"
+        );
+        assert_eq!(
+            ApnsSink::resolve_base_url("prod"),
+            "https://api.push.apple.com"
+        );
+        assert_eq!(
+            ApnsSink::resolve_base_url("sandbox"),
+            "https://api.sandbox.push.apple.com"
+        );
+        // Unknown values are sandbox, so a misconfiguration cannot silently
+        // deliver to real users.
+        assert_eq!(
+            ApnsSink::resolve_base_url(""),
+            "https://api.sandbox.push.apple.com"
+        );
+        // An explicit base survives verbatim; the tests point it at a mock.
+        assert_eq!(
+            ApnsSink::resolve_base_url("http://127.0.0.1:9000/"),
+            "http://127.0.0.1:9000"
+        );
+    }
+
     fn sink_with(p8: String) -> ApnsSink {
         ApnsSink::new(
             "https://api.sandbox.push.apple.com",

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -17,8 +17,8 @@ use bytes::BytesMut;
 use serde_json::{json, Value};
 
 use crate::auth::{
-    create_table_if_missing, durable_table_delete_where, durable_table_insert,
-    durable_table_update_where, find_row_by_field, random_id, unix_seconds,
+    add_column_if_missing, create_table_if_missing, durable_table_delete_where,
+    durable_table_insert, durable_table_update_where, find_row_by_field, random_id, unix_seconds,
 };
 use crate::resp;
 use crate::store::Store;
@@ -53,12 +53,21 @@ pub(crate) fn ensure_tables(
             "token STR,",
             "platform STR,",
             "app_id STR,",
+            // Which APNs host this token was minted for. Apple issues sandbox
+            // tokens to development builds and production tokens to TestFlight
+            // and the App Store, and a token is only valid against its own host.
+            // Empty means the registrant did not say, and delivery falls back to
+            // the app credential's `environment`.
+            "environment STR,",
             "created_at INT,",
             "last_seen_at INT,",
             "disabled_at INT",
         ],
         now,
     )?;
+    // `environment` arrived after `push.devices` shipped, so projects that
+    // registered a device on an older engine still have the original schema.
+    add_column_if_missing(store, cache, DEVICES_TABLE, "environment STR", now)?;
     create_table_if_missing(
         store,
         cache,
@@ -88,6 +97,10 @@ pub(crate) fn ensure_tables(
             "app_id STR,",
             "target_token STR,",
             "platform STR,",
+            // Copied from the device at enqueue so the row still routes to the
+            // right APNs host if the device re-registers or is deleted before
+            // the worker drains it.
+            "environment STR,",
             "payload STR,",
             "attempts INT,",
             "next_attempt_at INT,",
@@ -97,6 +110,7 @@ pub(crate) fn ensure_tables(
         ],
         now,
     )?;
+    add_column_if_missing(store, cache, OUTBOX_TABLE, "environment STR", now)?;
     Ok(())
 }
 
@@ -154,10 +168,15 @@ pub(crate) fn migrate_from_auth_scope(
         register_device(
             store,
             cache,
-            &m.get("user_id").cloned().unwrap_or_default(),
-            &token,
-            &m.get("platform").cloned().unwrap_or_else(|| "ios".into()),
-            &m.get("app_id").cloned().unwrap_or_else(|| "default".into()),
+            DeviceRegistration {
+                subject_id: &m.get("user_id").cloned().unwrap_or_default(),
+                token: &token,
+                platform: &m.get("platform").cloned().unwrap_or_else(|| "ios".into()),
+                app_id: &m.get("app_id").cloned().unwrap_or_else(|| "default".into()),
+                // The legacy layout had no per-device environment; delivery
+                // falls back to the app credential, as it did before.
+                environment: "",
+            },
             now,
         )?;
     }
@@ -212,23 +231,66 @@ pub(crate) struct ResolvedVapidCreds {
 // Device registry
 // ---------------------------------------------------------------------------
 
+/// Normalize a caller-supplied APNs environment to what `resolve_base_url`
+/// understands. An explicit `http(s)://` base survives verbatim, matching the
+/// override the app credential already accepts. Anything else unrecognized is
+/// treated as unspecified rather than guessed at, so delivery falls back to the
+/// app credential instead of silently routing to the wrong host.
+pub(crate) fn normalize_environment(environment: &str) -> String {
+    let trimmed = environment.trim();
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return trimmed.to_string();
+    }
+    match trimmed.to_ascii_lowercase().as_str() {
+        "production" | "prod" => "production".to_string(),
+        "sandbox" | "development" | "dev" => "sandbox".to_string(),
+        _ => String::new(),
+    }
+}
+
 /// Register (or refresh) a device token for `subject_id`. A token is unique
 /// across the registry: re-registering an existing token re-points it at the
 /// current subject and re-activates it rather than duplicating. Returns the
 /// device id.
+///
+/// `environment` is the APNs host the token belongs to ("sandbox" or
+/// "production"); empty means unspecified. A development build and a TestFlight
+/// build of the same app hold tokens for different hosts at the same time, so
+/// this is per device, not per project.
+pub(crate) struct DeviceRegistration<'a> {
+    pub subject_id: &'a str,
+    pub token: &'a str,
+    pub platform: &'a str,
+    pub app_id: &'a str,
+    /// "sandbox", "production", or empty for unspecified.
+    pub environment: &'a str,
+}
+
 pub(crate) fn register_device(
     store: &Store,
     cache: &SharedSchemaCache,
-    subject_id: &str,
-    token: &str,
-    platform: &str,
-    app_id: &str,
+    device: DeviceRegistration<'_>,
     now: Instant,
 ) -> Result<String, String> {
+    let DeviceRegistration {
+        subject_id,
+        token,
+        platform,
+        app_id,
+        environment,
+    } = device;
     ensure_tables(store, cache, now)?;
+    let environment = normalize_environment(environment);
     let now_s = unix_seconds().to_string();
     if let Some(existing) = find_row_by_field(store, cache, DEVICES_TABLE, "token", token, now)? {
         let id = existing.get("id").cloned().unwrap_or_default();
+        // A re-register that omits the environment must not erase a known one:
+        // the same token cannot move hosts, so silence means "unchanged".
+        let environment = if environment.is_empty() {
+            existing.get("environment").cloned().unwrap_or_default()
+        } else {
+            environment
+        };
         durable_table_update_where(
             store,
             cache,
@@ -237,6 +299,7 @@ pub(crate) fn register_device(
                 ("subject_id", subject_id),
                 ("platform", platform),
                 ("app_id", app_id),
+                ("environment", environment.as_str()),
                 ("last_seen_at", now_s.as_str()),
                 ("disabled_at", "0"),
             ],
@@ -256,6 +319,7 @@ pub(crate) fn register_device(
             ("token", token),
             ("platform", platform),
             ("app_id", app_id),
+            ("environment", environment.as_str()),
             ("created_at", now_s.as_str()),
             ("last_seen_at", now_s.as_str()),
             ("disabled_at", "0"),
@@ -292,6 +356,7 @@ pub(crate) fn list_devices(
                 "id": m.get("id").cloned().unwrap_or_default(),
                 "platform": m.get("platform").cloned().unwrap_or_default(),
                 "app_id": m.get("app_id").cloned().unwrap_or_default(),
+                "environment": m.get("environment").cloned().unwrap_or_default(),
                 "created_at": m.get("created_at").cloned().unwrap_or_default(),
                 "last_seen_at": m.get("last_seen_at").cloned().unwrap_or_default(),
             })
@@ -371,6 +436,7 @@ pub(crate) fn list_all_devices(
                 "subject_id": m.get("subject_id").cloned().unwrap_or_default(),
                 "platform": m.get("platform").cloned().unwrap_or_default(),
                 "app_id": m.get("app_id").cloned().unwrap_or_default(),
+                "environment": m.get("environment").cloned().unwrap_or_default(),
                 "created_at": m.get("created_at").cloned().unwrap_or_default(),
                 "last_seen_at": m.get("last_seen_at").cloned().unwrap_or_default(),
                 "disabled_at": m.get("disabled_at").cloned().unwrap_or_default(),
@@ -406,6 +472,7 @@ pub(crate) fn list_dead_letters(
                 "subject_id": m.get("subject_id").cloned().unwrap_or_default(),
                 "app_id": m.get("app_id").cloned().unwrap_or_default(),
                 "platform": m.get("platform").cloned().unwrap_or_default(),
+                "environment": m.get("environment").cloned().unwrap_or_default(),
                 "attempts": m.get("attempts").cloned().unwrap_or_default(),
                 "last_error": m.get("last_error").cloned().unwrap_or_default(),
                 "created_at": m.get("created_at").cloned().unwrap_or_default(),
@@ -632,6 +699,10 @@ fn enqueue_to_subject(
                     "platform",
                     m.get("platform").map(String::as_str).unwrap_or(""),
                 ),
+                (
+                    "environment",
+                    m.get("environment").map(String::as_str).unwrap_or(""),
+                ),
                 ("payload", payload),
                 ("attempts", "0"),
                 ("next_attempt_at", now_s.as_str()),
@@ -716,7 +787,7 @@ pub(crate) fn append_info(out: &mut String) {
 // RESP command: LUX PUSH ...
 // ---------------------------------------------------------------------------
 
-/// `LUX PUSH REGISTER <subject_id> <token> <platform> <app_id>`
+/// `LUX PUSH REGISTER <subject_id> <token> <platform> <app_id> [environment]`
 /// `LUX PUSH SEND <subject_id> <json>`
 /// `LUX PUSH CRED <app_id> <team_id> <key_id> <topic> <environment> <p8_pem>`
 /// `LUX PUSH DEVICES <subject_id>`
@@ -744,7 +815,15 @@ pub(crate) fn cmd_push(
     };
     match sub.as_str() {
         "REGISTER" if args.len() >= 7 => {
-            match register_device(store, cache, arg(3), arg(4), arg(5), arg(6), now) {
+            // args[7] (environment) is optional so existing callers still parse.
+            let device = DeviceRegistration {
+                subject_id: arg(3),
+                token: arg(4),
+                platform: arg(5),
+                app_id: arg(6),
+                environment: arg(7),
+            };
+            match register_device(store, cache, device, now) {
                 Ok(id) => resp::write_bulk(out, &id),
                 Err(e) => resp::write_error(out, &normalize_err(&e)),
             }
@@ -804,5 +883,42 @@ fn normalize_err(e: &str) -> String {
         e.to_string()
     } else {
         format!("ERR {e}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn environment_normalizes_apple_spellings() {
+        assert_eq!(normalize_environment("production"), "production");
+        assert_eq!(normalize_environment("PROD"), "production");
+        assert_eq!(normalize_environment(" Production "), "production");
+        assert_eq!(normalize_environment("sandbox"), "sandbox");
+        assert_eq!(normalize_environment("development"), "sandbox");
+        assert_eq!(normalize_environment("dev"), "sandbox");
+    }
+
+    // Unrecognized input must not be guessed at. Empty means "the device did
+    // not say", which falls back to the app credential; picking a host here
+    // would send a typo straight to the wrong one.
+    #[test]
+    fn unknown_environment_is_unspecified() {
+        assert_eq!(normalize_environment(""), "");
+        assert_eq!(normalize_environment("staging"), "");
+        assert_eq!(normalize_environment("apns"), "");
+    }
+
+    #[test]
+    fn explicit_base_url_survives_normalization() {
+        assert_eq!(
+            normalize_environment("http://127.0.0.1:9000"),
+            "http://127.0.0.1:9000"
+        );
+        assert_eq!(
+            normalize_environment("https://api.push.apple.com"),
+            "https://api.push.apple.com"
+        );
     }
 }

--- a/src/push/worker.rs
+++ b/src/push/worker.rs
@@ -127,40 +127,42 @@ async fn process_pending(
             .get("platform")
             .cloned()
             .unwrap_or_else(|| "ios".to_string());
+        let environment = m.get("environment").cloned().unwrap_or_default();
         let payload = m.get("payload").cloned().unwrap_or_default();
         let attempts: i64 = m.get("attempts").and_then(|a| a.parse().ok()).unwrap_or(0);
         if id.is_empty() {
             continue;
         }
 
-        let app_sink = match resolve_sink(store, cache, sinks, &app_id, &platform, now) {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                apply(
-                    store,
-                    cache,
-                    &Action::Dead {
-                        attempts,
-                        error: format!("no push credentials for app '{app_id}'"),
-                    },
-                    &id,
-                    &token,
-                    now,
-                )?;
-                continue;
-            }
-            Err(e) => {
-                apply(
-                    store,
-                    cache,
-                    &Action::Dead { attempts, error: e },
-                    &id,
-                    &token,
-                    now,
-                )?;
-                continue;
-            }
-        };
+        let app_sink =
+            match resolve_sink(store, cache, sinks, &app_id, &platform, &environment, now) {
+                Ok(Some(s)) => s,
+                Ok(None) => {
+                    apply(
+                        store,
+                        cache,
+                        &Action::Dead {
+                            attempts,
+                            error: format!("no push credentials for app '{app_id}'"),
+                        },
+                        &id,
+                        &token,
+                        now,
+                    )?;
+                    continue;
+                }
+                Err(e) => {
+                    apply(
+                        store,
+                        cache,
+                        &Action::Dead { attempts, error: e },
+                        &id,
+                        &token,
+                        now,
+                    )?;
+                    continue;
+                }
+            };
 
         let result = match &*app_sink {
             AppSink::Apns { sink, topic } => {
@@ -188,15 +190,22 @@ async fn process_pending(
 /// Build (or reuse a cached) sink for an app from its stored credentials.
 /// `Ok(None)` means no credentials are configured; `Err` means the credential
 /// material is unusable (bad `.p8`) and the row should dead-letter.
+///
+/// `environment` is the outbox row's APNs host, recorded from the device that
+/// registered the token. One `.p8` key is valid against both hosts, so a project
+/// with a development build and a TestFlight build in flight at the same time
+/// gets one sink per host off the same credentials. An empty `environment` means
+/// the device did not say, and the app credential decides.
 fn resolve_sink(
     store: &Arc<Store>,
     cache: &SharedSchemaCache,
     sinks: &mut HashMap<String, (String, Arc<AppSink>)>,
     app_id: &str,
     platform: &str,
+    environment: &str,
     now: Instant,
 ) -> Result<Option<Arc<AppSink>>, String> {
-    let cache_key = format!("{app_id}:{platform}");
+    let cache_key = format!("{app_id}:{platform}:{environment}");
 
     // Read the current credentials and derive a fingerprint. A cache hit skips
     // only the sink build (which holds the APNs provider-token cache); reading
@@ -223,16 +232,24 @@ fn resolve_sink(
                 sinks.remove(&cache_key);
                 return Ok(None);
             };
+            // The device's own environment wins. The credential's is only the
+            // fallback for tokens registered without one (including every token
+            // registered before `push.devices` carried the column).
+            let environment = if environment.is_empty() {
+                resolved.environment.as_str()
+            } else {
+                environment
+            };
             let fp = format!(
                 "apns|{}|{}|{}|{}",
-                resolved.environment, resolved.topic, resolved.creds.team_id, resolved.creds.key_id
+                environment, resolved.topic, resolved.creds.team_id, resolved.creds.key_id
             );
             if let Some((cached_fp, sink)) = sinks.get(&cache_key) {
                 if *cached_fp == fp {
                     return Ok(Some(sink.clone()));
                 }
             }
-            let base_url = ApnsSink::resolve_base_url(&resolved.environment);
+            let base_url = ApnsSink::resolve_base_url(environment);
             (
                 fp,
                 AppSink::Apns {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -62,6 +62,32 @@ pub fn find_lux_binary() -> std::path::PathBuf {
 /// Reserve `n` distinct localhost ports by holding listeners on `:0`
 /// simultaneously, then releasing them. Binding all at once guarantees the
 /// ports differ; releasing lets the spawned server claim them.
+/// Startup poll budget, at 50ms per poll. Servers answer in well under a second
+/// locally; this is sized for a loaded CI runner building in debug mode.
+const STARTUP_POLLS: usize = 300;
+
+/// Wait for a spawned server to answer on both protocols, panicking with what
+/// actually went wrong. A bare "did not start" cannot distinguish a slow boot
+/// from a process that exited, which makes the failure impossible to diagnose
+/// from a CI log.
+pub fn await_server_ready(child: &mut Child, resp_port: u16, http_port: u16) {
+    if let Ok(Some(status)) = child.try_wait() {
+        panic!("lux exited before serving (status {status}) on resp={resp_port} http={http_port}");
+    }
+    if !wait_for_resp_ready(resp_port, child) {
+        panic!(
+            "lux RESP port never became ready on resp={resp_port} (exited: {:?})",
+            child.try_wait().ok().flatten()
+        );
+    }
+    if http_port != 0 && !wait_for_http_ready(http_port, child) {
+        panic!(
+            "lux HTTP port never became ready on http={http_port} (exited: {:?})",
+            child.try_wait().ok().flatten()
+        );
+    }
+}
+
 pub fn free_ports(n: usize) -> Vec<u16> {
     let listeners: Vec<TcpListener> = (0..n)
         .map(|_| TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port"))
@@ -408,8 +434,14 @@ pub fn spawn_lux_with_data_dir(
 }
 
 /// Poll until the RESP port answers PING, bailing early if the child dies.
-fn wait_for_resp_ready(port: u16, child: &mut Child) -> bool {
-    for _ in 0..100 {
+/// Poll until the RESP port answers PING, bailing early if the child dies.
+///
+/// The ceiling is generous on purpose: CI builds are unoptimized and the whole
+/// suite spawns servers in parallel, so a cold start can take several seconds.
+/// This returns as soon as the server answers, so a high ceiling costs nothing
+/// on the happy path and only buys headroom on a loaded machine.
+pub fn wait_for_resp_ready(port: u16, child: &mut Child) -> bool {
+    for _ in 0..STARTUP_POLLS {
         if let Ok(Some(_)) = child.try_wait() {
             return false;
         }
@@ -430,8 +462,8 @@ fn wait_for_resp_ready(port: u16, child: &mut Child) -> bool {
 }
 
 /// Poll until the HTTP port returns an HTTP response, bailing early if the child dies.
-fn wait_for_http_ready(port: u16, child: &mut Child) -> bool {
-    for _ in 0..100 {
+pub fn wait_for_http_ready(port: u16, child: &mut Child) -> bool {
+    for _ in 0..STARTUP_POLLS {
         if let Ok(Some(_)) = child.try_wait() {
             return false;
         }

--- a/tests/live_ws.rs
+++ b/tests/live_ws.rs
@@ -69,17 +69,12 @@ fn start_lux_with_env(
         cmd.env(key, value);
     }
 
-    let child = cmd.spawn().expect("failed to start lux");
-    let server = LuxServer { child, tmpdir };
-    for _ in 0..80 {
-        if TcpStream::connect(("127.0.0.1", http_port)).is_ok()
-            && TcpStream::connect(("127.0.0.1", resp_port)).is_ok()
-        {
-            return server;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-    panic!("lux did not start on resp={resp_port} http={http_port}");
+    let mut child = cmd.spawn().expect("failed to start lux");
+    // A bare TCP connect is not readiness: the listener can be up before the
+    // server answers. Share the harness check so a slow CI boot is waited out
+    // and a dead child is reported as one.
+    common::await_server_ready(&mut child, resp_port, http_port);
+    LuxServer { child, tmpdir }
 }
 
 fn http_json_request(

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -972,3 +972,136 @@ fn push_web_push_delivers_encrypted() {
     assert!(!got.body.is_empty(), "encrypted body should be non-empty");
     drop(server);
 }
+
+/// Item 12: a project has one APNs key but its devices live on two hosts. Apple
+/// issues sandbox tokens to development builds and production tokens to
+/// TestFlight, both at once while a team is still developing, and a token is
+/// only valid against the host that minted it. Before this, a project held a
+/// single environment and every send went to that one host, so half the fleet
+/// failed with BadDeviceToken depending on which way the toggle was set.
+#[test]
+fn push_routes_each_device_to_its_own_apns_host() {
+    // Two mocks stand in for the two APNs hosts.
+    let testflight = MockApns::start(200);
+    let development = MockApns::start(200);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start_no_auth(dir.path(), resp_port, http_port);
+
+    // One credential, pointed at the "production" host. The same .p8 signs for
+    // both, so nothing about the credentials forces a single environment.
+    set_creds(http_port, &testflight.url());
+
+    // The TestFlight build registers without naming an environment, which is
+    // every client written before this existed: it falls back to the credential.
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"subject_id":"dual-env-user","token":"testflight-token",
+                "platform":"ios","app_id":"default"})
+        .to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "register testflight device: {b}");
+
+    // The development build names its own host and must not follow the
+    // credential.
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"subject_id":"dual-env-user","token":"development-token",
+                "platform":"ios","app_id":"default","environment":development.url()})
+        .to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "register development device: {b}");
+
+    // One send fans out to both devices.
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({"subject_id":"dual-env-user","notification":{"title":"both"}}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "send: {b}");
+    assert_eq!(b["enqueued"], 2);
+
+    let to_testflight = testflight
+        .wait_for_request(Duration::from_secs(5))
+        .expect("the credential host should receive the unlabelled device");
+    let to_development = development
+        .wait_for_request(Duration::from_secs(5))
+        .expect("the device's own host should receive the labelled device");
+
+    // Each token reached its own host, off one set of credentials.
+    assert_eq!(to_testflight.path, "/3/device/testflight-token");
+    assert_eq!(to_development.path, "/3/device/development-token");
+    drop(server);
+}
+
+/// The environment is recorded on the device and readable back, and a
+/// re-register that omits it does not erase it. A token cannot change hosts, so
+/// silence has to mean "unchanged" rather than "reset to the credential".
+#[test]
+fn push_device_environment_is_recorded_and_sticky() {
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start_no_auth(dir.path(), resp_port, http_port);
+
+    let register = |body: Value| {
+        let (s, b) = http(
+            http_port,
+            "POST",
+            "/v1/push/devices",
+            &body.to_string(),
+            Some("rootsecret"),
+        );
+        assert_eq!(s, 200, "register: {b}");
+    };
+
+    register(
+        json!({"subject_id":"env-user","token":"sticky-token","platform":"ios",
+                    "app_id":"default","environment":"development"}),
+    );
+
+    let environment_of = |token: &str| -> String {
+        let (s, b) = http(
+            http_port,
+            "GET",
+            "/v1/push/admin/devices",
+            "",
+            Some("rootsecret"),
+        );
+        assert_eq!(s, 200, "admin devices: {b}");
+        b["devices"]
+            .as_array()
+            .expect("devices array")
+            .iter()
+            .find(|d| d["id"].is_string() && d["subject_id"] == "env-user")
+            .map(|d| d["environment"].as_str().unwrap_or("").to_string())
+            .unwrap_or_else(|| panic!("no device row for {token}"))
+    };
+
+    // "development" is Apple's spelling for the sandbox host.
+    assert_eq!(environment_of("sticky-token"), "sandbox");
+
+    // A refresh that omits it keeps the stored value.
+    register(
+        json!({"subject_id":"env-user","token":"sticky-token","platform":"ios",
+                    "app_id":"default"}),
+    );
+    assert_eq!(environment_of("sticky-token"), "sandbox");
+
+    // An explicit value still updates it.
+    register(
+        json!({"subject_id":"env-user","token":"sticky-token","platform":"ios",
+                    "app_id":"default","environment":"production"}),
+    );
+    assert_eq!(environment_of("sticky-token"), "production");
+    drop(server);
+}

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -53,22 +53,16 @@ fn start(dir: &std::path::Path, resp_port: u16, http_port: u16, keep_dir: bool) 
         .env("LUX_AUTH_ENABLED", "true")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
-    let child = cmd.spawn().expect("spawn lux");
-    let server = PushServer {
+    let mut child = cmd.spawn().expect("spawn lux");
+    // A bare TCP connect is not readiness: the listener can be up before the
+    // server answers. Share the harness check so a slow CI boot is waited out
+    // and a dead child is reported as one.
+    common::await_server_ready(&mut child, resp_port, http_port);
+    PushServer {
         child,
         dir: dir.to_path_buf(),
         keep_dir,
-    };
-    for _ in 0..80 {
-        if TcpStream::connect(("127.0.0.1", http_port)).is_ok()
-            && TcpStream::connect(("127.0.0.1", resp_port)).is_ok()
-        {
-            std::thread::sleep(Duration::from_millis(150));
-            return server;
-        }
-        std::thread::sleep(Duration::from_millis(50));
     }
-    panic!("lux did not start");
 }
 
 fn http(port: u16, method: &str, path: &str, body: &str, auth: Option<&str>) -> (u16, Value) {
@@ -779,22 +773,13 @@ fn start_no_auth(dir: &std::path::Path, resp_port: u16, http_port: u16) -> PushS
         .env("LUX_PASSWORD", "rootsecret")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
-    let child = cmd.spawn().expect("spawn lux");
-    let server = PushServer {
+    let mut child = cmd.spawn().expect("spawn lux");
+    common::await_server_ready(&mut child, resp_port, http_port);
+    PushServer {
         child,
         dir: dir.to_path_buf(),
         keep_dir: false,
-    };
-    for _ in 0..80 {
-        if TcpStream::connect(("127.0.0.1", http_port)).is_ok()
-            && TcpStream::connect(("127.0.0.1", resp_port)).is_ok()
-        {
-            std::thread::sleep(Duration::from_millis(150));
-            return server;
-        }
-        std::thread::sleep(Duration::from_millis(50));
     }
-    panic!("lux did not start");
 }
 
 /// The Pompeii case: Lux auth OFF, a trusted secret-key caller registers a token

--- a/tests/reliability.rs
+++ b/tests/reliability.rs
@@ -60,14 +60,16 @@ fn connect(port: u16) -> TcpStream {
     stream
 }
 
-fn wait_for_port(port: u16) {
-    for _ in 0..80 {
-        if TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
-            return;
-        }
-        thread::sleep(Duration::from_millis(50));
+/// A bare TCP connect is not readiness, and a 4s ceiling is too tight for a
+/// loaded CI runner. Share the harness check, which waits on an actual PING and
+/// reports a dead child as one.
+fn wait_for_port(child: &mut std::process::Child, port: u16) {
+    if !common::wait_for_resp_ready(port, child) {
+        panic!(
+            "lux never became ready on port {port} (exited: {:?})",
+            child.try_wait().ok().flatten()
+        );
     }
-    panic!("lux did not start on port {port}");
 }
 
 struct LuxServer {
@@ -82,8 +84,8 @@ impl LuxServer {
             std::env::temp_dir().join(format!("lux_reliability_{}_{}", std::process::id(), port));
         let _ = std::fs::remove_dir_all(&tmpdir);
         std::fs::create_dir_all(&tmpdir).unwrap();
-        let child = Self::spawn(port, &tmpdir, maxmemory);
-        wait_for_port(port);
+        let mut child = Self::spawn(port, &tmpdir, maxmemory);
+        wait_for_port(&mut child, port);
         Self {
             port,
             child,
@@ -116,7 +118,7 @@ impl LuxServer {
         self.child.wait().ok();
         thread::sleep(Duration::from_millis(300));
         self.child = Self::spawn(self.port, &self.tmpdir, maxmemory);
-        wait_for_port(self.port);
+        wait_for_port(&mut self.child, self.port);
     }
 }
 

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -73,23 +73,15 @@ fn cmd(args: &[&str]) -> Vec<String> {
     args.iter().map(|s| s.to_string()).collect()
 }
 
-fn wait_for_port(port: u16) {
-    for _ in 0..80 {
-        if let Ok(mut stream) = TcpStream::connect(format!("127.0.0.1:{port}")) {
-            let _ = stream.set_read_timeout(Some(Duration::from_millis(250)));
-            if stream.write_all(&resp_cmd(&["PING".to_string()])).is_ok() {
-                let mut buf = [0u8; 64];
-                if stream
-                    .read(&mut buf)
-                    .is_ok_and(|n| String::from_utf8_lossy(&buf[..n]).contains("PONG"))
-                {
-                    return;
-                }
-            }
-        }
-        std::thread::sleep(Duration::from_millis(50));
+/// Same PING check as before, but with the shared budget and a panic that says
+/// whether the child died rather than only that it never answered.
+fn wait_for_port(child: &mut std::process::Child, port: u16) {
+    if !common::wait_for_resp_ready(port, child) {
+        panic!(
+            "lux never became ready on port {port} (exited: {:?})",
+            child.try_wait().ok().flatten()
+        );
     }
-    panic!("lux did not start on port {port}");
 }
 
 struct LuxServer {
@@ -109,8 +101,8 @@ impl LuxServer {
         ));
         let _ = std::fs::remove_dir_all(&tmpdir);
         std::fs::create_dir_all(&tmpdir).unwrap();
-        let child = Self::spawn(port, &tmpdir, tiered);
-        wait_for_port(port);
+        let mut child = Self::spawn(port, &tmpdir, tiered);
+        wait_for_port(&mut child, port);
         Self {
             port,
             child,
@@ -150,7 +142,7 @@ impl LuxServer {
         common::terminate_child(&mut self.child);
         self.port = common::free_port();
         self.child = Self::spawn(self.port, &self.tmpdir, tiered);
-        wait_for_port(self.port);
+        wait_for_port(&mut self.child, self.port);
     }
 
     fn crash_and_restart(&mut self, tiered: bool) {
@@ -158,7 +150,7 @@ impl LuxServer {
         self.child.wait().ok();
         self.port = common::free_port();
         self.child = Self::spawn(self.port, &self.tmpdir, tiered);
-        wait_for_port(self.port);
+        wait_for_port(&mut self.child, self.port);
     }
 }
 


### PR DESCRIPTION
A Lux project held a single APNs environment and every send went to the host it named. Apple issues sandbox device tokens to development builds and production tokens to TestFlight and the App Store, and both exist at once for any team that is still developing while testers are on a build, so whichever way the setting was pointed the other half of the fleet failed with BadDeviceToken. Nothing forced this: one `.p8` auth key is valid for both, Apple splits them by host.

`push.devices` now records the environment the token was minted for, `push.outbox` copies it at enqueue so the row still routes correctly if the device re-registers or is deleted before the worker drains it, and the worker builds one sink per host off the same credentials. A device that does not name an environment falls back to the app credential, which is what every existing client does, so nothing changes until a client starts sending it. `POST /v1/push/devices` and `LUX PUSH REGISTER` take it as an optional field, and the SDK exposes it as `environment: 'sandbox' | 'production'` on `register`/`registerFor`.

Re-registering without an environment keeps the stored one rather than clearing it, since a token cannot move hosts. Unrecognized values are treated as unspecified instead of guessed at, so a typo falls back to the credential rather than routing to the wrong host.

`environment` arrived after `push.devices` shipped, so existing projects need the column added. There was no path for that in `push/mod.rs`, only create. `add_column_if_missing` fills it in and logs the resolved TALTER itself: `table_add_column` does not append to the WAL, and internal callers never reach `execute_with_wal` where RESP and HTTP TALTER get raw-logged, so without it the column disappears on replay. There is a test for that, and it fails if the log is removed.

Testing: two mock APNs hosts, one credential, two devices under one subject, asserting each token reached its own host. Plus stickiness across re-register, the normalizer truth table, the base-URL split, and idempotence and WAL replay for the column add. Full suite green, fmt and clippy clean.