### PR TITLE
Engine-owned migrations, version discovery, and secure push config

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
+          build-args: LUX_BUILD_SHA=${{ github.sha }}
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:build-amd64
           cache-from: type=gha,scope=docker-amd64
@@ -75,6 +76,7 @@ jobs:
         with:
           context: .
           platforms: linux/arm64
+          build-args: LUX_BUILD_SHA=${{ github.sha }}
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:build-arm64
           cache-from: type=gha,scope=docker-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
 
   build:
     needs: test
+    env:
+      LUX_BUILD_SHA: ${{ github.sha }}
     strategy:
       matrix:
         include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN mkdir src \
     && rm -rf src
 
 COPY src/ src/
+ARG LUX_BUILD_SHA=unknown
+ENV LUX_BUILD_SHA=${LUX_BUILD_SHA}
 RUN touch src/lib.rs src/main.rs && cargo build --release
 
 FROM scratch

--- a/MANAGEMENT_API.md
+++ b/MANAGEMENT_API.md
@@ -1,0 +1,69 @@
+# Engine management API
+
+Lux owns migration parsing, checksums, execution progress, and repair state in
+the engine. CLI, Cloud, and Studio must use this contract rather than writing
+`__migrations` directly.
+
+## Discovery
+
+`GET /v1/version` and `LUX VERSION` return:
+
+- `version`: engine semantic version
+- `build_sha`: source revision (`unknown` for builds that do not provide one)
+- `api_version`: management API version
+- `capabilities`: feature identifiers callers must check before using a feature
+
+## Migrations
+
+Operator-authenticated HTTP routes:
+
+- `GET /v1/migrations?limit=100&offset=0`
+- `POST /v1/migrations/plan`
+- `POST /v1/migrations/apply`
+- `POST /v1/migrations/repair`
+
+Plan and apply accept:
+
+```json
+{
+  "filename": "001_create_messages.lux",
+  "body": "TCREATE messages id UUID PRIMARY KEY, body STR;"
+}
+```
+
+Studio may send `name` instead of `filename`; the engine generates a safe,
+timestamped `.lux` basename. Bodies are checksummed as exact UTF-8 bytes with
+SHA-256.
+
+The engine records `applying` before the first command and persists
+`completed_commands` after each success. `applying` and `failed` records block
+later migration writes. They never auto-resume. Repair requires one explicit
+action:
+
+```json
+{"filename":"001_create_messages.lux","action":"resume","from_command":1}
+{"filename":"001_create_messages.lux","action":"mark_applied"}
+{"filename":"001_create_messages.lux","action":"abandon"}
+```
+
+`from_command` is a reviewed, zero-based command index. Existing DJB2 and Studio
+FNV-1a ledger checksums remain readable and idempotent; all new records use
+SHA-256.
+
+RESP parity is available under `LUX MIGRATE LIST|PLAN|APPLY|REPAIR`.
+
+## Push configuration
+
+The operator-only configuration surface never returns provider secrets:
+
+- `GET /v1/push/config?app_id=default`
+- `PUT /v1/push/config/apns`
+- `DELETE /v1/push/config/apns?app_id=default`
+- `POST /v1/push/config/vapid` with `action: "enable"` or `"rotate"`
+- `DELETE /v1/push/config/vapid?app_id=default`
+
+APNs updates preserve the existing private key when `p8_pem` is omitted.
+VAPID enable is idempotent; rotate intentionally changes the public key.
+Provider private keys are written only to `ENCRYPTED` columns. Legacy plaintext
+keys remain readable until encryption is available, are reported as unhealthy,
+and are migrated in-engine as soon as an active encryption key exists.

--- a/README.md
+++ b/README.md
@@ -720,6 +720,7 @@ Lux 1.0 is defined by public contracts, not by an open-ended feature list:
 - [GA.md](GA.md) -- release criteria and 1.0 gate
 - [COMPATIBILITY.md](COMPATIBILITY.md) -- Redis-compatible, Lux-native, divergent, and unsupported behavior
 - [DURABILITY.md](DURABILITY.md) -- snapshot, WAL, restore, crash recovery, and data-loss expectations
+- [MANAGEMENT_API.md](MANAGEMENT_API.md) -- version discovery, engine-owned migrations, repair, and push configuration
 - [SECURITY.md](SECURITY.md) -- disclosure, deployment model, sensitive surfaces, and supported versions
 
 After 1.0, Lux follows semantic versioning for documented public APIs.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2585,7 +2585,10 @@ pub(crate) fn create_table_if_missing(
 ) -> Result<(), String> {
     match tables::table_schema(store, cache, table, now) {
         Ok(_) => Ok(()),
-        Err(_) => tables::table_create(store, cache, table, columns, now),
+        Err(error) if error == format!("ERR table '{table}' does not exist") => {
+            tables::table_create(store, cache, table, columns, now)
+        }
+        Err(error) => Err(format!("ERR could not inspect table '{table}': {error}")),
     }
 }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -370,7 +370,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: b"LUX",
