### PR TITLE
feat(push): route APNs by environment safely

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@luxdb/sdk",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "description": "Official Lux TypeScript SDK for app data, auth, tables, vectors, realtime, and Redis-compatible direct access",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",

--- a/sdk/src/push.ts
+++ b/sdk/src/push.ts
@@ -7,6 +7,9 @@ export interface LuxPushDevice {
 	subject_id?: string;
 	platform: string;
 	app_id: string;
+	/** The APNs host this token belongs to: `'sandbox'`, `'production'`, or
+	 *  `''` when the device did not say and the app credential decides. */
+	environment?: string;
 	created_at: string;
 	last_seen_at: string;
 }
@@ -18,6 +21,15 @@ export interface LuxPushRegisterOptions {
 	platform?: string;
 	/** App/credential set to route through. Defaults to `'default'`. */
 	app_id?: string;
+	/**
+	 * Which APNs host minted this token. Apple issues `'sandbox'` tokens to
+	 * development builds and `'production'` tokens to TestFlight and the App
+	 * Store, and a token only works against its own host, so a team that is
+	 * still developing while testers are on a build has both in use at once.
+	 * Read it from the `aps-environment` entitlement. Omit it and delivery falls
+	 * back to the environment on the app's credential.
+	 */
+	environment?: 'sandbox' | 'production';
 }
 
 /** A notification. `title`/`body` render the alert; the rest map to APNs `aps`
@@ -58,6 +70,7 @@ export class LuxPushNamespace {
 			token: options.token,
 			platform: options.platform ?? 'ios',
 			app_id: options.app_id ?? 'default',
+			environment: options.environment ?? '',
 		});
 	}
 
@@ -71,6 +84,7 @@ export class LuxPushNamespace {
 			token: options.token,
 			platform: options.platform ?? 'ios',
 			app_id: options.app_id ?? 'default',
+			environment: options.environment ?? '',
 		});
 	}
 

--- a/sdk/tests/project.test.ts
+++ b/sdk/tests/project.test.ts
@@ -36,6 +36,36 @@ describe('Lux project client', () => {
 		expect(seen?.body).toEqual({ command: ['PING'] });
 	});
 
+	test('push registration forwards the APNs device environment', async () => {
+		let seen: { url: string; body?: any } | null = null;
+		const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+			seen = {
+				url: String(input),
+				body: init?.body ? JSON.parse(String(init.body)) : undefined,
+			};
+			return new Response(JSON.stringify({ id: 'dev_1' }), { status: 200 });
+		};
+		const client = createProjectClient({
+			url: 'http://localhost:3957/v1/project',
+			key: 'lux_sec_test',
+			fetch: fetchImpl as typeof fetch,
+		});
+
+		const result = await client.push.register({
+			token: 'apns-device-token',
+			environment: 'production',
+		});
+
+		expect(result.error).toBeNull();
+		expect(seen?.url).toBe('http://localhost:3957/v1/project/push/devices');
+		expect(seen?.body).toEqual({
+			token: 'apns-device-token',
+			platform: 'ios',
+			app_id: 'default',
+			environment: 'production',
+		});
+	});
+
 	test('default fetch is bound for browser project requests', async () => {
 		const originalFetch = globalThis.fetch;
 		let receiver: unknown;

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2589,6 +2589,43 @@ pub(crate) fn create_table_if_missing(
     }
 }
 
+/// Add a column to an existing internal table if it isn't there already. The
+/// companion to `create_table_if_missing` for schema that arrives after a table
+/// has already shipped: new projects pick the column up from the CREATE, and
+/// projects created before it get it from here.
+///
+/// `tables::table_add_column` does not append to the WAL of its own accord. RESP
+/// and HTTP `TALTER` are raw-logged by `execute_with_wal`, which internal callers
+/// never reach, so log the resolved command here or the column is lost on replay.
+pub(crate) fn add_column_if_missing(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    table: &str,
+    field_spec: &str,
+    now: Instant,
+) -> Result<(), String> {
+    let mut tokens = field_spec.split_whitespace();
+    let Some(column) = tokens.next() else {
+        return Err("ERR empty column spec".to_string());
+    };
+    let schema = tables::table_schema(store, cache, table, now)?;
+    if schema
+        .iter()
+        .any(|field| field.split_whitespace().next() == Some(column))
+    {
+        return Ok(());
+    }
+
+    let mut args: Vec<Vec<u8>> = vec![
+        b"TALTER".to_vec(),
+        table.as_bytes().to_vec(),
+        b"ADD".to_vec(),
+    ];
+    args.extend(field_spec.split_whitespace().map(|t| t.as_bytes().to_vec()));
+    log_command(store, &args)?;
+    tables::table_add_column(store, cache, table, field_spec, now)
+}
+
 pub(crate) fn durable_table_insert(
     store: &Store,
     cache: &SharedSchemaCache,
@@ -5540,6 +5577,88 @@ mod tests {
             op: o.into(),
             value: v.into(),
         }
+    }
+
+    #[test]
+    fn add_column_if_missing_is_idempotent_and_leaves_existing_schema_alone() {
+        let store = Store::new();
+        let cache = Arc::new(RwLock::new(SchemaCache::new()));
+        let now = Instant::now();
+
+        create_table_if_missing(
+            &store,
+            &cache,
+            "widgets",
+            &["id STR PRIMARY KEY,", "name STR"],
+            now,
+        )
+        .unwrap();
+        crate::tables::table_insert(
+            &store,
+            &cache,
+            "widgets",
+            &[("id", "w1"), ("name", "bolt")],
+            now,
+        )
+        .unwrap();
+
+        add_column_if_missing(&store, &cache, "widgets", "environment STR", now).unwrap();
+        let schema = crate::tables::table_schema(&store, &cache, "widgets", now).unwrap();
+        assert!(
+            schema.iter().any(|f| f.starts_with("environment ")),
+            "column not added: {schema:?}"
+        );
+
+        // Called on every `ensure_tables`, so a second call must be a no-op
+        // rather than the "field already exists" error `table_add_column` raises.
+        add_column_if_missing(&store, &cache, "widgets", "environment STR", now).unwrap();
+        let after = crate::tables::table_schema(&store, &cache, "widgets", now).unwrap();
+        assert_eq!(schema, after);
+
+        // The existing row survives the backfill.
+        let row = find_row_by_field(&store, &cache, "widgets", "id", "w1", now)
+            .unwrap()
+            .expect("row should survive the column add");
+        assert_eq!(row.get("name").map(String::as_str), Some("bolt"));
+    }
+
+    // `table_add_column` does not log itself, and internal callers never reach
+    // `execute_with_wal`, so without the explicit log in `add_column_if_missing`
+    // the column would vanish on any restart that replays from the WAL.
+    #[test]
+    fn add_column_if_missing_survives_wal_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(crate::ServerConfig {
+            storage: crate::StorageConfig {
+                mode: crate::StorageMode::Tiered,
+                dir: dir.path().to_string_lossy().to_string(),
+            },
+            ..crate::ServerConfig::default()
+        });
+        let store = Arc::new(Store::new_with_config(config.clone()));
+        let cache = Arc::new(RwLock::new(SchemaCache::new()));
+        let now = Instant::now();
+
+        create_table_if_missing(
+            &store,
+            &cache,
+            "widgets",
+            &["id STR PRIMARY KEY,", "name STR"],
+            now,
+        )
+        .unwrap();
+        add_column_if_missing(&store, &cache, "widgets", "environment STR", now).unwrap();
+        store.fsync_wal();
+
+        let restored = Arc::new(Store::new_with_config(config));
+        restored.replay_wal(&crate::pubsub::Broker::new());
+        let restored_cache = Arc::new(RwLock::new(SchemaCache::new()));
+        let schema =
+            crate::tables::table_schema(&restored, &restored_cache, "widgets", now).unwrap();
+        assert!(
+            schema.iter().any(|f| f.starts_with("environment ")),
+            "column lost on replay: {schema:?}"
+        );
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -3135,6 +3135,14 @@ fn push_register(
     // "sandbox" or "production". Optional: an app that omits it keeps the old
     // behaviour of routing by the project's credential.
     let environment = parsed["environment"].as_str().unwrap_or("");
+    // A self-registering end user is not trusted to name the delivery host, and
+    // this route accepts a user's own JWT. See `normalize_environment`.
+    let environment_source = match auth {
+        HttpAuthContext::Operator | HttpAuthContext::Secret => {
+            crate::push::EnvironmentSource::Trusted
+        }
+        _ => crate::push::EnvironmentSource::User,
+    };
     match crate::push::register_device(
         store,
         cache,
@@ -3144,6 +3152,7 @@ fn push_register(
             platform,
             app_id,
             environment,
+            environment_source,
         },
         Instant::now(),
     ) {

--- a/src/http.rs
+++ b/src/http.rs
@@ -3132,13 +3132,19 @@ fn push_register(
     };
     let platform = parsed["platform"].as_str().unwrap_or("ios");
     let app_id = parsed["app_id"].as_str().unwrap_or("default");
+    // "sandbox" or "production". Optional: an app that omits it keeps the old
+    // behaviour of routing by the project's credential.
+    let environment = parsed["environment"].as_str().unwrap_or("");
     match crate::push::register_device(
         store,
         cache,
-        &subject_id,
-        token,
-        platform,
-        app_id,
+        crate::push::DeviceRegistration {
+            subject_id: &subject_id,
+            token,
+            platform,
+            app_id,
+            environment,
+        },
         Instant::now(),
     ) {
         Ok(id) => ok(format!(r#"{{"id":{}}}"#, serde_json::Value::String(id))),

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -307,6 +307,35 @@ mod tests {
             .to_string()
     }
 
+    // The two hosts are the whole reason a device carries an environment: one
+    // `.p8` signs for both, and a token minted for one is rejected by the other.
+    #[test]
+    fn base_url_splits_sandbox_from_production() {
+        assert_eq!(
+            ApnsSink::resolve_base_url("production"),
+            "https://api.push.apple.com"
+        );
+        assert_eq!(
+            ApnsSink::resolve_base_url("prod"),
+            "https://api.push.apple.com"
+        );
+        assert_eq!(
+            ApnsSink::resolve_base_url("sandbox"),
+            "https://api.sandbox.push.apple.com"
+        );
+        // Unknown values are sandbox, so a misconfiguration cannot silently
+        // deliver to real users.
+        assert_eq!(
+            ApnsSink::resolve_base_url(""),
+            "https://api.sandbox.push.apple.com"
+        );
+        // An explicit base survives verbatim; the tests point it at a mock.
+        assert_eq!(
+            ApnsSink::resolve_base_url("http://127.0.0.1:9000/"),
+            "http://127.0.0.1:9000"
+        );
+    }
+
     fn sink_with(p8: String) -> ApnsSink {
         ApnsSink::new(
             "https://api.sandbox.push.apple.com",

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -176,6 +176,7 @@ pub(crate) fn migrate_from_auth_scope(
                 // The legacy layout had no per-device environment; delivery
                 // falls back to the app credential, as it did before.
                 environment: "",
+                environment_source: EnvironmentSource::Trusted,
             },
             now,
         )?;
@@ -231,15 +232,34 @@ pub(crate) struct ResolvedVapidCreds {
 // Device registry
 // ---------------------------------------------------------------------------
 
+/// Who supplied a device's environment. Registration is reachable with an end
+/// user's own JWT, so the two are not equally trusted.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EnvironmentSource {
+    /// A secret key or operator: the project's own backend.
+    Trusted,
+    /// An end user self-registering with their session JWT.
+    User,
+}
+
 /// Normalize a caller-supplied APNs environment to what `resolve_base_url`
-/// understands. An explicit `http(s)://` base survives verbatim, matching the
-/// override the app credential already accepts. Anything else unrecognized is
-/// treated as unspecified rather than guessed at, so delivery falls back to the
-/// app credential instead of silently routing to the wrong host.
-pub(crate) fn normalize_environment(environment: &str) -> String {
+/// understands. Anything unrecognized is treated as unspecified rather than
+/// guessed at, so delivery falls back to the app credential instead of silently
+/// routing to the wrong host.
+///
+/// An explicit `http(s)://` base is only honored from a trusted caller. The
+/// delivery worker sends the APNs provider JWT as a bearer token to whatever
+/// host this resolves to, and that JWT is signed with the team's `.p8` and is
+/// good for the whole app, so letting an end user name the host would hand any
+/// signed-in user a way to collect it. Operators can already point the app
+/// credential at an arbitrary base, so they gain nothing new here.
+pub(crate) fn normalize_environment(environment: &str, source: EnvironmentSource) -> String {
     let trimmed = environment.trim();
     if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
-        return trimmed.to_string();
+        return match source {
+            EnvironmentSource::Trusted => trimmed.to_string(),
+            EnvironmentSource::User => String::new(),
+        };
     }
     match trimmed.to_ascii_lowercase().as_str() {
         "production" | "prod" => "production".to_string(),
@@ -264,6 +284,9 @@ pub(crate) struct DeviceRegistration<'a> {
     pub app_id: &'a str,
     /// "sandbox", "production", or empty for unspecified.
     pub environment: &'a str,
+    /// Whether `environment` came from the project's backend or from the end
+    /// user's own session. Gates the explicit-host override.
+    pub environment_source: EnvironmentSource,
 }
 
 pub(crate) fn register_device(
@@ -278,12 +301,13 @@ pub(crate) fn register_device(
         platform,
         app_id,
         environment,
+        environment_source,
     } = device;
     if platform.eq_ignore_ascii_case("web") {
         webpush::validate_subscription_token(token)?;
     }
     ensure_tables(store, cache, now)?;
-    let environment = normalize_environment(environment);
+    let environment = normalize_environment(environment, environment_source);
     let now_s = unix_seconds().to_string();
     if let Some(existing) = find_row_by_field(store, cache, DEVICES_TABLE, "token", token, now)? {
         let id = existing.get("id").cloned().unwrap_or_default();
@@ -825,6 +849,8 @@ pub(crate) fn cmd_push(
                 platform: arg(5),
                 app_id: arg(6),
                 environment: arg(7),
+                // LUX PUSH is operator-level RESP; there is no end user here.
+                environment_source: EnvironmentSource::Trusted,
             };
             match register_device(store, cache, device, now) {
                 Ok(id) => resp::write_bulk(out, &id),
@@ -893,14 +919,18 @@ fn normalize_err(e: &str) -> String {
 mod tests {
     use super::*;
 
+    use EnvironmentSource::{Trusted, User};
+
     #[test]
     fn environment_normalizes_apple_spellings() {
-        assert_eq!(normalize_environment("production"), "production");
-        assert_eq!(normalize_environment("PROD"), "production");
-        assert_eq!(normalize_environment(" Production "), "production");
-        assert_eq!(normalize_environment("sandbox"), "sandbox");
-        assert_eq!(normalize_environment("development"), "sandbox");
-        assert_eq!(normalize_environment("dev"), "sandbox");
+        for source in [Trusted, User] {
+            assert_eq!(normalize_environment("production", source), "production");
+            assert_eq!(normalize_environment("PROD", source), "production");
+            assert_eq!(normalize_environment(" Production ", source), "production");
+            assert_eq!(normalize_environment("sandbox", source), "sandbox");
+            assert_eq!(normalize_environment("development", source), "sandbox");
+            assert_eq!(normalize_environment("dev", source), "sandbox");
+        }
     }
 
     // Unrecognized input must not be guessed at. Empty means "the device did
@@ -908,20 +938,37 @@ mod tests {
     // would send a typo straight to the wrong one.
     #[test]
     fn unknown_environment_is_unspecified() {
-        assert_eq!(normalize_environment(""), "");
-        assert_eq!(normalize_environment("staging"), "");
-        assert_eq!(normalize_environment("apns"), "");
+        for source in [Trusted, User] {
+            assert_eq!(normalize_environment("", source), "");
+            assert_eq!(normalize_environment("staging", source), "");
+            assert_eq!(normalize_environment("apns", source), "");
+        }
     }
 
     #[test]
-    fn explicit_base_url_survives_normalization() {
+    fn explicit_base_url_survives_for_a_trusted_caller() {
         assert_eq!(
-            normalize_environment("http://127.0.0.1:9000"),
+            normalize_environment("http://127.0.0.1:9000", Trusted),
             "http://127.0.0.1:9000"
         );
         assert_eq!(
-            normalize_environment("https://api.push.apple.com"),
+            normalize_environment("https://api.push.apple.com", Trusted),
             "https://api.push.apple.com"
+        );
+    }
+
+    // The delivery worker sends the APNs provider JWT as a bearer token to
+    // whatever host this resolves to. `POST /v1/push/devices` accepts an end
+    // user's own session, so honoring a user-supplied host would let any
+    // signed-in user collect a token that is signed with the team's .p8 and
+    // valid for the whole app.
+    #[test]
+    fn a_user_cannot_name_the_delivery_host() {
+        assert_eq!(normalize_environment("http://attacker.example/", User), "");
+        assert_eq!(normalize_environment("https://attacker.example/", User), "");
+        assert_eq!(
+            normalize_environment("  HTTP://attacker.example/", User),
+            ""
         );
     }
 }

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -17,8 +17,8 @@ use bytes::BytesMut;
 use serde_json::{json, Value};
 
 use crate::auth::{
-    create_table_if_missing, durable_table_delete_where, durable_table_insert,
-    durable_table_update_where, find_row_by_field, random_id, unix_seconds,
+    add_column_if_missing, create_table_if_missing, durable_table_delete_where,
+    durable_table_insert, durable_table_update_where, find_row_by_field, random_id, unix_seconds,
 };
 use crate::resp;
 use crate::store::Store;
@@ -53,12 +53,21 @@ pub(crate) fn ensure_tables(
             "token STR,",
             "platform STR,",
             "app_id STR,",
+            // Which APNs host this token was minted for. Apple issues sandbox
+            // tokens to development builds and production tokens to TestFlight
+            // and the App Store, and a token is only valid against its own host.
+            // Empty means the registrant did not say, and delivery falls back to
+            // the app credential's `environment`.
+            "environment STR,",
             "created_at INT,",
             "last_seen_at INT,",
             "disabled_at INT",
         ],
         now,
     )?;
+    // `environment` arrived after `push.devices` shipped, so projects that
+    // registered a device on an older engine still have the original schema.
+    add_column_if_missing(store, cache, DEVICES_TABLE, "environment STR", now)?;
     create_table_if_missing(
         store,
         cache,
@@ -88,6 +97,10 @@ pub(crate) fn ensure_tables(
             "app_id STR,",
             "target_token STR,",
             "platform STR,",
+            // Copied from the device at enqueue so the row still routes to the
+            // right APNs host if the device re-registers or is deleted before
+            // the worker drains it.
+            "environment STR,",
             "payload STR,",
             "attempts INT,",
             "next_attempt_at INT,",
@@ -97,6 +110,7 @@ pub(crate) fn ensure_tables(
         ],
         now,
     )?;
+    add_column_if_missing(store, cache, OUTBOX_TABLE, "environment STR", now)?;
     Ok(())
 }
 
@@ -154,10 +168,15 @@ pub(crate) fn migrate_from_auth_scope(
         register_device(
             store,
             cache,
-            &m.get("user_id").cloned().unwrap_or_default(),
-            &token,
-            &m.get("platform").cloned().unwrap_or_else(|| "ios".into()),
-            &m.get("app_id").cloned().unwrap_or_else(|| "default".into()),
+            DeviceRegistration {
+                subject_id: &m.get("user_id").cloned().unwrap_or_default(),
+                token: &token,
+                platform: &m.get("platform").cloned().unwrap_or_else(|| "ios".into()),
+                app_id: &m.get("app_id").cloned().unwrap_or_else(|| "default".into()),
+                // The legacy layout had no per-device environment; delivery
+                // falls back to the app credential, as it did before.
+                environment: "",
+            },
             now,
         )?;
     }
@@ -212,26 +231,69 @@ pub(crate) struct ResolvedVapidCreds {
 // Device registry
 // ---------------------------------------------------------------------------
 
+/// Normalize a caller-supplied APNs environment to what `resolve_base_url`
+/// understands. An explicit `http(s)://` base survives verbatim, matching the
+/// override the app credential already accepts. Anything else unrecognized is
+/// treated as unspecified rather than guessed at, so delivery falls back to the
+/// app credential instead of silently routing to the wrong host.
+pub(crate) fn normalize_environment(environment: &str) -> String {
+    let trimmed = environment.trim();
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return trimmed.to_string();
+    }
+    match trimmed.to_ascii_lowercase().as_str() {
+        "production" | "prod" => "production".to_string(),
+        "sandbox" | "development" | "dev" => "sandbox".to_string(),
+        _ => String::new(),
+    }
+}
+
 /// Register (or refresh) a device token for `subject_id`. A token is unique
 /// across the registry: re-registering an existing token re-points it at the
 /// current subject and re-activates it rather than duplicating. Returns the
 /// device id.
+///
+/// `environment` is the APNs host the token belongs to ("sandbox" or
+/// "production"); empty means unspecified. A development build and a TestFlight
+/// build of the same app hold tokens for different hosts at the same time, so
+/// this is per device, not per project.
+pub(crate) struct DeviceRegistration<'a> {
+    pub subject_id: &'a str,
+    pub token: &'a str,
+    pub platform: &'a str,
+    pub app_id: &'a str,
+    /// "sandbox", "production", or empty for unspecified.
+    pub environment: &'a str,
+}
+
 pub(crate) fn register_device(
     store: &Store,
     cache: &SharedSchemaCache,
-    subject_id: &str,
-    token: &str,
-    platform: &str,
-    app_id: &str,
+    device: DeviceRegistration<'_>,
     now: Instant,
 ) -> Result<String, String> {
+    let DeviceRegistration {
+        subject_id,
+        token,
+        platform,
+        app_id,
+        environment,
+    } = device;
     if platform.eq_ignore_ascii_case("web") {
         webpush::validate_subscription_token(token)?;
     }
     ensure_tables(store, cache, now)?;
+    let environment = normalize_environment(environment);
     let now_s = unix_seconds().to_string();
     if let Some(existing) = find_row_by_field(store, cache, DEVICES_TABLE, "token", token, now)? {
         let id = existing.get("id").cloned().unwrap_or_default();
+        // A re-register that omits the environment must not erase a known one:
+        // the same token cannot move hosts, so silence means "unchanged".
+        let environment = if environment.is_empty() {
+            existing.get("environment").cloned().unwrap_or_default()
+        } else {
+            environment
+        };
         durable_table_update_where(
             store,
             cache,
@@ -240,6 +302,7 @@ pub(crate) fn register_device(
                 ("subject_id", subject_id),
                 ("platform", platform),
                 ("app_id", app_id),
+                ("environment", environment.as_str()),
                 ("last_seen_at", now_s.as_str()),
                 ("disabled_at", "0"),
             ],
@@ -259,6 +322,7 @@ pub(crate) fn register_device(
             ("token", token),
             ("platform", platform),
             ("app_id", app_id),
+            ("environment", environment.as_str()),
             ("created_at", now_s.as_str()),
             ("last_seen_at", now_s.as_str()),
             ("disabled_at", "0"),
@@ -295,6 +359,7 @@ pub(crate) fn list_devices(
                 "id": m.get("id").cloned().unwrap_or_default(),
                 "platform": m.get("platform").cloned().unwrap_or_default(),
                 "app_id": m.get("app_id").cloned().unwrap_or_default(),
+                "environment": m.get("environment").cloned().unwrap_or_default(),
                 "created_at": m.get("created_at").cloned().unwrap_or_default(),
                 "last_seen_at": m.get("last_seen_at").cloned().unwrap_or_default(),
             })
@@ -374,6 +439,7 @@ pub(crate) fn list_all_devices(
                 "subject_id": m.get("subject_id").cloned().unwrap_or_default(),
                 "platform": m.get("platform").cloned().unwrap_or_default(),
                 "app_id": m.get("app_id").cloned().unwrap_or_default(),
+                "environment": m.get("environment").cloned().unwrap_or_default(),
                 "created_at": m.get("created_at").cloned().unwrap_or_default(),
                 "last_seen_at": m.get("last_seen_at").cloned().unwrap_or_default(),
                 "disabled_at": m.get("disabled_at").cloned().unwrap_or_default(),
@@ -409,6 +475,7 @@ pub(crate) fn list_dead_letters(
                 "subject_id": m.get("subject_id").cloned().unwrap_or_default(),
                 "app_id": m.get("app_id").cloned().unwrap_or_default(),
                 "platform": m.get("platform").cloned().unwrap_or_default(),
+                "environment": m.get("environment").cloned().unwrap_or_default(),
                 "attempts": m.get("attempts").cloned().unwrap_or_default(),
                 "last_error": m.get("last_error").cloned().unwrap_or_default(),
                 "created_at": m.get("created_at").cloned().unwrap_or_default(),
@@ -635,6 +702,10 @@ fn enqueue_to_subject(
                     "platform",
                     m.get("platform").map(String::as_str).unwrap_or(""),
                 ),
+                (
+                    "environment",
+                    m.get("environment").map(String::as_str).unwrap_or(""),
+                ),
                 ("payload", payload),
                 ("attempts", "0"),
                 ("next_attempt_at", now_s.as_str()),
@@ -719,7 +790,7 @@ pub(crate) fn append_info(out: &mut String) {
 // RESP command: LUX PUSH ...
 // ---------------------------------------------------------------------------
 
-/// `LUX PUSH REGISTER <subject_id> <token> <platform> <app_id>`
+/// `LUX PUSH REGISTER <subject_id> <token> <platform> <app_id> [environment]`
 /// `LUX PUSH SEND <subject_id> <json>`
 /// `LUX PUSH CRED <app_id> <team_id> <key_id> <topic> <environment> <p8_pem>`
 /// `LUX PUSH DEVICES <subject_id>`
@@ -747,7 +818,15 @@ pub(crate) fn cmd_push(
     };
     match sub.as_str() {
         "REGISTER" if args.len() >= 7 => {
-            match register_device(store, cache, arg(3), arg(4), arg(5), arg(6), now) {
+            // args[7] (environment) is optional so existing callers still parse.
+            let device = DeviceRegistration {
+                subject_id: arg(3),
+                token: arg(4),
+                platform: arg(5),
+                app_id: arg(6),
+                environment: arg(7),
+            };
+            match register_device(store, cache, device, now) {
                 Ok(id) => resp::write_bulk(out, &id),
                 Err(e) => resp::write_error(out, &normalize_err(&e)),
             }
@@ -807,5 +886,42 @@ fn normalize_err(e: &str) -> String {
         e.to_string()
     } else {
         format!("ERR {e}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn environment_normalizes_apple_spellings() {
+        assert_eq!(normalize_environment("production"), "production");
+        assert_eq!(normalize_environment("PROD"), "production");
+        assert_eq!(normalize_environment(" Production "), "production");
+        assert_eq!(normalize_environment("sandbox"), "sandbox");
+        assert_eq!(normalize_environment("development"), "sandbox");
+        assert_eq!(normalize_environment("dev"), "sandbox");
+    }
+
+    // Unrecognized input must not be guessed at. Empty means "the device did
+    // not say", which falls back to the app credential; picking a host here
+    // would send a typo straight to the wrong one.
+    #[test]
+    fn unknown_environment_is_unspecified() {
+        assert_eq!(normalize_environment(""), "");
+        assert_eq!(normalize_environment("staging"), "");
+        assert_eq!(normalize_environment("apns"), "");
+    }
+
+    #[test]
+    fn explicit_base_url_survives_normalization() {
+        assert_eq!(
+            normalize_environment("http://127.0.0.1:9000"),
+            "http://127.0.0.1:9000"
+        );
+        assert_eq!(
+            normalize_environment("https://api.push.apple.com"),
+            "https://api.push.apple.com"
+        );
     }
 }

--- a/src/push/worker.rs
+++ b/src/push/worker.rs
@@ -127,40 +127,42 @@ async fn process_pending(
             .get("platform")
             .cloned()
             .unwrap_or_else(|| "ios".to_string());
+        let environment = m.get("environment").cloned().unwrap_or_default();
         let payload = m.get("payload").cloned().unwrap_or_default();
         let attempts: i64 = m.get("attempts").and_then(|a| a.parse().ok()).unwrap_or(0);
         if id.is_empty() {
             continue;
         }
 
-        let app_sink = match resolve_sink(store, cache, sinks, &app_id, &platform, now) {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                apply(
-                    store,
-                    cache,
-                    &Action::Dead {
-                        attempts,
-                        error: format!("no push credentials for app '{app_id}'"),
-                    },
-                    &id,
-                    &token,
-                    now,
-                )?;
-                continue;
-            }
-            Err(e) => {
-                apply(
-                    store,
-                    cache,
-                    &Action::Dead { attempts, error: e },
-                    &id,
-                    &token,
-                    now,
-                )?;
-                continue;
-            }
-        };
+        let app_sink =
+            match resolve_sink(store, cache, sinks, &app_id, &platform, &environment, now) {
+                Ok(Some(s)) => s,
+                Ok(None) => {
+                    apply(
+                        store,
+                        cache,
+                        &Action::Dead {
+                            attempts,
+                            error: format!("no push credentials for app '{app_id}'"),
+                        },
+                        &id,
+                        &token,
+                        now,
+                    )?;
+                    continue;
+                }
+                Err(e) => {
+                    apply(
+                        store,
+                        cache,
+                        &Action::Dead { attempts, error: e },
+                        &id,
+                        &token,
+                        now,
+                    )?;
+                    continue;
+                }
+            };
 
         let result = match &*app_sink {
             AppSink::Apns { sink, topic } => {
@@ -188,15 +190,22 @@ async fn process_pending(
 /// Build (or reuse a cached) sink for an app from its stored credentials.
 /// `Ok(None)` means no credentials are configured; `Err` means the credential
 /// material is unusable (bad `.p8`) and the row should dead-letter.
+///
+/// `environment` is the outbox row's APNs host, recorded from the device that
+/// registered the token. One `.p8` key is valid against both hosts, so a project
+/// with a development build and a TestFlight build in flight at the same time
+/// gets one sink per host off the same credentials. An empty `environment` means
+/// the device did not say, and the app credential decides.
 fn resolve_sink(
     store: &Arc<Store>,
     cache: &SharedSchemaCache,
     sinks: &mut HashMap<String, (String, Arc<AppSink>)>,
     app_id: &str,
     platform: &str,
+    environment: &str,
     now: Instant,
 ) -> Result<Option<Arc<AppSink>>, String> {
-    let cache_key = format!("{app_id}:{platform}");
+    let cache_key = format!("{app_id}:{platform}:{environment}");
 
     // Read the current credentials and derive a fingerprint. A cache hit skips
     // only the sink build (which holds the APNs provider-token cache); reading
@@ -223,16 +232,24 @@ fn resolve_sink(
                 sinks.remove(&cache_key);
                 return Ok(None);
             };
+            // The device's own environment wins. The credential's is only the
+            // fallback for tokens registered without one (including every token
+            // registered before `push.devices` carried the column).
+            let environment = if environment.is_empty() {
+                resolved.environment.as_str()
+            } else {
+                environment
+            };
             let fp = format!(
                 "apns|{}|{}|{}|{}",
-                resolved.environment, resolved.topic, resolved.creds.team_id, resolved.creds.key_id
+                environment, resolved.topic, resolved.creds.team_id, resolved.creds.key_id
             );
             if let Some((cached_fp, sink)) = sinks.get(&cache_key) {
                 if *cached_fp == fp {
                     return Ok(Some(sink.clone()));
                 }
             }
-            let base_url = ApnsSink::resolve_base_url(&resolved.environment);
+            let base_url = ApnsSink::resolve_base_url(environment);
             (
                 fp,
                 AppSink::Apns {

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -1109,3 +1109,56 @@ fn push_device_environment_is_recorded_and_sticky() {
     assert_eq!(environment_of("sticky-token"), "production");
     drop(server);
 }
+
+/// The delivery worker sends the APNs provider JWT as a bearer token to
+/// whichever host the environment resolves to, and that JWT is signed with the
+/// team's `.p8` and is good for the whole app. `POST /v1/push/devices` accepts
+/// an end user's own session, so a user-supplied host would hand any signed-in
+/// user a way to collect it.
+#[test]
+fn user_session_cannot_redirect_delivery_to_its_own_host() {
+    let real = MockApns::start(200);
+    let attacker = MockApns::start(200);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start(dir.path(), resp_port, http_port, false);
+
+    set_creds(http_port, &real.url());
+    let (token, uid) = anon_login(http_port);
+
+    // A signed-in user self-registers and tries to name the delivery host.
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"token":"victim-token","platform":"ios","app_id":"default",
+                "environment": attacker.url()})
+        .to_string(),
+        Some(&token),
+    );
+    assert_eq!(s, 200, "register: {b}");
+
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({"subject_id": uid, "notification":{"title":"secret"}}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "send: {b}");
+
+    // Delivery goes to the project's own credential host, not the one the user
+    // named, so no provider token reaches it.
+    let got = real
+        .wait_for_request(Duration::from_secs(5))
+        .expect("the credential host should receive the delivery");
+    assert_eq!(got.path, "/3/device/victim-token");
+    assert!(
+        attacker
+            .wait_for_request(Duration::from_millis(750))
+            .is_none(),
+        "a user-named host received a delivery, leaking the APNs provider token"
+    );
+    drop(server);
+}

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -976,3 +976,136 @@ fn push_web_push_delivers_encrypted() {
     assert!(!got.body.is_empty(), "encrypted body should be non-empty");
     drop(server);
 }
+
+/// Item 12: a project has one APNs key but its devices live on two hosts. Apple
+/// issues sandbox tokens to development builds and production tokens to
+/// TestFlight, both at once while a team is still developing, and a token is
+/// only valid against the host that minted it. Before this, a project held a
+/// single environment and every send went to that one host, so half the fleet
+/// failed with BadDeviceToken depending on which way the toggle was set.
+#[test]
+fn push_routes_each_device_to_its_own_apns_host() {
+    // Two mocks stand in for the two APNs hosts.
+    let testflight = MockApns::start(200);
+    let development = MockApns::start(200);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start_no_auth(dir.path(), resp_port, http_port);
+
+    // One credential, pointed at the "production" host. The same .p8 signs for
+    // both, so nothing about the credentials forces a single environment.
+    set_creds(http_port, &testflight.url());
+
+    // The TestFlight build registers without naming an environment, which is
+    // every client written before this existed: it falls back to the credential.
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"subject_id":"dual-env-user","token":"testflight-token",
+                "platform":"ios","app_id":"default"})
+        .to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "register testflight device: {b}");
+
+    // The development build names its own host and must not follow the
+    // credential.
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"subject_id":"dual-env-user","token":"development-token",
+                "platform":"ios","app_id":"default","environment":development.url()})
+        .to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "register development device: {b}");
+
+    // One send fans out to both devices.
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({"subject_id":"dual-env-user","notification":{"title":"both"}}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "send: {b}");
+    assert_eq!(b["enqueued"], 2);
+
+    let to_testflight = testflight
+        .wait_for_request(Duration::from_secs(5))
+        .expect("the credential host should receive the unlabelled device");
+    let to_development = development
+        .wait_for_request(Duration::from_secs(5))
+        .expect("the device's own host should receive the labelled device");
+
+    // Each token reached its own host, off one set of credentials.
+    assert_eq!(to_testflight.path, "/3/device/testflight-token");
+    assert_eq!(to_development.path, "/3/device/development-token");
+    drop(server);
+}
+
+/// The environment is recorded on the device and readable back, and a
+/// re-register that omits it does not erase it. A token cannot change hosts, so
+/// silence has to mean "unchanged" rather than "reset to the credential".
+#[test]
+fn push_device_environment_is_recorded_and_sticky() {
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start_no_auth(dir.path(), resp_port, http_port);
+
+    let register = |body: Value| {
+        let (s, b) = http(
+            http_port,
+            "POST",
+            "/v1/push/devices",
+            &body.to_string(),
+            Some("rootsecret"),
+        );
+        assert_eq!(s, 200, "register: {b}");
+    };
+
+    register(
+        json!({"subject_id":"env-user","token":"sticky-token","platform":"ios",
+                    "app_id":"default","environment":"development"}),
+    );
+
+    let environment_of = |token: &str| -> String {
+        let (s, b) = http(
+            http_port,
+            "GET",
+            "/v1/push/admin/devices",
+            "",
+            Some("rootsecret"),
+        );
+        assert_eq!(s, 200, "admin devices: {b}");
+        b["devices"]
+            .as_array()
+            .expect("devices array")
+            .iter()
+            .find(|d| d["id"].is_string() && d["subject_id"] == "env-user")
+            .map(|d| d["environment"].as_str().unwrap_or("").to_string())
+            .unwrap_or_else(|| panic!("no device row for {token}"))
+    };
+
+    // "development" is Apple's spelling for the sandbox host.
+    assert_eq!(environment_of("sticky-token"), "sandbox");
+
+    // A refresh that omits it keeps the stored value.
+    register(
+        json!({"subject_id":"env-user","token":"sticky-token","platform":"ios",
+                    "app_id":"default"}),
+    );
+    assert_eq!(environment_of("sticky-token"), "sandbox");
+
+    // An explicit value still updates it.
+    register(
+        json!({"subject_id":"env-user","token":"sticky-token","platform":"ios",
+                    "app_id":"default","environment":"production"}),
+    );
+    assert_eq!(environment_of("sticky-token"), "production");
+    drop(server);
+}


### PR DESCRIPTION
## Summary
- persist an APNs environment selector in native and SDK registration APIs
- route sandbox tokens to Apple sandbox and production tokens to Apple production
- reject user-controlled APNs delivery hosts while retaining trusted operator configuration
- add an exploit regression test proving provider JWTs are never sent to an attacker-controlled host

## Security impact
The original work preserved arbitrary client-provided APNs environment URLs. Because delivery attaches the APNs provider JWT, that created a credential-exfiltration path. This replacement branch accepts only canonical sandbox/production environments from users; custom hosts remain restricted to trusted operator paths.

## Validation
- full Rust release test suite: 600 library tests plus integrations and docs passed
- `cargo clippy --release --all-targets --locked -- -D warnings`
- `cargo fmt --check --all`
- SDK tests: 64 passed
- SDK build passed

Supersedes #59, excluding its unrelated readiness-test commit.