-        min_arity: 3,
+        min_arity: 2,
     },
     CommandSpec {
         name: b"CONFIG",
@@ -1975,7 +1975,25 @@ pub fn execute(
         }
         b'L' => {
             if cmd_eq(cmd, b"LUX") {
-                crate::push::cmd_push(args, store, cache, out, now);
+                if args.get(1).is_some_and(|arg| cmd_eq(arg, b"PUSH")) {
+                    crate::push::cmd_push(args, store, cache, out, now);
+                } else if args.get(1).is_some_and(|arg| cmd_eq(arg, b"MIGRATE")) {
+                    crate::migrations::cmd_migrate(args, store, cache, broker, out, now);
+                } else if args.get(1).is_some_and(|arg| cmd_eq(arg, b"VERSION")) {
+                    let build_sha = option_env!("LUX_BUILD_SHA").unwrap_or("unknown");
+                    resp::write_bulk(
+                        out,
+                        &serde_json::json!({
+                            "version": env!("CARGO_PKG_VERSION"),
+                            "build_sha": build_sha,
+                            "api_version": crate::migrations::API_VERSION,
+                            "capabilities": crate::migrations::CAPABILITIES
+                        })
+                        .to_string(),
+                    );
+                } else {
+                    resp::write_error(out, "ERR usage: LUX <VERSION|MIGRATE|PUSH> ...");
+                }
                 return CmdResult::Written;
             }
             if cmd_eq(cmd, b"LCS") {
@@ -5607,6 +5625,28 @@ mod tests {
         let out = exec_str(&store, &[b"HELLO"]);
         assert!(out.contains("lux"), "contains server name: {out}");
         assert!(out.contains("proto"), "contains proto: {out}");
+    }
+
+    #[test]
+    fn lux_version_and_migrate_have_resp_parity() {
+        let store = Store::new();
+        let version = exec_str(&store, &[b"LUX", b"VERSION"]);
+        assert!(version.contains("\"version\""), "{version}");
+        assert!(version.contains("\"migrations.apply\""), "{version}");
+
+        let applied = exec_str(
+            &store,
+            &[
+                b"LUX",
+                b"MIGRATE",
+                b"APPLY",
+                b"001_resp.lux",
+                b"TCREATE resp_migrated id INT PRIMARY KEY;",
+            ],
+        );
+        assert!(applied.contains("\"status\":\"applied\""), "{applied}");
+        let schema = exec_str(&store, &[b"TSCHEMA", b"resp_migrated"]);
+        assert!(!schema.starts_with('-'), "{schema}");
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -2676,6 +2676,17 @@ fn route_request_with_auth(
     }
 
     match (method, base) {
+        // ── engine management contract ──
+        ("GET", ["version"]) => engine_version(),
+        ("GET", ["migrations"]) => migration_list(params, store, cache),
+        ("POST", ["migrations", "plan"]) => migration_plan(body, store, cache),
+        ("POST", ["migrations", "apply"]) => {
+            migration_apply(body, store, broker, cache, script_engine)
+        }
+        ("POST", ["migrations", "repair"]) => {
+            migration_repair(body, store, broker, cache, script_engine)
+        }
+
         // ── exec (escape hatch) ──
         ("POST", ["exec"]) => ok(handle_exec(body, store, broker, cache, script_engine)),
 
@@ -2686,6 +2697,11 @@ fn route_request_with_auth(
         ("DELETE", ["push", "devices"]) => push_delete_device_by_token(body, store, cache),
         ("POST", ["push", "send"]) => push_send(body, store, cache),
         ("POST", ["push", "credentials"]) => push_set_credentials(body, store, cache),
+        ("GET", ["push", "config"]) => push_config(params, store, cache),
+        ("PUT", ["push", "config", "apns"]) => push_update_apns(body, store, cache),
+        ("DELETE", ["push", "config", "apns"]) => push_clear_apns(params, store, cache),
+        ("POST", ["push", "config", "vapid"]) => push_enable_vapid(body, store, cache),
+        ("DELETE", ["push", "config", "vapid"]) => push_disable_vapid(params, store, cache),
         ("GET", ["push", "admin", "devices"]) => push_admin_devices(store, cache),
         ("GET", ["push", "admin", "outbox"]) => push_admin_outbox(store, cache),
         ("GET", ["push", "admin", "stats"]) => push_admin_stats(),
@@ -3045,6 +3061,10 @@ fn route_requires_project_access(method: &str, base: &[&str]) -> bool {
     matches!(
         (method, base),
         ("POST", ["exec"])
+            | ("GET", ["migrations"])
+            | ("POST", ["migrations", "plan"])
+            | ("POST", ["migrations", "apply"])
+            | ("POST", ["migrations", "repair"])
             | ("GET", ["dbsize"])
             | ("GET", ["keys"])
             | ("GET", ["keys", _])
@@ -3067,11 +3087,185 @@ fn route_requires_project_access(method: &str, base: &[&str]) -> bool {
             | ("DELETE", ["vectors", _])
             | ("POST", ["push", "send"])
             | ("POST", ["push", "credentials"])
+            | ("GET", ["push", "config"])
+            | ("PUT", ["push", "config", "apns"])
+            | ("DELETE", ["push", "config", "apns"])
+            | ("POST", ["push", "config", "vapid"])
+            | ("DELETE", ["push", "config", "vapid"])
             | ("DELETE", ["push", "devices"])
             | ("GET", ["push", "admin", "devices"])
             | ("GET", ["push", "admin", "outbox"])
             | ("GET", ["push", "admin", "stats"])
     )
+}
+
+fn engine_version() -> (u16, &'static str, String) {
+    let build_sha = option_env!("LUX_BUILD_SHA").unwrap_or("unknown");
+    ok(json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "build_sha": build_sha,
+        "api_version": crate::migrations::API_VERSION,
+        "capabilities": crate::migrations::CAPABILITIES
+    })
+    .to_string())
+}
+
+fn migration_list(
+    params: &[(String, String)],
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> (u16, &'static str, String) {
+    let limit = get_param(params, "limit")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(100);
+    let offset = get_param(params, "offset")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+    match crate::migrations::list(store, cache, limit, offset, Instant::now()) {
+        Ok(migrations) => ok(json!({
+            "migrations": migrations,
+            "limit": limit.clamp(1, 1000),
+            "offset": offset
+        })
+        .to_string()),
+        Err(error) => migration_json_error(&error),
+    }
+}
+
+fn parse_migration_request(body: &str) -> Result<(String, String), (u16, &'static str, String)> {
+    let parsed: Value = serde_json::from_str(body)
+        .map_err(|_| push_json_error(400, "Bad Request", "invalid json"))?;
+    let filename = crate::migrations::resolve_filename(
+        parsed.get("filename").and_then(Value::as_str),
+        parsed.get("name").and_then(Value::as_str),
+    )
+    .map_err(|error| migration_json_error(&error))?;
+    let migration_body = parsed
+        .get("body")
+        .and_then(Value::as_str)
+        .ok_or_else(|| push_json_error(400, "Bad Request", "body is required"))?
+        .to_string();
+    Ok((filename, migration_body))
+}
+
+fn migration_plan(
+    body: &str,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> (u16, &'static str, String) {
+    let (filename, migration_body) = match parse_migration_request(body) {
+        Ok(request) => request,
+        Err(response) => return response,
+    };
+    match crate::migrations::plan(store, cache, &filename, &migration_body, Instant::now()) {
+        Ok(plan) => ok(json!({ "plan": plan }).to_string()),
+        Err(error) => migration_json_error(&error),
+    }
+}
+
+fn execute_migration_command(
+    command: &[String],
+    store: &Arc<Store>,
+    broker: &Broker,
+    cache: &SharedSchemaCache,
+    script_engine: &Arc<lua::ScriptEngine>,
+) -> Result<(), String> {
+    if command
+        .first()
+        .is_some_and(|value| value.eq_ignore_ascii_case("LUX"))
+    {
+        return Err("nested LUX commands are not allowed in migrations".to_string());
+    }
+    let args: Vec<&str> = command.iter().map(String::as_str).collect();
+    let response =
+        exec_resp(store, broker, cache, script_engine, &args).map_err(|error| error.to_string())?;
+    if response.first() == Some(&b'-') {
+        let message = std::str::from_utf8(&response[1..])
+            .unwrap_or("engine command failed")
+            .trim_end_matches("\r\n");
+        Err(message.to_string())
+    } else {
+        Ok(())
+    }
+}
+
+fn migration_apply(
+    body: &str,
+    store: &Arc<Store>,
+    broker: &Broker,
+    cache: &SharedSchemaCache,
+    script_engine: &Arc<lua::ScriptEngine>,
+) -> (u16, &'static str, String) {
+    let (filename, migration_body) = match parse_migration_request(body) {
+        Ok(request) => request,
+        Err(response) => return response,
+    };
+    match crate::migrations::apply(
+        store,
+        cache,
+        &filename,
+        &migration_body,
+        Instant::now(),
+        |command| execute_migration_command(command, store, broker, cache, script_engine),
+    ) {
+        Ok(result) => ok(json!({
+            "migration": result.migration,
+            "already_applied": result.already_applied
+        })
+        .to_string()),
+        Err(error) => migration_json_error(&error),
+    }
+}
+
+fn migration_repair(
+    body: &str,
+    store: &Arc<Store>,
+    broker: &Broker,
+    cache: &SharedSchemaCache,
+    script_engine: &Arc<lua::ScriptEngine>,
+) -> (u16, &'static str, String) {
+    let parsed: Value = match serde_json::from_str(body) {
+        Ok(value) => value,
+        Err(_) => return push_json_error(400, "Bad Request", "invalid json"),
+    };
+    let filename = match parsed.get("filename").and_then(Value::as_str) {
+        Some(value) => value,
+        None => return push_json_error(400, "Bad Request", "filename is required"),
+    };
+    let action = match parsed.get("action").and_then(Value::as_str) {
+        Some("resume") => {
+            let Some(from_command) = parsed.get("from_command").and_then(Value::as_u64) else {
+                return push_json_error(
+                    400,
+                    "Bad Request",
+                    "resume requires an explicit zero-based from_command",
+                );
+            };
+            crate::migrations::RepairAction::Resume {
+                from_command: from_command as usize,
+            }
+        }
+        Some("mark_applied") => crate::migrations::RepairAction::MarkApplied,
+        Some("abandon") => crate::migrations::RepairAction::Abandon,
+        _ => {
+            return push_json_error(
+                400,
+                "Bad Request",
+                "action must be resume, mark_applied, or abandon",
+            )
+        }
+    };
+    match crate::migrations::repair(store, cache, filename, action, Instant::now(), |command| {
+        execute_migration_command(command, store, broker, cache, script_engine)
+    }) {
+        Ok(migration) => ok(json!({ "migration": migration }).to_string()),
+        Err(error) => migration_json_error(&error),
+    }
+}
+
+fn migration_json_error(message: &str) -> (u16, &'static str, String) {
+    let message = message.strip_prefix("ERR ").unwrap_or(message);
+    push_json_error(400, "Bad Request", message)
 }
 
 fn ok(result: String) -> (u16, &'static str, String) {
@@ -3296,6 +3490,132 @@ fn push_admin_stats() -> (u16, &'static str, String) {
     .to_string())
 }
 
+/// `GET /v1/push/config?app_id=...` — secret-free configuration and health.
+fn push_config(
+    params: &[(String, String)],
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> (u16, &'static str, String) {
+    let app_id = get_param(params, "app_id").unwrap_or("default");
+    match crate::push::credential_config(store, cache, app_id, Instant::now()) {
+        Ok(config) => ok(json!({ "config": config }).to_string()),
+        Err(error) => push_json_error(400, "Bad Request", &error),
+    }
+}
+
+/// `PUT /v1/push/config/apns` — update APNs metadata. Omitting `p8_pem`
+/// preserves the existing encrypted key; first-time setup requires it.
+fn push_update_apns(
+    body: &str,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> (u16, &'static str, String) {
+    let parsed: Value = match serde_json::from_str(body) {
+        Ok(value) => value,
+        Err(_) => return push_json_error(400, "Bad Request", "invalid json"),
+    };
+    let app_id = parsed["app_id"].as_str().unwrap_or("default");
+    let team_id = parsed["team_id"].as_str().unwrap_or("");
+    let key_id = parsed["key_id"].as_str().unwrap_or("");
+    let topic = parsed["topic"].as_str().unwrap_or("");
+    let environment = parsed["environment"].as_str().unwrap_or("sandbox");
+    let p8_pem = parsed.get("p8_pem").and_then(Value::as_str);
+    if team_id.is_empty() || key_id.is_empty() || topic.is_empty() {
+        return push_json_error(
+            400,
+            "Bad Request",
+            "team_id, key_id, and topic are required",
+        );
+    }
+    match crate::push::update_apns_credentials(
+        store,
+        cache,
+        app_id,
+        team_id,
+        key_id,
+        p8_pem,
+        topic,
+        environment,
+        Instant::now(),
+    ) {
+        Ok(()) => match crate::push::credential_config(store, cache, app_id, Instant::now()) {
+            Ok(config) => ok(json!({ "config": config }).to_string()),
+            Err(error) => push_json_error(400, "Bad Request", &error),
+        },
+        Err(error) => push_json_error(400, "Bad Request", &error),
+    }
+}
+
+fn push_clear_apns(
+    params: &[(String, String)],
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> (u16, &'static str, String) {
+    let app_id = get_param(params, "app_id").unwrap_or("default");
+    match crate::push::clear_apns_credentials(store, cache, app_id, Instant::now()) {
+        Ok(()) => ok(json!({ "ok": true, "app_id": app_id }).to_string()),
+        Err(error) => push_json_error(400, "Bad Request", &error),
+    }
+}
+
+/// `POST /v1/push/config/vapid` with `action=enable|rotate`. Enable is
+/// idempotent; rotate intentionally replaces the browser-facing public key.
+fn push_enable_vapid(
+    body: &str,
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> (u16, &'static str, String) {
+    let parsed: Value = match serde_json::from_str(body) {
+        Ok(value) => value,
+        Err(_) => return push_json_error(400, "Bad Request", "invalid json"),
+    };
+    let app_id = parsed["app_id"].as_str().unwrap_or("default");
+    let action = parsed["action"].as_str().unwrap_or("enable");
+    let subject = parsed["subject"]
+        .as_str()
+        .unwrap_or("mailto:push@luxdb.dev");
+    if let Err(error) = crate::push::credential_config(store, cache, app_id, Instant::now()) {
+        return push_json_error(400, "Bad Request", &error);
+    }
+    if action == "enable" {
+        match crate::push::vapid_public_key(store, cache, app_id, Instant::now()) {
+            Ok(Some(public_key)) => {
+                return ok(json!({
+                    "ok": true,
+                    "rotated": false,
+                    "public_key": public_key
+                })
+                .to_string())
+            }
+            Ok(None) => {}
+            Err(error) => return push_json_error(400, "Bad Request", &error),
+        }
+    } else if action != "rotate" {
+        return push_json_error(400, "Bad Request", "action must be enable or rotate");
+    }
+    match crate::push::rotate_vapid_credentials(store, cache, app_id, subject, Instant::now()) {
+        Ok(public_key) => ok(json!({
+            "ok": true,
+            "rotated": action == "rotate",
+            "public_key": public_key
+        })
+        .to_string()),
+        Err(error) => push_json_error(400, "Bad Request", &error),
+    }
+}
+
+fn push_disable_vapid(
+    params: &[(String, String)],
+    store: &Arc<Store>,
+    cache: &SharedSchemaCache,
+) -> (u16, &'static str, String) {
+    let app_id = get_param(params, "app_id").unwrap_or("default");
+    match crate::push::disable_vapid_credentials(store, cache, app_id, Instant::now()) {
+        Ok(()) => ok(json!({ "ok": true, "app_id": app_id }).to_string()),
+        Err(error) => push_json_error(400, "Bad Request", &error),
+    }
+}
+
 /// `POST /v1/push/credentials` (operator) — set an app's APNs credentials.
 fn push_set_credentials(
     body: &str,
@@ -3333,17 +3653,17 @@ fn push_set_credentials(
     // APNs credentials.
     let team_id = parsed["team_id"].as_str().unwrap_or("");
     let key_id = parsed["key_id"].as_str().unwrap_or("");
-    let p8_pem = parsed["p8_pem"].as_str().unwrap_or("");
+    let p8_pem = parsed.get("p8_pem").and_then(Value::as_str);
     let topic = parsed["topic"].as_str().unwrap_or("");
     let environment = parsed["environment"].as_str().unwrap_or("sandbox");
-    if team_id.is_empty() || key_id.is_empty() || p8_pem.is_empty() || topic.is_empty() {
+    if team_id.is_empty() || key_id.is_empty() || topic.is_empty() {
         return push_json_error(
             400,
             "Bad Request",
-            "team_id, key_id, p8_pem, and topic are required",
+            "team_id, key_id, and topic are required; p8_pem is required only for first-time setup",
         );
     }
-    match crate::push::set_apns_credentials(
+    match crate::push::update_apns_credentials(
         store,
         cache,
         app_id,
@@ -4830,6 +5150,10 @@ mod tests {
         // A bug here hands token users raw KV / exec / catalog. Lock it down.
         for (m, base) in [
             ("POST", vec!["exec"]),
+            ("GET", vec!["migrations"]),
+            ("POST", vec!["migrations", "plan"]),
+            ("POST", vec!["migrations", "apply"]),
+            ("POST", vec!["migrations", "repair"]),
             ("GET", vec!["dbsize"]),
             ("GET", vec!["keys"]),
             ("GET", vec!["kv", "secret"]),
@@ -4843,6 +5167,11 @@ mod tests {
             ("GET", vec!["vectors", "idx"]),
             ("POST", vec!["vectors", "idx"]),
             ("DELETE", vec!["vectors", "idx"]),
+            ("GET", vec!["push", "config"]),
+            ("PUT", vec!["push", "config", "apns"]),
+            ("DELETE", vec!["push", "config", "apns"]),
+            ("POST", vec!["push", "config", "vapid"]),
+            ("DELETE", vec!["push", "config", "vapid"]),
         ] {
             assert!(
                 route_requires_project_access(m, &base),
@@ -4850,6 +5179,41 @@ mod tests {
                 base.join("/")
             );
         }
+    }
+
+    #[test]
+    fn migration_http_contract_executes_and_is_idempotent() {
+        let (store, broker, cache, script_engine) = encrypted_http_fixture();
+        let body = json!({
+            "filename": "001_messages.lux",
+            "body": "TCREATE messages id INT PRIMARY KEY, body STR;\nTINSERT messages id 1 body hello;"
+        })
+        .to_string();
+        let (status, _, response) = migration_apply(&body, &store, &broker, &cache, &script_engine);
+        assert_eq!(status, 200, "{response}");
+        let parsed: Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(parsed["migration"]["status"], "applied");
+        assert_eq!(parsed["migration"]["completed_commands"], 2);
+        assert_eq!(parsed["already_applied"], false);
+
+        let (status, _, response) = migration_apply(&body, &store, &broker, &cache, &script_engine);
+        assert_eq!(status, 200, "{response}");
+        let parsed: Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(parsed["already_applied"], true);
+    }
+
+    #[test]
+    fn version_contract_advertises_management_capabilities() {
+        let (status, _, response) = engine_version();
+        assert_eq!(status, 200);
+        let parsed: Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(parsed["api_version"], crate::migrations::API_VERSION);
+        assert!(parsed["capabilities"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "migrations.apply"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod hnsw;
 mod http;
 mod jsonb;
 mod lua;
+mod migrations;
 mod pubsub;
 mod push;
 mod resp;

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -1,0 +1,1163 @@
+//! Engine-owned migration parsing, checksums, ledger state, and execution.
+//!
+//! Every surface (CLI, Cloud, and Studio) calls this contract instead of
+//! maintaining its own parser or writing `__migrations` directly. A migration
+//! is recorded as `applying` before its first command and advances its durable
+//! command cursor after every successful command. An interrupted or failed
+//! migration blocks later writes until an operator explicitly repairs it.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Instant;
+
+use bytes::BytesMut;
+use parking_lot::Mutex;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::auth::{
+    add_column_if_missing, durable_table_insert, durable_table_update_where, unix_seconds,
+};
+use crate::cmd::CmdResult;
+use crate::pubsub::Broker;
+use crate::resp;
+use crate::store::Store;
+use crate::tables::{self, SelectPlan, SelectResult, SharedSchemaCache};
+
+pub(crate) const LEDGER_TABLE: &str = "__migrations";
+pub(crate) const API_VERSION: &str = "1";
+pub(crate) const CHECKSUM_ALGORITHM: &str = "sha256";
+pub(crate) const CAPABILITIES: &[&str] = &[
+    "migrations.plan",
+    "migrations.apply",
+    "migrations.repair",
+    "migrations.sha256",
+    "push.config",
+    "push.apns.preserve_key",
+    "push.vapid.rotate",
+    "push.secrets.encrypted",
+];
+
+const STATUS_APPLYING: &str = "applying";
+const STATUS_APPLIED: &str = "applied";
+const STATUS_FAILED: &str = "failed";
+const STATUS_ABANDONED: &str = "abandoned";
+
+// Migration execution changes both user data and the ledger. Serialize writers
+// so two concurrent callers cannot both plan against the same pre-insert state.
+// Embedded servers retain isolated stores; a process-wide lock is conservative
+// and keeps the contract correct without leaking state between them.
+static MIGRATION_WRITE_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct MigrationRecord {
+    pub filename: String,
+    pub checksum: String,
+    pub checksum_algorithm: String,
+    pub applied_at: u64,
+    pub body: String,
+    pub status: String,
+    pub command_count: usize,
+    pub completed_commands: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PlanAction {
+    Apply,
+    AlreadyApplied,
+    Conflict,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct MigrationPlan {
+    pub filename: String,
+    pub checksum: String,
+    pub checksum_algorithm: &'static str,
+    pub command_count: usize,
+    pub action: PlanAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct ApplyResult {
+    pub migration: MigrationRecord,
+    pub already_applied: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RepairAction {
+    Resume { from_command: usize },
+    MarkApplied,
+    Abandon,
+}
+
+/// Return a safe migration filename. CLI callers normally supply a complete
+/// filename; Studio may supply a human name and let the engine timestamp it.
+pub(crate) fn resolve_filename(
+    filename: Option<&str>,
+    name: Option<&str>,
+) -> Result<String, String> {
+    if let Some(filename) = filename.map(str::trim).filter(|v| !v.is_empty()) {
+        validate_filename(filename)?;
+        return Ok(filename.to_string());
+    }
+    let name = name
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| "ERR filename or name is required".to_string())?;
+    let slug = slugify(name);
+    Ok(format!("{}_{}.lux", unix_seconds(), slug))
+}
+
+fn validate_filename(filename: &str) -> Result<(), String> {
+    if filename.len() > 255
+        || filename == "."
+        || filename == ".."
+        || filename.contains('/')
+        || filename.contains('\\')
+        || filename.chars().any(char::is_control)
+    {
+        return Err("ERR migration filename must be a safe basename".to_string());
+    }
+    Ok(())
+}
+
+fn slugify(name: &str) -> String {
+    let mut out = String::new();
+    let mut separator = false;
+    for ch in name.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            if separator && !out.is_empty() {
+                out.push('_');
+            }
+            out.push(ch);
+            separator = false;
+        } else {
+            separator = true;
+        }
+    }
+    if out.is_empty() {
+        "migration".to_string()
+    } else {
+        out
+    }
+}
+
+pub(crate) fn checksum(body: &str) -> String {
+    let digest = Sha256::digest(body.as_bytes());
+    format!("{digest:x}")
+}
+
+fn legacy_djb2_checksum(body: &str) -> String {
+    let mut hash: u64 = 5381;
+    for byte in body.bytes() {
+        hash = hash.wrapping_mul(33).wrapping_add(byte as u64);
+    }
+    format!("{hash:016x}")
+}
+
+fn legacy_fnv1a_checksum(body: &str) -> String {
+    let mut hash: u32 = 0x811c9dc5;
+    for unit in body.encode_utf16() {
+        hash ^= u32::from(unit);
+        hash = hash.wrapping_mul(0x01000193);
+    }
+    format!("{hash:x}")
+}
+
+fn checksum_matches(record: &MigrationRecord, body: &str) -> bool {
+    match record.checksum_algorithm.as_str() {
+        CHECKSUM_ALGORITHM => record.checksum == checksum(body),
+        "djb2-64" => record.checksum == legacy_djb2_checksum(body),
+        "fnv1a-32-utf16" => record.checksum == legacy_fnv1a_checksum(body),
+        "legacy" | "" => {
+            record.checksum == legacy_djb2_checksum(body)
+                || record.checksum == legacy_fnv1a_checksum(body)
+        }
+        _ => false,
+    }
+}
+
+fn is_missing_table_error(error: &str) -> bool {
+    error == format!("ERR table '{LEDGER_TABLE}' does not exist")
+}
+
+/// Strictly create or upgrade the ledger. Unexpected schema failures are
+/// returned; they are never treated as proof that the table is absent.
+pub(crate) fn ensure_ledger(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    now: Instant,
+) -> Result<(), String> {
+    match tables::table_schema(store, cache, LEDGER_TABLE, now) {
+        Ok(_) => {}
+        Err(error) if is_missing_table_error(&error) => {
+            tables::table_create(
+                store,
+                cache,
+                LEDGER_TABLE,
+                &[
+                    "filename STR PRIMARY KEY,",
+                    "checksum STR,",
+                    "applied_at INT,",
+                    "body STR,",
+                    "status STR,",
+                    "checksum_algorithm STR,",
+                    "command_count INT,",
+                    "completed_commands INT,",
+                    "error STR",
+                ],
+                now,
+            )?;
+        }
+        Err(error) => return Err(format!("ERR could not inspect migration ledger: {error}")),
+    }
+
+    for spec in [
+        "body STR",
+        "status STR",
+        "checksum_algorithm STR",
+        "command_count INT",
+        "completed_commands INT",
+        "error STR",
+    ] {
+        add_column_if_missing(store, cache, LEDGER_TABLE, spec, now)?;
+    }
+    normalize_legacy_rows(store, cache, now)
+}
+
+fn raw_rows(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    limit: Option<usize>,
+    offset: Option<usize>,
+    now: Instant,
+) -> Result<Vec<HashMap<String, String>>, String> {
+    let plan = SelectPlan {
+        table: LEDGER_TABLE.to_string(),
+        alias: None,
+        projections: Vec::new(),
+        aggregates: Vec::new(),
+        joins: Vec::new(),
+        conditions: Vec::new(),
+        group_by: Vec::new(),
+        having: Vec::new(),
+        near: None,
+        order_by: Some(("applied_at".to_string(), true)),
+        limit,
+        offset,
+        decrypt_authorized: true,
+    };
+    match tables::table_select(store, cache, &plan, now)? {
+        SelectResult::Rows(rows) => Ok(rows
+            .into_iter()
+            .map(|row| row.into_iter().collect())
+            .collect()),
+        SelectResult::Aggregate(_) => {
+            Err("ERR migration ledger query returned an aggregate".into())
+        }
+    }
+}
+
+fn normalize_legacy_rows(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    now: Instant,
+) -> Result<(), String> {
+    let rows = raw_rows(store, cache, Some(10_001), None, now)?;
+    if rows.len() > 10_000 {
+        return Err("ERR migration ledger exceeds the 10000-row safety limit".to_string());
+    }
+    let mut filenames = HashSet::new();
+    for row in &rows {
+        let filename = row.get("filename").cloned().unwrap_or_default();
+        if filename.is_empty() {
+            return Err("ERR migration ledger contains a row without a filename".to_string());
+        }
+        if !filenames.insert(filename.clone()) {
+            return Err(format!(
+                "ERR migration ledger contains duplicate filename '{filename}'"
+            ));
+        }
+    }
+    for row in rows {
+        let filename = row.get("filename").cloned().unwrap_or_default();
+        let body = row.get("body").cloned().unwrap_or_default();
+        let command_count = parse_migration_commands(&body)
+            .map(|commands| commands.len())
+            .unwrap_or(0)
+            .to_string();
+        let status = row.get("status").map(String::as_str).unwrap_or("");
+        let algorithm = row
+            .get("checksum_algorithm")
+            .map(String::as_str)
+            .unwrap_or("");
+        let completed = row
+            .get("completed_commands")
+            .map(String::as_str)
+            .unwrap_or("");
+        if status.is_empty() || algorithm.is_empty() || completed.is_empty() {
+            let checksum_algorithm = if algorithm.is_empty() {
+                infer_legacy_algorithm(row.get("checksum").map(String::as_str).unwrap_or(""), &body)
+            } else {
+                algorithm
+            };
+            let fields = [
+                (
+                    "status",
+                    if status.is_empty() {
+                        STATUS_APPLIED
+                    } else {
+                        status
+                    },
+                ),
+                ("checksum_algorithm", checksum_algorithm),
+                ("command_count", command_count.as_str()),
+                (
+                    "completed_commands",
+                    if completed.is_empty() {
+                        command_count.as_str()
+                    } else {
+                        completed
+                    },
+                ),
+                ("error", row.get("error").map(String::as_str).unwrap_or("")),
+            ];
+            durable_table_update_where(
+                store,
+                cache,
+                LEDGER_TABLE,
+                &fields,
+                &["filename", "=", filename.as_str()],
+                now,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn infer_legacy_algorithm(stored: &str, body: &str) -> &'static str {
+    if stored == legacy_djb2_checksum(body) {
+        "djb2-64"
+    } else if stored == legacy_fnv1a_checksum(body) {
+        "fnv1a-32-utf16"
+    } else {
+        "legacy"
+    }
+}
+
+fn record_from_row(row: HashMap<String, String>) -> Result<MigrationRecord, String> {
+    let parse_number = |field: &str| -> Result<u64, String> {
+        let raw = row.get(field).map(String::as_str).unwrap_or("0");
+        raw.parse()
+            .map_err(|_| format!("ERR migration ledger has invalid {field}"))
+    };
+    let filename = row.get("filename").cloned().unwrap_or_default();
+    if filename.is_empty() {
+        return Err("ERR migration ledger contains a row without a filename".to_string());
+    }
+    let error = row
+        .get("error")
+        .cloned()
+        .filter(|value| !value.is_empty() && value != "NULL");
+    Ok(MigrationRecord {
+        filename,
+        checksum: row.get("checksum").cloned().unwrap_or_default(),
+        checksum_algorithm: row
+            .get("checksum_algorithm")
+            .cloned()
+            .unwrap_or_else(|| "legacy".to_string()),
+        applied_at: parse_number("applied_at")?,
+        body: row.get("body").cloned().unwrap_or_default(),
+        status: row
+            .get("status")
+            .cloned()
+            .unwrap_or_else(|| STATUS_APPLIED.to_string()),
+        command_count: parse_number("command_count")? as usize,
+        completed_commands: parse_number("completed_commands")? as usize,
+        error,
+    })
+}
+
+pub(crate) fn list(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    limit: usize,
+    offset: usize,
+    now: Instant,
+) -> Result<Vec<MigrationRecord>, String> {
+    ensure_ledger(store, cache, now)?;
+    raw_rows(store, cache, Some(limit.clamp(1, 1000)), Some(offset), now)?
+        .into_iter()
+        .map(record_from_row)
+        .collect()
+}
+
+fn all_records(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    now: Instant,
+) -> Result<Vec<MigrationRecord>, String> {
+    raw_rows(store, cache, Some(10_000), None, now)?
+        .into_iter()
+        .map(record_from_row)
+        .collect()
+}
+
+fn blocker<'a>(
+    records: &'a [MigrationRecord],
+    except: Option<&str>,
+) -> Option<&'a MigrationRecord> {
+    records.iter().find(|record| {
+        Some(record.filename.as_str()) != except
+            && matches!(record.status.as_str(), STATUS_APPLYING | STATUS_FAILED)
+    })
+}
+
+pub(crate) fn plan(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    filename: &str,
+    body: &str,
+    now: Instant,
+) -> Result<MigrationPlan, String> {
+    validate_filename(filename)?;
+    ensure_ledger(store, cache, now)?;
+    let commands = parse_migration_commands(body)?;
+    if commands.is_empty() {
+        return Err("ERR migration has no commands".to_string());
+    }
+    let records = all_records(store, cache, now)?;
+    let wanted_checksum = checksum(body);
+    let existing = records.iter().find(|record| record.filename == filename);
+    let (action, reason) = if let Some(existing) = existing {
+        if existing.status == STATUS_APPLIED && checksum_matches(existing, body) {
+            (PlanAction::AlreadyApplied, None)
+        } else if matches!(existing.status.as_str(), STATUS_APPLYING | STATUS_FAILED) {
+            (
+                PlanAction::Blocked,
+                Some(format!(
+                    "migration is {}; repair it explicitly before continuing",
+                    existing.status
+                )),
+            )
+        } else {
+            (
+                PlanAction::Conflict,
+                Some("filename already exists with different content or state".to_string()),
+            )
+        }
+    } else if let Some(blocked) = blocker(&records, None) {
+        (
+            PlanAction::Blocked,
+            Some(format!(
+                "{} migration '{}' must be repaired first",
+                blocked.status, blocked.filename
+            )),
+        )
+    } else {
+        (PlanAction::Apply, None)
+    };
+    Ok(MigrationPlan {
+        filename: filename.to_string(),
+        checksum: wanted_checksum,
+        checksum_algorithm: CHECKSUM_ALGORITHM,
+        command_count: commands.len(),
+        action,
+        reason,
+    })
+}
+
+pub(crate) fn apply<F>(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    filename: &str,
+    body: &str,
+    now: Instant,
+    mut execute: F,
+) -> Result<ApplyResult, String>
+where
+    F: FnMut(&[String]) -> Result<(), String>,
+{
+    let _write_guard = MIGRATION_WRITE_LOCK.lock();
+    let planned = plan(store, cache, filename, body, now)?;
+    if planned.action == PlanAction::AlreadyApplied {
+        let migration = all_records(store, cache, now)?
+            .into_iter()
+            .find(|record| record.filename == filename)
+            .ok_or_else(|| "ERR migration disappeared during apply".to_string())?;
+        return Ok(ApplyResult {
+            migration,
+            already_applied: true,
+        });
+    }
+    if planned.action != PlanAction::Apply {
+        return Err(format!(
+            "ERR migration cannot be applied: {}",
+            planned.reason.unwrap_or_else(|| "conflict".to_string())
+        ));
+    }
+    let commands = parse_migration_commands(body)?;
+    let now_s = unix_seconds().to_string();
+    let command_count = commands.len().to_string();
+    durable_table_insert(
+        store,
+        cache,
+        LEDGER_TABLE,
+        &[
+            ("filename", filename),
+            ("checksum", planned.checksum.as_str()),
+            ("applied_at", "0"),
+            ("body", body),
+            ("status", STATUS_APPLYING),
+            ("checksum_algorithm", CHECKSUM_ALGORITHM),
+            ("command_count", command_count.as_str()),
+            ("completed_commands", "0"),
+            ("error", ""),
+        ],
+        now,
+    )?;
+    execute_from(store, cache, filename, &commands, 0, now, &mut execute)?;
+    durable_table_update_where(
+        store,
+        cache,
+        LEDGER_TABLE,
+        &[
+            ("status", STATUS_APPLIED),
+            ("applied_at", now_s.as_str()),
+            ("error", ""),
+        ],
+        &["filename", "=", filename],
+        now,
+    )?;
+    let migration = all_records(store, cache, now)?
+        .into_iter()
+        .find(|record| record.filename == filename)
+        .ok_or_else(|| "ERR applied migration was not recorded".to_string())?;
+    Ok(ApplyResult {
+        migration,
+        already_applied: false,
+    })
+}
+
+fn execute_from<F>(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    filename: &str,
+    commands: &[Vec<String>],
+    from_command: usize,
+    now: Instant,
+    execute: &mut F,
+) -> Result<(), String>
+where
+    F: FnMut(&[String]) -> Result<(), String>,
+{
+    for (index, command) in commands.iter().enumerate().skip(from_command) {
+        if let Err(error) = execute(command) {
+            let safe_error = error.chars().take(2000).collect::<String>();
+            durable_table_update_where(
+                store,
+                cache,
+                LEDGER_TABLE,
+                &[("status", STATUS_FAILED), ("error", safe_error.as_str())],
+                &["filename", "=", filename],
+                now,
+            )?;
+            return Err(format!(
+                "ERR migration '{filename}' failed at command {}: {error}",
+                index + 1
+            ));
+        }
+        let completed = (index + 1).to_string();
+        durable_table_update_where(
+            store,
+            cache,
+            LEDGER_TABLE,
+            &[("completed_commands", completed.as_str())],
+            &["filename", "=", filename],
+            now,
+        )?;
+    }
+    Ok(())
+}
+
+pub(crate) fn repair<F>(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    filename: &str,
+    action: RepairAction,
+    now: Instant,
+    mut execute: F,
+) -> Result<MigrationRecord, String>
+where
+    F: FnMut(&[String]) -> Result<(), String>,
+{
+    let _write_guard = MIGRATION_WRITE_LOCK.lock();
+    validate_filename(filename)?;
+    ensure_ledger(store, cache, now)?;
+    let records = all_records(store, cache, now)?;
+    let record = records
+        .iter()
+        .find(|record| record.filename == filename)
+        .cloned()
+        .ok_or_else(|| format!("ERR migration '{filename}' was not found"))?;
+    if !matches!(record.status.as_str(), STATUS_APPLYING | STATUS_FAILED) {
+        return Err(format!(
+            "ERR migration '{}' is {}; only applying or failed migrations can be repaired",
+            filename, record.status
+        ));
+    }
+    match action {
+        RepairAction::Resume { from_command } => {
+            let commands = parse_migration_commands(&record.body)?;
+            if from_command > commands.len() {
+                return Err(format!(
+                    "ERR from_command {from_command} exceeds command count {}",
+                    commands.len()
+                ));
+            }
+            let reviewed = from_command.to_string();
+            durable_table_update_where(
+                store,
+                cache,
+                LEDGER_TABLE,
+                &[
+                    ("status", STATUS_APPLYING),
+                    ("completed_commands", reviewed.as_str()),
+                    ("error", ""),
+                ],
+                &["filename", "=", filename],
+                now,
+            )?;
+            execute_from(
+                store,
+                cache,
+                filename,
+                &commands,
+                from_command,
+                now,
+                &mut execute,
+            )?;
+            let applied_at = unix_seconds().to_string();
+            durable_table_update_where(
+                store,
+                cache,
+                LEDGER_TABLE,
+                &[
+                    ("status", STATUS_APPLIED),
+                    ("applied_at", applied_at.as_str()),
+                    ("error", ""),
+                ],
+                &["filename", "=", filename],
+                now,
+            )?;
+        }
+        RepairAction::MarkApplied => {
+            let applied_at = unix_seconds().to_string();
+            let completed = record.command_count.to_string();
+            durable_table_update_where(
+                store,
+                cache,
+                LEDGER_TABLE,
+                &[
+                    ("status", STATUS_APPLIED),
+                    ("applied_at", applied_at.as_str()),
+                    ("completed_commands", completed.as_str()),
+                    ("error", ""),
+                ],
+                &["filename", "=", filename],
+                now,
+            )?;
+        }
+        RepairAction::Abandon => {
+            durable_table_update_where(
+                store,
+                cache,
+                LEDGER_TABLE,
+                &[("status", STATUS_ABANDONED), ("error", "")],
+                &["filename", "=", filename],
+                now,
+            )?;
+        }
+    }
+    all_records(store, cache, now)?
+        .into_iter()
+        .find(|record| record.filename == filename)
+        .ok_or_else(|| "ERR repaired migration disappeared".to_string())
+}
+
+pub(crate) fn parse_migration_commands(content: &str) -> Result<Vec<Vec<String>>, String> {
+    let (statements, saw_semicolon) = split_statements(content);
+    if !saw_semicolon {
+        return parse_migration_lines(content);
+    }
+    let mut commands = Vec::new();
+    for (index, statement) in statements.iter().enumerate() {
+        let statement = statement.trim();
+        if statement.is_empty() {
+            continue;
+        }
+        if statement.starts_with('[') {
+            let parsed: Vec<String> = serde_json::from_str(statement).map_err(|error| {
+                format!(
+                    "ERR statement {} is not a valid JSON argv array: {error}",
+                    index + 1
+                )
+            })?;
+            if parsed.is_empty() {
+                return Err(format!("ERR statement {} has an empty command", index + 1));
+            }
+            commands.push(parsed);
+        } else {
+            let parsed = split_command_line(statement).map_err(|error| {
+                format!("ERR statement {} could not be parsed: {error}", index + 1)
+            })?;
+            if !parsed.is_empty() {
+                commands.push(parsed);
+            }
+        }
+    }
+    Ok(commands)
+}
+
+fn split_statements(content: &str) -> (Vec<String>, bool) {
+    let mut statements = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut line_comment = false;
+    let mut saw_semicolon = false;
+    let mut chars = content.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if line_comment {
+            if ch == '\n' {
+                line_comment = false;
+                current.push(' ');
+            }
+            continue;
+        }
+        match quote {
+            Some(expected) => {
+                current.push(ch);
+                if ch == '\\' {
+                    if let Some(next) = chars.next() {
+                        current.push(next);
+                    }
+                } else if ch == expected {
+                    quote = None;
+                }
+            }
+            None if ch == '#' => line_comment = true,
+            None if ch == '-' && chars.peek() == Some(&'-') => {
+                chars.next();
+                line_comment = true;
+            }
+            None if ch == '"' || ch == '\'' => {
+                quote = Some(ch);
+                current.push(ch);
+            }
+            None if ch == ';' => {
+                saw_semicolon = true;
+                statements.push(std::mem::take(&mut current));
+            }
+            None if ch == '\n' || ch == '\r' => current.push(' '),
+            None => current.push(ch),
+        }
+    }
+    if !current.trim().is_empty() {
+        statements.push(current);
+    }
+    (statements, saw_semicolon)
+}
+
+fn parse_migration_lines(content: &str) -> Result<Vec<Vec<String>>, String> {
+    let mut commands = Vec::new();
+    for (index, raw) in content.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with("--") {
+            continue;
+        }
+        if line.starts_with('[') {
+            let parsed: Vec<String> = serde_json::from_str(line).map_err(|error| {
+                format!(
+                    "ERR line {} is not a valid JSON argv array: {error}",
+                    index + 1
+                )
+            })?;
+            if parsed.is_empty() {
+                return Err(format!("ERR line {} has an empty command", index + 1));
+            }
+            commands.push(parsed);
+        } else {
+            let parsed = split_command_line(line)
+                .map_err(|error| format!("ERR line {} could not be parsed: {error}", index + 1))?;
+            if !parsed.is_empty() {
+                commands.push(parsed);
+            }
+        }
+    }
+    Ok(commands)
+}
+
+fn split_command_line(input: &str) -> Result<Vec<String>, String> {
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match quote {
+            Some(expected) if ch == expected => quote = None,
+            Some(_) if ch == '\\' => {
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
+            }
+            Some(_) => current.push(ch),
+            None if ch == '"' || ch == '\'' => quote = Some(ch),
+            None if ch.is_whitespace() => {
+                if !current.is_empty() {
+                    args.push(std::mem::take(&mut current));
+                }
+            }
+            None => current.push(ch),
+        }
+    }
+    if let Some(expected) = quote {
+        return Err(format!("unterminated {expected} quote"));
+    }
+    if !current.is_empty() {
+        args.push(current);
+    }
+    Ok(args)
+}
+
+/// RESP parity for the engine-owned HTTP migration contract.
+///
+/// - `LUX MIGRATE LIST [limit] [offset]`
+/// - `LUX MIGRATE PLAN <filename> <body>`
+/// - `LUX MIGRATE APPLY <filename> <body>`
+/// - `LUX MIGRATE REPAIR <filename> RESUME <from_command>`
+/// - `LUX MIGRATE REPAIR <filename> MARK-APPLIED|ABANDON`
+pub(crate) fn cmd_migrate(
+    args: &[&[u8]],
+    store: &Store,
+    cache: &SharedSchemaCache,
+    broker: &Broker,
+    out: &mut BytesMut,
+    now: Instant,
+) {
+    let arg = |index: usize| -> Result<&str, String> {
+        args.get(index)
+            .ok_or_else(|| "ERR missing argument".to_string())
+            .and_then(|value| {
+                std::str::from_utf8(value).map_err(|_| "ERR arguments must be UTF-8".to_string())
+            })
+    };
+    let subcommand = match arg(2) {
+        Ok(value) => value.to_ascii_uppercase(),
+        Err(error) => {
+            resp::write_error(out, &error);
+            return;
+        }
+    };
+    let result = match subcommand.as_str() {
+        "LIST" => {
+            let limit = arg(3)
+                .ok()
+                .and_then(|value| value.parse::<usize>().ok())
+                .unwrap_or(100);
+            let offset = arg(4)
+                .ok()
+                .and_then(|value| value.parse::<usize>().ok())
+                .unwrap_or(0);
+            list(store, cache, limit, offset, now)
+                .and_then(|items| serde_json::to_string(&items).map_err(|error| error.to_string()))
+        }
+        "PLAN" if args.len() == 5 => arg(3).and_then(|filename| {
+            arg(4).and_then(|body| {
+                plan(store, cache, filename, body, now)
+                    .and_then(|value| serde_json::to_string(&value).map_err(|e| e.to_string()))
+            })
+        }),
+        "APPLY" if args.len() == 5 => arg(3).and_then(|filename| {
+            arg(4).and_then(|body| {
+                apply(store, cache, filename, body, now, |command| {
+                    execute_resp_command(store, cache, broker, command, now)
+                })
+                .and_then(|value| serde_json::to_string(&value).map_err(|e| e.to_string()))
+            })
+        }),
+        "REPAIR" if args.len() >= 5 => arg(3).and_then(|filename| {
+            arg(4).and_then(|raw_action| {
+                let action = match raw_action.to_ascii_uppercase().as_str() {
+                    "RESUME" => {
+                        let from_command = arg(5)?
+                            .parse::<usize>()
+                            .map_err(|_| "ERR from_command must be an integer".to_string())?;
+                        RepairAction::Resume { from_command }
+                    }
+                    "MARK-APPLIED" | "MARK_APPLIED" => RepairAction::MarkApplied,
+                    "ABANDON" => RepairAction::Abandon,
+                    _ => {
+                        return Err("ERR repair action must be RESUME, MARK-APPLIED, or ABANDON"
+                            .to_string())
+                    }
+                };
+                repair(store, cache, filename, action, now, |command| {
+                    execute_resp_command(store, cache, broker, command, now)
+                })
+                .and_then(|value| serde_json::to_string(&value).map_err(|e| e.to_string()))
+            })
+        }),
+        _ => Err("ERR usage: LUX MIGRATE <LIST|PLAN|APPLY|REPAIR> ...".to_string()),
+    };
+    match result {
+        Ok(json) => resp::write_bulk(out, &json),
+        Err(error) => {
+            let error = if error.starts_with("ERR") {
+                error
+            } else {
+                format!("ERR {error}")
+            };
+            resp::write_error(out, &error);
+        }
+    }
+}
+
+fn execute_resp_command(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    broker: &Broker,
+    command: &[String],
+    now: Instant,
+) -> Result<(), String> {
+    if command
+        .first()
+        .is_some_and(|value| value.eq_ignore_ascii_case("LUX"))
+    {
+        return Err("nested LUX commands are not allowed in migrations".to_string());
+    }
+    let owned: Vec<Vec<u8>> = command
+        .iter()
+        .map(|value| value.as_bytes().to_vec())
+        .collect();
+    let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+    let mut command_out = BytesMut::new();
+    let result = crate::cmd::execute_with_wal(store, cache, broker, &refs, &mut command_out, now);
+    if command_out.first() == Some(&b'-') {
+        let message = std::str::from_utf8(&command_out[1..])
+            .unwrap_or("engine command failed")
+            .trim_end_matches("\r\n");
+        return Err(message.to_string());
+    }
+    if !matches!(result, CmdResult::Written) {
+        return Err("blocking commands are not allowed in migrations".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn state() -> (Store, SharedSchemaCache) {
+        (
+            Store::new(),
+            Arc::new(parking_lot::RwLock::new(tables::SchemaCache::new())),
+        )
+    }
+
+    #[test]
+    fn parser_handles_comments_quotes_and_json_argv() {
+        let commands = parse_migration_commands(
+            "-- schema\nTCREATE notes id INT, body STR;\n\
+             TINSERT notes id 1 body \"semi; colon\";\n\
+             [\"PING\"];\n",
+        )
+        .unwrap();
+        assert_eq!(commands.len(), 3);
+        assert_eq!(commands[1][5], "semi; colon");
+        assert_eq!(commands[2], vec!["PING"]);
+    }
+
+    #[test]
+    fn filename_is_a_basename_or_generated_slug() {
+        assert!(resolve_filename(Some("../bad.lux"), None).is_err());
+        assert_eq!(
+            resolve_filename(Some("001_create.lux"), None).unwrap(),
+            "001_create.lux"
+        );
+        let generated = resolve_filename(None, Some("Create Messages!")).unwrap();
+        assert!(generated.ends_with("_create_messages.lux"));
+    }
+
+    #[test]
+    fn failed_apply_is_durable_and_blocks_later_migrations() {
+        let (store, cache) = state();
+        let now = Instant::now();
+        let error = apply(
+            &store,
+            &cache,
+            "001_first.lux",
+            "PING;\nFAIL;",
+            now,
+            |command| {
+                if command[0] == "FAIL" {
+                    Err("boom".to_string())
+                } else {
+                    Ok(())
+                }
+            },
+        )
+        .unwrap_err();
+        assert!(error.contains("command 2"));
+        let rows = list(&store, &cache, 100, 0, now).unwrap();
+        assert_eq!(rows[0].status, STATUS_FAILED);
+        assert_eq!(rows[0].completed_commands, 1);
+        let plan = plan(&store, &cache, "002_second.lux", "PING;", now).unwrap();
+        assert_eq!(plan.action, PlanAction::Blocked);
+    }
+
+    #[test]
+    fn explicit_resume_uses_reviewed_command_index() {
+        let (store, cache) = state();
+        let now = Instant::now();
+        let _ = apply(
+            &store,
+            &cache,
+            "001_first.lux",
+            "ONE;\nTWO;",
+            now,
+            |command| {
+                if command[0] == "TWO" {
+                    Err("stop".to_string())
+                } else {
+                    Ok(())
+                }
+            },
+        );
+        let mut seen = Vec::new();
+        let repaired = repair(
+            &store,
+            &cache,
+            "001_first.lux",
+            RepairAction::Resume { from_command: 1 },
+            now,
+            |command| {
+                seen.push(command[0].clone());
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(seen, vec!["TWO"]);
+        assert_eq!(repaired.status, STATUS_APPLIED);
+        assert_eq!(repaired.completed_commands, 2);
+    }
+
+    #[test]
+    fn legacy_djb2_rows_upgrade_and_remain_idempotent() {
+        let (store, cache) = state();
+        let now = Instant::now();
+        tables::table_create(
+            &store,
+            &cache,
+            LEDGER_TABLE,
+            &[
+                "filename STR,",
+                "checksum STR,",
+                "applied_at INT,",
+                "body STR",
+            ],
+            now,
+        )
+        .unwrap();
+        let body = "PING;";
+        tables::table_insert(
+            &store,
+            &cache,
+            LEDGER_TABLE,
+            &[
+                ("filename", "001_ping.lux"),
+                ("checksum", &legacy_djb2_checksum(body)),
+                ("applied_at", "1"),
+                ("body", body),
+            ],
+            now,
+        )
+        .unwrap();
+        let planned = plan(&store, &cache, "001_ping.lux", body, now).unwrap();
+        assert_eq!(planned.action, PlanAction::AlreadyApplied);
+        let records = list(&store, &cache, 10, 0, now).unwrap();
+        assert_eq!(records[0].checksum_algorithm, "djb2-64");
+        assert_eq!(records[0].status, STATUS_APPLIED);
+    }
+
+    #[test]
+    fn duplicate_legacy_filenames_fail_closed() {
+        let (store, cache) = state();
+        let now = Instant::now();
+        tables::table_create(
+            &store,
+            &cache,
+            LEDGER_TABLE,
+            &[
+                "filename STR,",
+                "checksum STR,",
+                "applied_at INT,",
+                "body STR",
+            ],
+            now,
+        )
+        .unwrap();
+        for applied_at in ["1", "2"] {
+            tables::table_insert(
+                &store,
+                &cache,
+                LEDGER_TABLE,
+                &[
+                    ("filename", "duplicate.lux"),
+                    ("checksum", "legacy"),
+                    ("applied_at", applied_at),
+                    ("body", "PING;"),
+                ],
+                now,
+            )
+            .unwrap();
+        }
+        let error = ensure_ledger(&store, &cache, now).unwrap_err();
+        assert!(error.contains("duplicate filename"));
+    }
+
+    #[test]
+    fn concurrent_apply_has_one_writer_and_one_idempotent_reader() {
+        let store = Arc::new(Store::new());
+        let cache = Arc::new(parking_lot::RwLock::new(tables::SchemaCache::new()));
+        let mut workers = Vec::new();
+        for _ in 0..2 {
+            let store = store.clone();
+            let cache = cache.clone();
+            workers.push(std::thread::spawn(move || {
+                apply(
+                    &store,
+                    &cache,
+                    "001_once.lux",
+                    "PING;",
+                    Instant::now(),
+                    |_| Ok(()),
+                )
+                .unwrap()
+                .already_applied
+            }));
+        }
+        let results: Vec<bool> = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect();
+        assert_eq!(results.iter().filter(|value| **value).count(), 1);
+        assert_eq!(results.iter().filter(|value| !**value).count(), 1);
+    }
+}

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -77,6 +77,8 @@ pub(crate) fn ensure_tables(
             "platform STR,",
             "apns_team_id STR,",
             "apns_key_id STR,",
+            // Legacy plaintext columns remain readable for pre-encryption
+            // projects. New writes go only to the ENCRYPTED replacements below.
             "apns_p8_pem STR,",
             "apns_topic STR,",
             "environment STR,",
@@ -87,6 +89,7 @@ pub(crate) fn ensure_tables(
         ],
         now,
     )?;
+    ensure_encrypted_credential_columns(store, cache, now)?;
     create_table_if_missing(
         store,
         cache,
@@ -111,6 +114,84 @@ pub(crate) fn ensure_tables(
         now,
     )?;
     add_column_if_missing(store, cache, OUTBOX_TABLE, "environment STR", now)?;
+    Ok(())
+}
+
+fn ensure_encrypted_credential_columns(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    now: Instant,
+) -> Result<(), String> {
+    // Device registration and delivery remain usable without ENC, but provider
+    // secrets may never be newly persisted in plaintext.
+    if !store.encryption().has_active_key() {
+        return Ok(());
+    }
+    add_column_if_missing(
+        store,
+        cache,
+        CREDENTIALS_TABLE,
+        "apns_p8_pem_encrypted STR ENCRYPTED",
+        now,
+    )?;
+    add_column_if_missing(
+        store,
+        cache,
+        CREDENTIALS_TABLE,
+        "vapid_private_encrypted STR ENCRYPTED",
+        now,
+    )?;
+    migrate_plaintext_credential_secrets(store, cache, now)
+}
+
+fn migrate_plaintext_credential_secrets(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    now: Instant,
+) -> Result<(), String> {
+    for row in select_rows(store, cache, CREDENTIALS_TABLE, Vec::new(), None, now)? {
+        let fields: std::collections::HashMap<String, String> = row.into_iter().collect();
+        let app_id = fields.get("app_id").cloned().unwrap_or_default();
+        if app_id.is_empty() {
+            continue;
+        }
+        let legacy_apns = fields.get("apns_p8_pem").cloned().unwrap_or_default();
+        let encrypted_apns = fields
+            .get("apns_p8_pem_encrypted")
+            .cloned()
+            .unwrap_or_default();
+        if !legacy_apns.is_empty() && encrypted_apns.is_empty() {
+            durable_table_update_where(
+                store,
+                cache,
+                CREDENTIALS_TABLE,
+                &[
+                    ("apns_p8_pem_encrypted", legacy_apns.as_str()),
+                    ("apns_p8_pem", ""),
+                ],
+                &["app_id", "=", app_id.as_str()],
+                now,
+            )?;
+        }
+        let legacy_vapid = fields.get("vapid_private").cloned().unwrap_or_default();
+        let encrypted_vapid = fields
+            .get("vapid_private_encrypted")
+            .cloned()
+            .unwrap_or_default();
+        if !legacy_vapid.is_empty() && encrypted_vapid.is_empty() {
+            durable_table_update_where(
+                store,
+                cache,
+                CREDENTIALS_TABLE,
+                &[
+                    ("vapid_private_encrypted", legacy_vapid.as_str()),
+                    ("vapid_private", ""),
+                ],
+                &["app_id", "=", app_id.as_str()],
+                now,
+            )?;
+        }
+    }
     Ok(())
 }
 
@@ -143,17 +224,54 @@ pub(crate) fn migrate_from_auth_scope(
             continue;
         }
         let g = |k: &str| m.get(k).cloned().unwrap_or_default();
-        set_apns_credentials(
-            store,
-            cache,
-            &app_id,
-            &g("apns_team_id"),
-            &g("apns_key_id"),
-            &g("apns_p8_pem"),
-            &g("apns_topic"),
-            &g("environment"),
-            now,
-        )?;
+        let apns_private = g("apns_p8_pem");
+        let vapid_private = g("vapid_private");
+        if store.encryption().has_active_key() {
+            if !apns_private.is_empty() {
+                set_apns_credentials(
+                    store,
+                    cache,
+                    &app_id,
+                    &g("apns_team_id"),
+                    &g("apns_key_id"),
+                    &apns_private,
+                    &g("apns_topic"),
+                    &g("environment"),
+                    now,
+                )?;
+            }
+            if !vapid_private.is_empty() {
+                set_vapid_credentials(
+                    store,
+                    cache,
+                    &app_id,
+                    &g("vapid_public"),
+                    &vapid_private,
+                    &g("vapid_subject"),
+                    now,
+                )?;
+            }
+        } else {
+            // This copies already-plaintext legacy data; it is not a new secret
+            // write surface. Reads report it unhealthy, and ensure_tables
+            // migrates it into ENCRYPTED columns once ENC becomes available.
+            upsert_credential_fields(
+                store,
+                cache,
+                &app_id,
+                &[
+                    ("apns_team_id", g("apns_team_id").as_str()),
+                    ("apns_key_id", g("apns_key_id").as_str()),
+                    ("apns_p8_pem", apns_private.as_str()),
+                    ("apns_topic", g("apns_topic").as_str()),
+                    ("environment", g("environment").as_str()),
+                    ("vapid_public", g("vapid_public").as_str()),
+                    ("vapid_private", vapid_private.as_str()),
+                    ("vapid_subject", g("vapid_subject").as_str()),
+                ],
+                now,
+            )?;
+        }
     }
 
     // Devices: user_id -> subject_id, re-keyed by token.
@@ -555,19 +673,82 @@ pub(crate) fn set_apns_credentials(
     environment: &str,
     now: Instant,
 ) -> Result<(), String> {
-    upsert_credential_fields(
+    update_apns_credentials(
         store,
         cache,
         app_id,
-        &[
-            ("apns_team_id", team_id),
-            ("apns_key_id", key_id),
-            ("apns_p8_pem", p8_pem),
-            ("apns_topic", topic),
-            ("environment", environment),
-        ],
+        team_id,
+        key_id,
+        Some(p8_pem),
+        topic,
+        environment,
         now,
     )
+}
+
+/// Update APNs metadata while preserving the existing private key when
+/// `p8_pem` is omitted. New secret writes require engine encryption.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn update_apns_credentials(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    app_id: &str,
+    team_id: &str,
+    key_id: &str,
+    p8_pem: Option<&str>,
+    topic: &str,
+    environment: &str,
+    now: Instant,
+) -> Result<(), String> {
+    if p8_pem.is_some() && !store.encryption().has_active_key() {
+        return Err("new push secrets require ENC INIT or an active encryption key".to_string());
+    }
+    ensure_tables(store, cache, now)?;
+    if p8_pem.is_none() {
+        let existing = get_apns_credentials(store, cache, app_id, now)?;
+        if existing
+            .as_ref()
+            .is_none_or(|credentials| credentials.creds.p8_pem.is_empty())
+        {
+            return Err("p8_pem is required when APNs has no existing key".to_string());
+        }
+    }
+    let mut fields = vec![
+        ("apns_team_id", team_id),
+        ("apns_key_id", key_id),
+        ("apns_topic", topic),
+        ("environment", environment),
+    ];
+    if store.encryption().has_active_key() {
+        fields.push(("apns_p8_pem", ""));
+    }
+    if let Some(p8_pem) = p8_pem {
+        if p8_pem.trim().is_empty() {
+            return Err("p8_pem cannot be empty; use clear to remove APNs".to_string());
+        }
+        fields.push(("apns_p8_pem_encrypted", p8_pem));
+    }
+    upsert_credential_fields(store, cache, app_id, &fields, now)
+}
+
+pub(crate) fn clear_apns_credentials(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    app_id: &str,
+    now: Instant,
+) -> Result<(), String> {
+    ensure_tables(store, cache, now)?;
+    let mut fields = vec![
+        ("apns_team_id", ""),
+        ("apns_key_id", ""),
+        ("apns_p8_pem", ""),
+        ("apns_topic", ""),
+        ("environment", ""),
+    ];
+    if store.encryption().has_active_key() {
+        fields.push(("apns_p8_pem_encrypted", ""));
+    }
+    upsert_credential_fields(store, cache, app_id, &fields, now)
 }
 
 /// Upsert an app's Web Push (VAPID) credentials (operator only). Preserves APNs.
@@ -580,17 +761,62 @@ pub(crate) fn set_vapid_credentials(
     subject: &str,
     now: Instant,
 ) -> Result<(), String> {
+    if !store.encryption().has_active_key() {
+        return Err(
+            "push credential writes require ENC INIT or an active encryption key".to_string(),
+        );
+    }
+    ensure_tables(store, cache, now)?;
     upsert_credential_fields(
         store,
         cache,
         app_id,
         &[
             ("vapid_public", public_key),
-            ("vapid_private", private_pem),
+            ("vapid_private", ""),
+            ("vapid_private_encrypted", private_pem),
             ("vapid_subject", subject),
         ],
         now,
     )
+}
+
+pub(crate) fn rotate_vapid_credentials(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    app_id: &str,
+    subject: &str,
+    now: Instant,
+) -> Result<String, String> {
+    let (public_key, private_pem) = webpush::generate_vapid_keypair()?;
+    set_vapid_credentials(
+        store,
+        cache,
+        app_id,
+        &public_key,
+        &private_pem,
+        subject,
+        now,
+    )?;
+    Ok(public_key)
+}
+
+pub(crate) fn disable_vapid_credentials(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    app_id: &str,
+    now: Instant,
+) -> Result<(), String> {
+    ensure_tables(store, cache, now)?;
+    let mut fields = vec![
+        ("vapid_public", ""),
+        ("vapid_private", ""),
+        ("vapid_subject", ""),
+    ];
+    if store.encryption().has_active_key() {
+        fields.push(("vapid_private_encrypted", ""));
+    }
+    upsert_credential_fields(store, cache, app_id, &fields, now)
 }
 
 pub(crate) fn get_vapid_credentials(
@@ -605,7 +831,14 @@ pub(crate) fn get_vapid_credentials(
     };
     let get = |k: &str| row.get(k).cloned().unwrap_or_default();
     let public_key = get("vapid_public");
-    let private_pem = get("vapid_private");
+    let private_pem = {
+        let encrypted = get("vapid_private_encrypted");
+        if encrypted.is_empty() {
+            get("vapid_private")
+        } else {
+            encrypted
+        }
+    };
     if public_key.is_empty() || private_pem.is_empty() {
         return Ok(None);
     }
@@ -641,10 +874,70 @@ pub(crate) fn get_apns_credentials(
         creds: apns::ApnsCredentials {
             team_id: get("apns_team_id"),
             key_id: get("apns_key_id"),
-            p8_pem: get("apns_p8_pem"),
+            p8_pem: {
+                let encrypted = get("apns_p8_pem_encrypted");
+                if encrypted.is_empty() {
+                    get("apns_p8_pem")
+                } else {
+                    encrypted
+                }
+            },
         },
         topic: get("apns_topic"),
         environment: get("environment"),
+    }))
+}
+
+/// Secret-free operator metadata for CLI/Studio configuration and health.
+pub(crate) fn credential_config(
+    store: &Store,
+    cache: &SharedSchemaCache,
+    app_id: &str,
+    now: Instant,
+) -> Result<Value, String> {
+    ensure_tables(store, cache, now)?;
+    let row = find_row_by_field(store, cache, CREDENTIALS_TABLE, "app_id", app_id, now)?;
+    let fields = row.unwrap_or_default();
+    let get = |key: &str| fields.get(key).cloned().unwrap_or_default();
+    let apns_encrypted = !get("apns_p8_pem_encrypted").is_empty();
+    let apns_legacy = !get("apns_p8_pem").is_empty();
+    let vapid_encrypted = !get("vapid_private_encrypted").is_empty();
+    let vapid_legacy = !get("vapid_private").is_empty();
+    let encryption_available = store.encryption().has_active_key();
+    let plaintext_secrets = apns_legacy || vapid_legacy;
+    let any_configured = apns_encrypted || apns_legacy || vapid_encrypted || vapid_legacy;
+    let mut warnings = Vec::new();
+    if plaintext_secrets {
+        warnings.push(
+            "legacy plaintext push secrets are readable but unhealthy; configure engine encryption to migrate them"
+                .to_string(),
+        );
+    }
+    if !encryption_available {
+        warnings.push(
+            "push credential changes are disabled until engine encryption is initialized"
+                .to_string(),
+        );
+    }
+    Ok(json!({
+        "app_id": app_id,
+        "healthy": !plaintext_secrets && (!any_configured || encryption_available),
+        "encryption_available": encryption_available,
+        "warnings": warnings,
+        "apns": {
+            "configured": apns_encrypted || apns_legacy,
+            "team_id": get("apns_team_id"),
+            "key_id": get("apns_key_id"),
+            "topic": get("apns_topic"),
+            "environment": get("environment"),
+            "secret_storage": if apns_encrypted { "encrypted" } else if apns_legacy { "legacy_plaintext" } else { "none" }
+        },
+        "vapid": {
+            "configured": vapid_encrypted || vapid_legacy,
+            "public_key": get("vapid_public"),
+            "subject": get("vapid_subject"),
+            "secret_storage": if vapid_encrypted { "encrypted" } else if vapid_legacy { "legacy_plaintext" } else { "none" }
+        }
     }))
 }
 
@@ -760,8 +1053,12 @@ pub(crate) fn select_rows(
     // Push tables are created lazily on first write, so a project that has never
     // used push has no `push.*` tables. Treat a missing table as no rows — this
     // keeps reads (and the worker's outbox scan) quiet until push is configured.
-    if tables::table_schema(store, cache, table, now).is_err() {
-        return Ok(Vec::new());
+    match tables::table_schema(store, cache, table, now) {
+        Ok(_) => {}
+        Err(error) if error == format!("ERR table '{table}' does not exist") => {
+            return Ok(Vec::new())
+        }
+        Err(error) => return Err(error),
     }
     let plan = SelectPlan {
         table: table.to_string(),
@@ -919,7 +1216,28 @@ fn normalize_err(e: &str) -> String {
 mod tests {
     use super::*;
 
+    use crate::{EncryptionConfig, EncryptionKeyConfig, ServerConfig};
+    use std::sync::Arc;
     use EnvironmentSource::{Trusted, User};
+
+    fn cache() -> SharedSchemaCache {
+        Arc::new(parking_lot::RwLock::new(tables::SchemaCache::new()))
+    }
+
+    fn encrypted_store() -> Store {
+        Store::new_with_config(Arc::new(ServerConfig {
+            encryption: EncryptionConfig {
+                active_key_id: Some("push-test".to_string()),
+                keys: vec![EncryptionKeyConfig {
+                    id: "push-test".to_string(),
+                    secret: b"push-test-secret".to_vec(),
+                    decrypt_only: false,
+                }],
+                ..Default::default()
+            },
+            ..ServerConfig::default()
+        }))
+    }
 
     #[test]
     fn environment_normalizes_apple_spellings() {
@@ -969,6 +1287,145 @@ mod tests {
         assert_eq!(
             normalize_environment("  HTTP://attacker.example/", User),
             ""
+        );
+    }
+
+    #[test]
+    fn plaintext_push_secret_writes_are_rejected() {
+        let store = Store::new();
+        let error = update_apns_credentials(
+            &store,
+            &cache(),
+            "default",
+            "team",
+            "key",
+            Some("private"),
+            "com.example.app",
+            "sandbox",
+            Instant::now(),
+        )
+        .unwrap_err();
+        assert!(error.contains("encryption key"));
+    }
+
+    #[test]
+    fn apns_metadata_update_preserves_encrypted_key_and_clear_removes_it() {
+        let store = encrypted_store();
+        let cache = cache();
+        let now = Instant::now();
+        update_apns_credentials(
+            &store,
+            &cache,
+            "default",
+            "team",
+            "key",
+            Some("private-v1"),
+            "com.example.app",
+            "sandbox",
+            now,
+        )
+        .unwrap();
+        update_apns_credentials(
+            &store,
+            &cache,
+            "default",
+            "team",
+            "key-2",
+            None,
+            "com.example.app",
+            "production",
+            now,
+        )
+        .unwrap();
+        let credentials = get_apns_credentials(&store, &cache, "default", now)
+            .unwrap()
+            .unwrap();
+        assert_eq!(credentials.creds.p8_pem, "private-v1");
+        assert_eq!(credentials.creds.key_id, "key-2");
+        let config = credential_config(&store, &cache, "default", now).unwrap();
+        assert_eq!(
+            config["apns"]["secret_storage"],
+            Value::String("encrypted".to_string())
+        );
+        assert!(config.to_string().find("private-v1").is_none());
+
+        clear_apns_credentials(&store, &cache, "default", now).unwrap();
+        let cleared = get_apns_credentials(&store, &cache, "default", now)
+            .unwrap()
+            .unwrap();
+        assert!(cleared.creds.p8_pem.is_empty());
+    }
+
+    #[test]
+    fn vapid_rotation_generates_and_encrypts_a_new_keypair() {
+        let store = encrypted_store();
+        let cache = cache();
+        let now = Instant::now();
+        let first =
+            rotate_vapid_credentials(&store, &cache, "default", "mailto:test@example.com", now)
+                .unwrap();
+        let second =
+            rotate_vapid_credentials(&store, &cache, "default", "mailto:test@example.com", now)
+                .unwrap();
+        assert_ne!(first, second);
+        let resolved = get_vapid_credentials(&store, &cache, "default", now)
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.public_key, second);
+        assert!(resolved.private_pem.contains("PRIVATE KEY"));
+    }
+
+    #[test]
+    fn legacy_plaintext_credentials_migrate_when_encryption_is_available() {
+        let store = encrypted_store();
+        let cache = cache();
+        let now = Instant::now();
+        tables::table_create(
+            &store,
+            &cache,
+            CREDENTIALS_TABLE,
+            &[
+                "app_id STR PRIMARY KEY,",
+                "platform STR,",
+                "apns_team_id STR,",
+                "apns_key_id STR,",
+                "apns_p8_pem STR,",
+                "apns_topic STR,",
+                "environment STR,",
+                "vapid_public STR,",
+                "vapid_private STR,",
+                "vapid_subject STR,",
+                "created_at INT",
+            ],
+            now,
+        )
+        .unwrap();
+        tables::table_insert(
+            &store,
+            &cache,
+            CREDENTIALS_TABLE,
+            &[
+                ("app_id", "default"),
+                ("apns_p8_pem", "legacy-apns-secret"),
+                ("vapid_private", "legacy-vapid-secret"),
+                ("created_at", "1"),
+            ],
+            now,
+        )
+        .unwrap();
+        ensure_tables(&store, &cache, now).unwrap();
+        let config = credential_config(&store, &cache, "default", now).unwrap();
+        assert_eq!(config["healthy"], true);
+        assert_eq!(config["apns"]["secret_storage"], "encrypted");
+        assert_eq!(config["vapid"]["secret_storage"], "encrypted");
+        let row = find_row_by_field(&store, &cache, CREDENTIALS_TABLE, "app_id", "default", now)
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.get("apns_p8_pem").map(String::as_str), Some(""));
+        assert_eq!(row.get("vapid_private").map(String::as_str), Some(""));
+        assert_eq!(
+            row.get("apns_p8_pem_encrypted").map(String::as_str),
+            Some("legacy-apns-secret")
         );
     }
 }

--- a/src/push/webpush.rs
+++ b/src/push/webpush.rs
@@ -13,6 +13,7 @@ use base64::Engine as _;
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use p256::ecdh::diffie_hellman;
 use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::pkcs8::{EncodePrivateKey, LineEnding};
 use p256::{PublicKey, SecretKey};
 use rand_core::{OsRng, RngCore};
 use ring::{aead, hmac};
@@ -30,6 +31,19 @@ const ALLOW_PRIVATE_ENDPOINTS_ENV: &str = "LUX_PUSH_ALLOW_PRIVATE_ENDPOINTS";
 
 const B64: base64::engine::general_purpose::GeneralPurpose =
     base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+/// Generate an RFC 8292 VAPID key pair. The public key is the browser-facing
+/// base64url uncompressed P-256 point; the private key is PKCS#8 PEM for ES256
+/// signing and must only be stored in an engine ENCRYPTED column.
+pub(crate) fn generate_vapid_keypair() -> Result<(String, String), String> {
+    let secret = SecretKey::random(&mut OsRng);
+    let public = B64.encode(secret.public_key().to_encoded_point(false).as_bytes());
+    let private = secret
+        .to_pkcs8_pem(LineEnding::LF)
+        .map_err(|error| format!("could not encode VAPID private key: {error}"))?
+        .to_string();
+    Ok((public, private))
+}
 
 /// Decode a base64url (no-pad) subscription field.
 pub(crate) fn b64url_decode(s: &str) -> Result<Vec<u8>, String> {

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -51,6 +51,10 @@ fn start(dir: &std::path::Path, resp_port: u16, http_port: u16, keep_dir: bool) 
         .env("LUX_STORAGE_DIR", dir.join("storage").to_str().unwrap())
         .env("LUX_PASSWORD", "rootsecret")
         .env("LUX_AUTH_ENABLED", "true")
+        // Provider private keys are accepted only when the engine can persist
+        // them in ENCRYPTED columns. Keep this stable across restart tests.
+        .env("LUX_ENCRYPTION_KEY_ID", "push-integration")
+        .env("LUX_ENCRYPTION_KEY", "push-integration-secret")
         // Integration delivery uses a loopback mock push service. Production
         // defaults reject private and non-HTTPS Web Push endpoints.
         .env("LUX_PUSH_ALLOW_PRIVATE_ENDPOINTS", "1")
@@ -62,7 +66,7 @@ fn start(dir: &std::path::Path, resp_port: u16, http_port: u16, keep_dir: bool) 
         dir: dir.to_path_buf(),
         keep_dir,
     };
-    for _ in 0..80 {
+    for _ in 0..160 {
         if TcpStream::connect(("127.0.0.1", http_port)).is_ok()
             && TcpStream::connect(("127.0.0.1", resp_port)).is_ok()
         {
@@ -780,6 +784,8 @@ fn start_no_auth(dir: &std::path::Path, resp_port: u16, http_port: u16) -> PushS
         .env("LUX_STORAGE_MODE", "tiered")
         .env("LUX_STORAGE_DIR", dir.join("storage").to_str().unwrap())
         .env("LUX_PASSWORD", "rootsecret")
+        .env("LUX_ENCRYPTION_KEY_ID", "push-integration")
+        .env("LUX_ENCRYPTION_KEY", "push-integration-secret")
         .env("LUX_PUSH_ALLOW_PRIVATE_ENDPOINTS", "1")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
@@ -789,7 +795,7 @@ fn start_no_auth(dir: &std::path::Path, resp_port: u16, http_port: u16) -> PushS
         dir: dir.to_path_buf(),
         keep_dir: false,
     };
-    for _ in 0..80 {
+    for _ in 0..160 {
         if TcpStream::connect(("127.0.0.1", http_port)).is_ok()
             && TcpStream::connect(("127.0.0.1", resp_port)).is_ok()
         {


### PR DESCRIPTION
## Summary

- move migration parsing, SHA-256 checksums, durable progress, planning, pagination, and explicit repair into the engine
- expose the management contract over HTTP and RESP, including semantic version, build SHA, API version, and capabilities
- encrypt APNs/VAPID private keys, migrate legacy plaintext in-engine, preserve omitted APNs keys, and add VAPID enable/rotate/disable plus secret-free status
- make internal schema discovery fail closed and embed build SHAs in release/Docker artifacts

## Migration safety

- records `applying` before command 1 and persists `completed_commands` after each success
- failed/interrupted migrations block later writes
- never auto-resumes; repair requires an explicit reviewed command index, mark-applied, or abandon
- recognizes existing CLI DJB2 and Studio FNV-1a ledger checksums while all new entries use SHA-256
- serializes concurrent migration writers

## Validation

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` (all unit and integration suites green)
- `docker buildx build --check .`
