### PR TITLE
feat(push): complete standard APNs notifications

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -34,6 +34,28 @@ const { data: session, error } = await lux.auth.signInWithPassword({
 if (error) throw error;
 ```
 
+## Push notifications
+
+Server-side callers can send to one subject or many with a secret key. Set
+`interruption_level` when an Apple notification should be quieter or more
+prominent; omit it for the normal `active` behavior.
+
+```ts
+import { createClient } from "@luxdb/sdk";
+
+const lux = createClient(process.env.LUX_URL!, process.env.LUX_SECRET_KEY!);
+
+await lux.push.send("agent-123", {
+  title: "Input needed",
+  body: "The agent is waiting for your answer.",
+  interruption_level: "time-sensitive",
+});
+```
+
+The supported values are `passive`, `active`, `time-sensitive`, and `critical`.
+Time-sensitive notifications may break through Focus when the user allows it.
+Critical notifications require Apple's Critical Alerts entitlement.
+
 ## Tables
 
 Queries and mutations return a Supabase-style result object:

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -36,9 +36,9 @@ if (error) throw error;
 
 ## Push notifications
 
-Server-side callers can send to one subject or many with a secret key. Set
-`interruption_level` when an Apple notification should be quieter or more
-prominent; omit it for the normal `active` behavior.
+Server-side callers can send to one subject or many with a secret key. Lux
+derives the APNs topic and push type, routes each device to its sandbox or
+production host, and validates the final APNs payload before enqueue.
 
 ```ts
 import { createClient } from "@luxdb/sdk";
@@ -48,13 +48,47 @@ const lux = createClient(process.env.LUX_URL!, process.env.LUX_SECRET_KEY!);
 await lux.push.send("agent-123", {
   title: "Input needed",
   body: "The agent is waiting for your answer.",
+  subtitle: "Vigil",
+  image: "https://example.com/question.png",
   interruption_level: "time-sensitive",
+  target_content_id: "question-window",
+  relevance_score: 0.9,
+  filter_criteria: "work",
+  apns: {
+    collapse_id: "agent-123-question",
+    expiration: Math.floor(Date.now() / 1000) + 300,
+    priority: 10,
+  },
+  data: { question: { id: "q_123" }, requires_reply: true },
 });
 ```
 
 The supported values are `passive`, `active`, `time-sensitive`, and `critical`.
 Time-sensitive notifications may break through Focus when the user allows it.
-Critical notifications require Apple's Critical Alerts entitlement.
+Omit `interruption_level` for the normal `active` behavior.
+
+Images are delivered through a custom `image_url` payload field and
+automatically enable APNs `mutable-content`; the iOS app needs a Notification
+Service Extension that downloads the URL and attaches it to the notification.
+Action buttons use `category`, which must match a category registered by the
+app. Bundle localization is available through `title_loc_key`,
+`subtitle_loc_key`, `body_loc_key`, and their corresponding `_loc_args`.
+
+Critical notifications require Apple's Critical Alerts entitlement and can use
+a critical sound object:
+
+```ts
+await lux.push.send("agent-123", {
+  title: "Immediate action required",
+  interruption_level: "critical",
+  sound: { critical: true, name: "default", volume: 1 },
+});
+```
+
+APNs transport options support collapse IDs, delivery expiration, and
+priorities `1`, `5`, or `10`. Background-only notifications use push type
+`background` and require priority `5`; other notifications use `alert`. Lux
+generates a stable, unique APNs request UUID per durable outbox delivery.
 
 ## Tables
 

--- a/sdk/src/index.browser.ts
+++ b/sdk/src/index.browser.ts
@@ -62,8 +62,11 @@ export type {
 	LuxVectorSearchOptions,
 } from './project';
 export type {
+	LuxPushApnsOptions,
+	LuxPushCriticalSound,
 	LuxPushDevice,
 	LuxPushInterruptionLevel,
+	LuxPushJsonValue,
 	LuxPushNotification,
 	LuxPushRegisterOptions,
 } from './push';

--- a/sdk/src/index.browser.ts
+++ b/sdk/src/index.browser.ts
@@ -62,6 +62,12 @@ export type {
 	LuxVectorSearchOptions,
 } from './project';
 export type {
+	LuxPushDevice,
+	LuxPushInterruptionLevel,
+	LuxPushNotification,
+	LuxPushRegisterOptions,
+} from './push';
+export type {
 	LuxStorageListOptions,
 	LuxStorageObject,
 	LuxStorageSignOptions,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -68,6 +68,7 @@ export type {
 } from './project';
 export type {
 	LuxPushDevice,
+	LuxPushInterruptionLevel,
 	LuxPushNotification,
 	LuxPushRegisterOptions,
 } from './push';

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -67,8 +67,11 @@ export type {
 	LuxVectorSearchOptions,
 } from './project';
 export type {
+	LuxPushApnsOptions,
+	LuxPushCriticalSound,
 	LuxPushDevice,
 	LuxPushInterruptionLevel,
+	LuxPushJsonValue,
 	LuxPushNotification,
 	LuxPushRegisterOptions,
 } from './push';

--- a/sdk/src/push.ts
+++ b/sdk/src/push.ts
@@ -32,6 +32,9 @@ export interface LuxPushRegisterOptions {
 	environment?: 'sandbox' | 'production';
 }
 
+/** APNs notification prominence. `active` is Apple's normal/default behavior. */
+export type LuxPushInterruptionLevel = 'passive' | 'active' | 'time-sensitive' | 'critical';
+
 /** A notification. `title`/`body` render the alert; the rest map to APNs `aps`
  *  fields (and their platform equivalents). `data` arrives in the client. */
 export interface LuxPushNotification {
@@ -50,6 +53,12 @@ export interface LuxPushNotification {
 	mutable_content?: boolean;
 	/** Silent/background delivery (APNs `content-available`). */
 	content_available?: boolean;
+	/**
+	 * Delivery prominence on Apple devices. `passive` is quiet, `active` is
+	 * normal, and `time-sensitive` may break through Focus when the user allows
+	 * it. `critical` requires Apple's Critical Alerts entitlement.
+	 */
+	interruption_level?: LuxPushInterruptionLevel;
 	/** Arbitrary string key/values delivered to the client. */
 	data?: Record<string, string>;
 }

--- a/sdk/src/push.ts
+++ b/sdk/src/push.ts
@@ -35,17 +35,56 @@ export interface LuxPushRegisterOptions {
 /** APNs notification prominence. `active` is Apple's normal/default behavior. */
 export type LuxPushInterruptionLevel = 'passive' | 'active' | 'time-sensitive' | 'critical';
 
+/** JSON-safe custom notification data. */
+export type LuxPushJsonValue =
+	| string
+	| number
+	| boolean
+	| null
+	| LuxPushJsonValue[]
+	| { [key: string]: LuxPushJsonValue };
+
+/** A critical-alert sound. Requires Apple's Critical Alerts entitlement. */
+export interface LuxPushCriticalSound {
+	critical: true;
+	/** A bundled sound filename, or `'default'`. */
+	name: string;
+	/** Playback volume from `0` (silent) to `1` (full volume). */
+	volume?: number;
+}
+
+/** APNs request controls. Lux derives topic and push type safely. */
+export interface LuxPushApnsOptions {
+	/** Coalesce repeated notifications with the same identifier (maximum 64 bytes). */
+	collapse_id?: string;
+	/** UNIX epoch seconds after which APNs should stop attempting delivery. `0` means once only. */
+	expiration?: number;
+	/** APNs delivery priority. Background notifications require `5`. */
+	priority?: 1 | 5 | 10;
+}
+
 /** A notification. `title`/`body` render the alert; the rest map to APNs `aps`
  *  fields (and their platform equivalents). `data` arrives in the client. */
 export interface LuxPushNotification {
 	title?: string;
 	body?: string;
 	subtitle?: string;
+	/** Localizable.strings key used instead of `title`. */
+	title_loc_key?: string;
+	title_loc_args?: string[];
+	/** Localizable.strings key used instead of `subtitle`. */
+	subtitle_loc_key?: string;
+	subtitle_loc_args?: string[];
+	/** Localizable.strings key used instead of `body`. */
+	body_loc_key?: string;
+	body_loc_args?: string[];
+	/** Bundled launch image or storyboard shown when the notification opens the app. */
+	launch_image?: string;
 	/** Lock-screen grouping key (APNs `thread-id`). */
 	thread_id?: string;
 	/** Notification category (action buttons). */
 	category?: string;
-	sound?: string;
+	sound?: string | LuxPushCriticalSound;
 	badge?: number;
 	/** Image URL; flips `mutable-content` so a notification-service-extension
 	 *  can attach a thumbnail. */
@@ -59,8 +98,16 @@ export interface LuxPushNotification {
 	 * it. `critical` requires Apple's Critical Alerts entitlement.
 	 */
 	interruption_level?: LuxPushInterruptionLevel;
-	/** Arbitrary string key/values delivered to the client. */
-	data?: Record<string, string>;
+	/** Scene/window identifier populated as APNs `target-content-id`. */
+	target_content_id?: string;
+	/** Notification Summary ranking from `0` to `1`. */
+	relevance_score?: number;
+	/** Focus filter criteria evaluated by the receiving app. */
+	filter_criteria?: string;
+	/** APNs transport controls. */
+	apns?: LuxPushApnsOptions;
+	/** Arbitrary JSON delivered to the client. The reserved `aps` key is rejected. */
+	data?: Record<string, LuxPushJsonValue>;
 }
 
 /**

--- a/sdk/tests/project.test.ts
+++ b/sdk/tests/project.test.ts
@@ -66,6 +66,37 @@ describe('Lux project client', () => {
 		});
 	});
 
+	test('push send forwards the APNs interruption level', async () => {
+		let seen: { url: string; body?: any } | null = null;
+		const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+			seen = {
+				url: String(input),
+				body: init?.body ? JSON.parse(String(init.body)) : undefined,
+			};
+			return new Response(JSON.stringify({ enqueued: 1 }), { status: 200 });
+		};
+		const client = createProjectClient({
+			url: 'http://localhost:3957/v1/project',
+			key: 'lux_sec_test',
+			fetch: fetchImpl as typeof fetch,
+		});
+
+		const result = await client.push.send('user-1', {
+			title: 'Question',
+			interruption_level: 'time-sensitive',
+		});
+
+		expect(result).toEqual({ data: { enqueued: 1 }, error: null });
+		expect(seen?.url).toBe('http://localhost:3957/v1/project/push/send');
+		expect(seen?.body).toEqual({
+			subject_id: 'user-1',
+			notification: {
+				title: 'Question',
+				interruption_level: 'time-sensitive',
+			},
+		});
+	});
+
 	test('default fetch is bound for browser project requests', async () => {
 		const originalFetch = globalThis.fetch;
 		let receiver: unknown;

--- a/sdk/tests/project.test.ts
+++ b/sdk/tests/project.test.ts
@@ -82,8 +82,20 @@ describe('Lux project client', () => {
 		});
 
 		const result = await client.push.send('user-1', {
-			title: 'Question',
+			title_loc_key: 'QUESTION_TITLE',
+			title_loc_args: ['Codex'],
+			body: 'The agent is waiting.',
 			interruption_level: 'time-sensitive',
+			sound: 'alarm.caf',
+			target_content_id: 'question-window',
+			relevance_score: 0.9,
+			filter_criteria: 'work',
+			apns: {
+				collapse_id: 'question-user-1',
+				expiration: 1_900_000_000,
+				priority: 10,
+			},
+			data: { question: { id: 7 }, requires_reply: true },
 		});
 
 		expect(result).toEqual({ data: { enqueued: 1 }, error: null });
@@ -91,8 +103,20 @@ describe('Lux project client', () => {
 		expect(seen?.body).toEqual({
 			subject_id: 'user-1',
 			notification: {
-				title: 'Question',
+				title_loc_key: 'QUESTION_TITLE',
+				title_loc_args: ['Codex'],
+				body: 'The agent is waiting.',
 				interruption_level: 'time-sensitive',
+				sound: 'alarm.caf',
+				target_content_id: 'question-window',
+				relevance_score: 0.9,
+				filter_criteria: 'work',
+				apns: {
+					collapse_id: 'question-user-1',
+					expiration: 1_900_000_000,
+					priority: 10,
+				},
+				data: { question: { id: 7 }, requires_reply: true },
 			},
 		});
 	});

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -203,6 +203,9 @@ pub(crate) fn apns_body_from_payload(payload: &[u8]) -> Vec<u8> {
     if let Some(v) = s("sound") {
         aps.insert("sound".into(), json!(v));
     }
+    if let Some(v) = s("interruption_level").filter(|v| super::is_valid_interruption_level(v)) {
+        aps.insert("interruption-level".into(), json!(v));
+    }
     if let Some(v) = parsed.get("badge").and_then(|v| v.as_i64()) {
         aps.insert("badge".into(), json!(v));
     }
@@ -416,6 +419,7 @@ mod tests {
         let payload = br#"{
             "title":"T","body":"B","subtitle":"S","thread_id":"th1",
             "category":"MSG","sound":"ping.caf","badge":3,"image":"https://x/i.png",
+            "interruption_level":"time-sensitive",
             "data":{"route":"/w/1"}
         }"#;
         let v: serde_json::Value =
@@ -424,10 +428,19 @@ mod tests {
         assert_eq!(v["aps"]["thread-id"], "th1");
         assert_eq!(v["aps"]["category"], "MSG");
         assert_eq!(v["aps"]["sound"], "ping.caf");
+        assert_eq!(v["aps"]["interruption-level"], "time-sensitive");
         assert_eq!(v["aps"]["badge"], 3);
         assert_eq!(v["aps"]["mutable-content"], 1); // image → NSE
         assert_eq!(v["image_url"], "https://x/i.png");
         assert_eq!(v["route"], "/w/1");
+    }
+
+    #[test]
+    fn body_omits_invalid_interruption_level() {
+        let payload = br#"{"title":"Hi","interruption_level":"urgent"}"#;
+        let v: serde_json::Value =
+            serde_json::from_slice(&apns_body_from_payload(payload)).unwrap();
+        assert!(v["aps"].get("interruption-level").is_none());
     }
 
     #[test]

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -8,7 +8,8 @@ use std::time::{Duration, Instant};
 
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use serde::Serialize;
-use serde_json::json;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 
 /// A single delivery target: the platform token plus whatever routing metadata
 /// the sink needs (APNs topic, etc.).
@@ -16,25 +17,33 @@ use serde_json::json;
 pub(crate) struct DeliveryTarget {
     pub token: String,
     pub topic: String,
+    /// Stable per-outbox-row APNs request UUID, reused across retries.
+    pub request_id: String,
 }
 
-/// Outcome of a failed delivery. `Retryable` is re-attempted with backoff;
-/// `Terminal` means the token is dead (prune the device) or the request is
-/// permanently malformed.
+/// Outcome of a failed delivery. `Retryable` is re-attempted with backoff,
+/// `Permanent` dead-letters the request without touching the device, and
+/// `InvalidTarget` prunes a token or subscription that cannot receive again.
 #[derive(Debug)]
 pub(crate) enum DeliveryError {
     Retryable(String),
-    Terminal(String),
+    Permanent(String),
+    InvalidTarget(String),
 }
 
 impl DeliveryError {
     pub fn message(&self) -> &str {
         match self {
-            DeliveryError::Retryable(m) | DeliveryError::Terminal(m) => m,
+            DeliveryError::Retryable(m)
+            | DeliveryError::Permanent(m)
+            | DeliveryError::InvalidTarget(m) => m,
         }
     }
-    pub fn is_terminal(&self) -> bool {
-        matches!(self, DeliveryError::Terminal(_))
+    pub fn is_permanent(&self) -> bool {
+        matches!(self, DeliveryError::Permanent(_))
+    }
+    pub fn invalidates_target(&self) -> bool {
+        matches!(self, DeliveryError::InvalidTarget(_))
     }
 }
 
@@ -121,7 +130,9 @@ impl ApnsSink {
                 return Ok(cached.jwt.clone());
             }
         }
-        let jwt = self.mint_token(now_secs).map_err(DeliveryError::Terminal)?;
+        let jwt = self
+            .mint_token(now_secs)
+            .map_err(DeliveryError::Permanent)?;
         *cache = Some(CachedToken {
             jwt: jwt.clone(),
             minted: Instant::now(),
@@ -147,13 +158,15 @@ impl ApnsSink {
     fn classify_status(status: u16, reason: &str) -> Result<(), DeliveryError> {
         match status {
             200 => Ok(()),
-            410 => Err(DeliveryError::Terminal(format!("unregistered: {reason}"))),
+            410 => Err(DeliveryError::InvalidTarget(format!(
+                "unregistered: {reason}"
+            ))),
             400 if reason.contains("BadDeviceToken")
                 || reason.contains("DeviceTokenNotForTopic") =>
             {
-                Err(DeliveryError::Terminal(format!("bad token: {reason}")))
+                Err(DeliveryError::InvalidTarget(format!("bad token: {reason}")))
             }
-            400 | 403 | 404 => Err(DeliveryError::Terminal(format!(
+            400 | 403 | 404 | 405 | 413 => Err(DeliveryError::Permanent(format!(
                 "rejected ({status}): {reason}"
             ))),
             429 => Err(DeliveryError::Retryable(format!("throttled: {reason}"))),
@@ -178,16 +191,31 @@ pub(crate) fn apns_body_from_payload(payload: &[u8]) -> Vec<u8> {
             .filter(|v| !v.is_empty())
     };
 
-    // aps.alert (title / body / subtitle)
+    // aps.alert (literal text, bundle localization, and launch image)
     let mut alert = serde_json::Map::new();
-    if let Some(v) = s("title") {
-        alert.insert("title".into(), json!(v));
+    for (source, target) in [
+        ("title", "title"),
+        ("body", "body"),
+        ("subtitle", "subtitle"),
+        ("title_loc_key", "title-loc-key"),
+        ("subtitle_loc_key", "subtitle-loc-key"),
+        ("body_loc_key", "loc-key"),
+        ("launch_image", "launch-image"),
+    ] {
+        if let Some(value) = s(source) {
+            alert.insert(target.into(), json!(value));
+        }
     }
-    if let Some(v) = s("body") {
-        alert.insert("body".into(), json!(v));
-    }
-    if let Some(v) = s("subtitle") {
-        alert.insert("subtitle".into(), json!(v));
+    for (source, target) in [
+        ("title_loc_args", "title-loc-args"),
+        ("subtitle_loc_args", "subtitle-loc-args"),
+        ("body_loc_args", "loc-args"),
+    ] {
+        if let Some(values) = parsed.get(source).and_then(Value::as_array) {
+            if values.iter().all(Value::is_string) {
+                alert.insert(target.into(), Value::Array(values.clone()));
+            }
+        }
     }
 
     let mut aps = serde_json::Map::new();
@@ -200,11 +228,48 @@ pub(crate) fn apns_body_from_payload(payload: &[u8]) -> Vec<u8> {
     if let Some(v) = s("category") {
         aps.insert("category".into(), json!(v));
     }
-    if let Some(v) = s("sound") {
-        aps.insert("sound".into(), json!(v));
+    if let Some(sound) = parsed.get("sound") {
+        match sound {
+            Value::String(value) if !value.is_empty() => {
+                aps.insert("sound".into(), json!(value));
+            }
+            Value::Object(sound)
+                if sound.get("critical").and_then(Value::as_bool) == Some(true)
+                    && sound
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .is_some_and(|name| !name.is_empty()) =>
+            {
+                let mut critical = serde_json::Map::new();
+                critical.insert("critical".into(), json!(1));
+                critical.insert("name".into(), sound["name"].clone());
+                if let Some(volume) = sound
+                    .get("volume")
+                    .and_then(Value::as_f64)
+                    .filter(|volume| (0.0..=1.0).contains(volume))
+                {
+                    critical.insert("volume".into(), json!(volume));
+                }
+                aps.insert("sound".into(), Value::Object(critical));
+            }
+            _ => {}
+        }
     }
     if let Some(v) = s("interruption_level").filter(|v| super::is_valid_interruption_level(v)) {
         aps.insert("interruption-level".into(), json!(v));
+    }
+    if let Some(v) = s("target_content_id") {
+        aps.insert("target-content-id".into(), json!(v));
+    }
+    if let Some(v) = parsed
+        .get("relevance_score")
+        .and_then(Value::as_f64)
+        .filter(|value| (0.0..=1.0).contains(value))
+    {
+        aps.insert("relevance-score".into(), json!(v));
+    }
+    if let Some(v) = s("filter_criteria") {
+        aps.insert("filter-criteria".into(), json!(v));
     }
     if let Some(v) = parsed.get("badge").and_then(|v| v.as_i64()) {
         aps.insert("badge".into(), json!(v));
@@ -229,38 +294,100 @@ pub(crate) fn apns_body_from_payload(payload: &[u8]) -> Vec<u8> {
 
     let mut envelope = serde_json::Map::new();
     envelope.insert("aps".into(), serde_json::Value::Object(aps));
-    if let Some(v) = s("image") {
-        envelope.insert("image_url".into(), json!(v));
-    }
     // Arbitrary custom data merged at top level (arrives in the client userInfo).
     if let Some(data) = parsed.get("data").and_then(|v| v.as_object()) {
         for (k, v) in data {
-            envelope.insert(k.clone(), v.clone());
+            if k != "aps" {
+                envelope.insert(k.clone(), v.clone());
+            }
         }
+    }
+    // This is the contract with Lux's iOS notification-service extension.
+    // Insert it after custom data so callers cannot accidentally replace it.
+    if let Some(v) = s("image") {
+        envelope.insert("image_url".into(), json!(v));
     }
     serde_json::to_vec(&serde_json::Value::Object(envelope)).unwrap_or_else(|_| b"{}".to_vec())
 }
 
-/// `(apns-push-type, apns-priority)` for a payload. A `content_available` push
-/// with no visible alert is a background push (type `background`, priority 5);
-/// everything else is a normal alert (type `alert`, priority 10).
-pub(crate) fn apns_delivery_headers(payload: &[u8]) -> (&'static str, &'static str) {
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ApnsDeliveryHeaders {
+    push_type: &'static str,
+    priority: &'static str,
+    expiration: Option<String>,
+    collapse_id: Option<String>,
+}
+
+/// APNs request headers for a payload. Lux derives the push type so callers
+/// cannot accidentally mismatch the payload and header; the remaining optional
+/// transport controls are validated before enqueue.
+pub(crate) fn apns_delivery_headers(payload: &[u8]) -> ApnsDeliveryHeaders {
     let parsed: serde_json::Value = serde_json::from_slice(payload).unwrap_or(json!({}));
-    let s = |k: &str| {
-        parsed
-            .get(k)
-            .and_then(|v| v.as_str())
-            .filter(|v| !v.is_empty())
-    };
-    let has_alert = s("title").is_some() || s("body").is_some();
-    let content_available = parsed
-        .get("content_available")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    if content_available && !has_alert {
-        ("background", "5")
+    let background = super::notification_is_background(&parsed);
+    let apns = parsed.get("apns").and_then(Value::as_object);
+    let configured_priority = apns
+        .and_then(|options| options.get("priority"))
+        .and_then(Value::as_u64);
+    let priority = if background {
+        "5"
     } else {
-        ("alert", "10")
+        match configured_priority {
+            Some(1) => "1",
+            Some(5) => "5",
+            Some(10) => "10",
+            _ => "10",
+        }
+    };
+    ApnsDeliveryHeaders {
+        push_type: if background { "background" } else { "alert" },
+        priority,
+        expiration: apns
+            .and_then(|options| options.get("expiration"))
+            .and_then(Value::as_u64)
+            .map(|value| value.to_string()),
+        collapse_id: apns
+            .and_then(|options| options.get("collapse_id"))
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty() && value.len() <= 64)
+            .map(str::to_string),
+    }
+}
+
+/// Derive a stable canonical request UUID from the durable outbox id. APNs
+/// echoes this value in error responses, and retries of one delivery keep the
+/// same id while fan-out rows get distinct ids.
+pub(crate) fn apns_request_id(outbox_id: &str) -> String {
+    let digest = Sha256::digest(outbox_id.as_bytes());
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    // RFC 9562 UUIDv8: application-defined bytes plus the RFC variant bits.
+    bytes[6] = (bytes[6] & 0x0f) | 0x80;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    let hex = bytes
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let id = format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    );
+    debug_assert!(super::is_canonical_uuid(&id));
+    id
+}
+
+fn with_optional_header(
+    request: reqwest::RequestBuilder,
+    name: &'static str,
+    value: &Option<String>,
+) -> reqwest::RequestBuilder {
+    if let Some(value) = value {
+        request.header(name, value)
+    } else {
+        request
     }
 }
 
@@ -270,27 +397,39 @@ impl Sink for ApnsSink {
         let jwt = self.provider_token(now_secs)?;
         let url = format!("{}/3/device/{}", self.base_url, target.token);
         let body = apns_body_from_payload(payload);
-        let (push_type, priority) = apns_delivery_headers(payload);
-        let resp = self
+        if body.len() > super::APNS_PAYLOAD_LIMIT_BYTES {
+            return Err(DeliveryError::Permanent(format!(
+                "APNs payload exceeds {} bytes",
+                super::APNS_PAYLOAD_LIMIT_BYTES
+            )));
+        }
+        let headers = apns_delivery_headers(payload);
+        let request = self
             .client
             .post(&url)
             .header("authorization", format!("bearer {jwt}"))
             .header("apns-topic", &target.topic)
-            .header("apns-push-type", push_type)
-            .header("apns-priority", priority)
+            .header("apns-id", &target.request_id)
+            .header("apns-push-type", headers.push_type)
+            .header("apns-priority", headers.priority)
             .header("content-type", "application/json")
-            .body(body)
-            .send()
-            .await
-            .map_err(|e| {
-                if e.is_timeout() || e.is_connect() {
-                    DeliveryError::Retryable(format!("apns transport: {e}"))
-                } else {
-                    DeliveryError::Retryable(format!("apns request failed: {e}"))
-                }
-            })?;
+            .body(body);
+        let request = with_optional_header(request, "apns-expiration", &headers.expiration);
+        let request = with_optional_header(request, "apns-collapse-id", &headers.collapse_id);
+        let resp = request.send().await.map_err(|e| {
+            if e.is_timeout() || e.is_connect() {
+                DeliveryError::Retryable(format!("apns transport: {e}"))
+            } else {
+                DeliveryError::Retryable(format!("apns request failed: {e}"))
+            }
+        })?;
         let status = resp.status().as_u16();
-        let reason = resp.text().await.unwrap_or_default();
+        let response_body = resp.text().await.unwrap_or_default();
+        let reason = if target.request_id.is_empty() {
+            response_body
+        } else {
+            format!("apns-id {}: {response_body}", target.request_id)
+        };
         ApnsSink::classify_status(status, &reason)
     }
 }
@@ -379,12 +518,22 @@ mod tests {
     }
 
     #[test]
-    fn invalid_p8_is_terminal() {
+    fn request_id_is_stable_canonical_and_unique_per_outbox_row() {
+        let first = apns_request_id("out_first");
+        assert_eq!(first, apns_request_id("out_first"));
+        assert_ne!(first, apns_request_id("out_second"));
+        assert!(super::super::is_canonical_uuid(&first));
+        assert_eq!(&first[14..15], "8");
+    }
+
+    #[test]
+    fn invalid_p8_is_permanent_without_invalidating_device() {
         let sink = sink_with(
             "-----BEGIN PRIVATE KEY-----\nnonsense\n-----END PRIVATE KEY-----".to_string(),
         );
         let err = sink.provider_token(1_700_000_000).unwrap_err();
-        assert!(err.is_terminal(), "bad key must be terminal, got {err:?}");
+        assert!(err.is_permanent(), "bad key must be permanent, got {err:?}");
+        assert!(!err.invalidates_target());
     }
 
     #[test]
@@ -392,16 +541,19 @@ mod tests {
         assert!(ApnsSink::classify_status(200, "").is_ok());
         assert!(ApnsSink::classify_status(410, "Unregistered")
             .unwrap_err()
-            .is_terminal());
+            .invalidates_target());
         assert!(ApnsSink::classify_status(400, "BadDeviceToken")
             .unwrap_err()
-            .is_terminal());
-        assert!(!ApnsSink::classify_status(429, "TooManyRequests")
-            .unwrap_err()
-            .is_terminal());
-        assert!(!ApnsSink::classify_status(503, "ServiceUnavailable")
-            .unwrap_err()
-            .is_terminal());
+            .invalidates_target());
+        let bad_payload = ApnsSink::classify_status(400, "BadCollapseId").unwrap_err();
+        assert!(bad_payload.is_permanent());
+        assert!(!bad_payload.invalidates_target());
+        let throttled = ApnsSink::classify_status(429, "TooManyRequests").unwrap_err();
+        assert!(!throttled.is_permanent());
+        assert!(!throttled.invalidates_target());
+        let unavailable = ApnsSink::classify_status(503, "ServiceUnavailable").unwrap_err();
+        assert!(!unavailable.is_permanent());
+        assert!(!unavailable.invalidates_target());
     }
 
     #[test]
@@ -419,8 +571,9 @@ mod tests {
         let payload = br#"{
             "title":"T","body":"B","subtitle":"S","thread_id":"th1",
             "category":"MSG","sound":"ping.caf","badge":3,"image":"https://x/i.png",
-            "interruption_level":"time-sensitive",
-            "data":{"route":"/w/1"}
+            "interruption_level":"time-sensitive","target_content_id":"message-window",
+            "relevance_score":0.75,"filter_criteria":"work",
+            "data":{"route":"/w/1","nested":{"count":2}}
         }"#;
         let v: serde_json::Value =
             serde_json::from_slice(&apns_body_from_payload(payload)).unwrap();
@@ -429,10 +582,52 @@ mod tests {
         assert_eq!(v["aps"]["category"], "MSG");
         assert_eq!(v["aps"]["sound"], "ping.caf");
         assert_eq!(v["aps"]["interruption-level"], "time-sensitive");
+        assert_eq!(v["aps"]["target-content-id"], "message-window");
+        assert_eq!(v["aps"]["relevance-score"], 0.75);
+        assert_eq!(v["aps"]["filter-criteria"], "work");
         assert_eq!(v["aps"]["badge"], 3);
         assert_eq!(v["aps"]["mutable-content"], 1); // image → NSE
         assert_eq!(v["image_url"], "https://x/i.png");
         assert_eq!(v["route"], "/w/1");
+        assert_eq!(v["nested"]["count"], 2);
+    }
+
+    #[test]
+    fn body_maps_localization_launch_image_and_critical_sound() {
+        let payload = br#"{
+            "title_loc_key":"QUESTION_TITLE","title_loc_args":["Codex"],
+            "subtitle_loc_key":"PROJECT_NAME","subtitle_loc_args":["Vigil"],
+            "body_loc_key":"QUESTION_BODY","body_loc_args":["Deploy"],
+            "launch_image":"LaunchQuestion",
+            "sound":{"critical":true,"name":"alarm.caf","volume":0.4}
+        }"#;
+        let v: Value = serde_json::from_slice(&apns_body_from_payload(payload)).unwrap();
+        let alert = &v["aps"]["alert"];
+        assert_eq!(alert["title-loc-key"], "QUESTION_TITLE");
+        assert_eq!(alert["title-loc-args"], json!(["Codex"]));
+        assert_eq!(alert["subtitle-loc-key"], "PROJECT_NAME");
+        assert_eq!(alert["subtitle-loc-args"], json!(["Vigil"]));
+        assert_eq!(alert["loc-key"], "QUESTION_BODY");
+        assert_eq!(alert["loc-args"], json!(["Deploy"]));
+        assert_eq!(alert["launch-image"], "LaunchQuestion");
+        assert_eq!(v["aps"]["sound"]["critical"], 1);
+        assert_eq!(v["aps"]["sound"]["name"], "alarm.caf");
+        assert_eq!(v["aps"]["sound"]["volume"], 0.4);
+    }
+
+    #[test]
+    fn custom_data_cannot_replace_aps_envelope() {
+        let payload = br#"{
+            "title":"Safe",
+            "image":"https://example.com/safe.png",
+            "data":{
+                "aps":{"alert":"overridden"},
+                "image_url":"https://example.com/overridden.png"
+            }
+        }"#;
+        let v: Value = serde_json::from_slice(&apns_body_from_payload(payload)).unwrap();
+        assert_eq!(v["aps"]["alert"]["title"], "Safe");
+        assert_eq!(v["image_url"], "https://example.com/safe.png");
     }
 
     #[test]
@@ -447,12 +642,53 @@ mod tests {
     fn content_available_is_a_background_push() {
         assert_eq!(
             apns_delivery_headers(br#"{"content_available":true}"#),
-            ("background", "5")
+            ApnsDeliveryHeaders {
+                push_type: "background",
+                priority: "5",
+                expiration: None,
+                collapse_id: None,
+            }
         );
         assert_eq!(
             apns_delivery_headers(br#"{"title":"hi","content_available":true}"#),
-            ("alert", "10")
+            ApnsDeliveryHeaders {
+                push_type: "alert",
+                priority: "10",
+                expiration: None,
+                collapse_id: None,
+            }
         );
-        assert_eq!(apns_delivery_headers(br#"{"title":"hi"}"#), ("alert", "10"));
+        assert_eq!(
+            apns_delivery_headers(br#"{"badge":1,"content_available":true}"#).push_type,
+            "alert"
+        );
+        assert_eq!(
+            apns_delivery_headers(br#"{"title_loc_key":"TITLE","content_available":true}"#)
+                .push_type,
+            "alert"
+        );
+    }
+
+    #[test]
+    fn delivery_headers_map_transport_controls() {
+        let headers = apns_delivery_headers(
+            br#"{
+                "title":"Hi",
+                "apns":{
+                    "priority":5,
+                    "expiration":1700000000,
+                    "collapse_id":"thread-1"
+                }
+            }"#,
+        );
+        assert_eq!(
+            headers,
+            ApnsDeliveryHeaders {
+                push_type: "alert",
+                priority: "5",
+                expiration: Some("1700000000".to_string()),
+                collapse_id: Some("thread-1".to_string()),
+            }
+        );
     }
 }

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -945,6 +945,27 @@ pub(crate) fn credential_config(
 // Send / enqueue
 // ---------------------------------------------------------------------------
 
+const APNS_INTERRUPTION_LEVELS: [&str; 4] = ["passive", "active", "time-sensitive", "critical"];
+
+fn is_valid_interruption_level(level: &str) -> bool {
+    APNS_INTERRUPTION_LEVELS.contains(&level)
+}
+
+fn validate_notification(notification: &Value) -> Result<(), String> {
+    let Some(value) = notification.get("interruption_level") else {
+        return Ok(());
+    };
+    let Some(level) = value.as_str() else {
+        return Err("interruption_level must be a string".to_string());
+    };
+    if !is_valid_interruption_level(level) {
+        return Err(
+            "interruption_level must be passive, active, time-sensitive, or critical".to_string(),
+        );
+    }
+    Ok(())
+}
+
 /// Fan a notification out to all of `subject_id`'s active devices by inserting
 /// one pending outbox row each. Returns the number enqueued. The worker delivers
 /// asynchronously.
@@ -955,6 +976,7 @@ pub(crate) fn enqueue_send(
     notification: &Value,
     now: Instant,
 ) -> Result<usize, String> {
+    validate_notification(notification)?;
     let payload = serde_json::to_string(notification).unwrap_or_else(|_| "{}".to_string());
     enqueue_to_subject(store, cache, subject_id, &payload, now)
 }
@@ -968,6 +990,7 @@ pub(crate) fn enqueue_send_many(
     notification: &Value,
     now: Instant,
 ) -> Result<usize, String> {
+    validate_notification(notification)?;
     let payload = serde_json::to_string(notification).unwrap_or_else(|_| "{}".to_string());
     let mut total = 0usize;
     for subject_id in subject_ids {
@@ -1249,6 +1272,22 @@ mod tests {
             assert_eq!(normalize_environment("development", source), "sandbox");
             assert_eq!(normalize_environment("dev", source), "sandbox");
         }
+    }
+
+    #[test]
+    fn notification_interruption_level_accepts_only_apns_values() {
+        for level in APNS_INTERRUPTION_LEVELS {
+            assert!(validate_notification(&json!({ "interruption_level": level })).is_ok());
+        }
+        assert!(validate_notification(&json!({ "title": "normal" })).is_ok());
+        assert_eq!(
+            validate_notification(&json!({ "interruption_level": "urgent" })).unwrap_err(),
+            "interruption_level must be passive, active, time-sensitive, or critical"
+        );
+        assert_eq!(
+            validate_notification(&json!({ "interruption_level": 1 })).unwrap_err(),
+            "interruption_level must be a string"
+        );
     }
 
     // Unrecognized input must not be guessed at. Empty means "the device did

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -946,14 +946,128 @@ pub(crate) fn credential_config(
 // ---------------------------------------------------------------------------
 
 const APNS_INTERRUPTION_LEVELS: [&str; 4] = ["passive", "active", "time-sensitive", "critical"];
+const APNS_PAYLOAD_LIMIT_BYTES: usize = 4096;
 
 fn is_valid_interruption_level(level: &str) -> bool {
     APNS_INTERRUPTION_LEVELS.contains(&level)
 }
 
+fn notification_has_alert(notification: &Value) -> bool {
+    [
+        "title",
+        "body",
+        "subtitle",
+        "title_loc_key",
+        "subtitle_loc_key",
+        "body_loc_key",
+    ]
+    .iter()
+    .any(|field| {
+        notification
+            .get(field)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.is_empty())
+    })
+}
+
+fn notification_is_background(notification: &Value) -> bool {
+    let content_available = notification
+        .get("content_available")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let has_badge = notification.get("badge").is_some();
+    let has_sound = notification.get("sound").is_some_and(|sound| match sound {
+        Value::String(value) => !value.is_empty(),
+        Value::Object(_) => true,
+        _ => false,
+    });
+    content_available && !notification_has_alert(notification) && !has_badge && !has_sound
+}
+
+fn is_canonical_uuid(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 36 {
+        return false;
+    }
+    bytes.iter().enumerate().all(|(index, byte)| {
+        if matches!(index, 8 | 13 | 18 | 23) {
+            *byte == b'-'
+        } else {
+            byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')
+        }
+    })
+}
+
 fn validate_notification(notification: &Value) -> Result<(), String> {
+    let Some(object) = notification.as_object() else {
+        return Err("notification must be a JSON object".to_string());
+    };
+    for field in [
+        "title",
+        "body",
+        "subtitle",
+        "title_loc_key",
+        "subtitle_loc_key",
+        "body_loc_key",
+        "launch_image",
+        "thread_id",
+        "category",
+        "image",
+        "target_content_id",
+        "filter_criteria",
+    ] {
+        if object.get(field).is_some_and(|value| !value.is_string()) {
+            return Err(format!("{field} must be a string"));
+        }
+    }
+    for field in ["title_loc_args", "subtitle_loc_args", "body_loc_args"] {
+        if let Some(value) = object.get(field) {
+            let valid = value
+                .as_array()
+                .is_some_and(|items| items.iter().all(Value::is_string));
+            if !valid {
+                return Err(format!("{field} must be an array of strings"));
+            }
+        }
+    }
+    for field in ["mutable_content", "content_available"] {
+        if object.get(field).is_some_and(|value| !value.is_boolean()) {
+            return Err(format!("{field} must be a boolean"));
+        }
+    }
+    if let Some(badge) = object.get("badge") {
+        if badge.as_i64().is_none_or(|value| value < 0) {
+            return Err("badge must be a non-negative integer".to_string());
+        }
+    }
+    if let Some(sound) = object.get("sound") {
+        match sound {
+            Value::String(_) => {}
+            Value::Object(sound) => {
+                if sound.get("critical").and_then(Value::as_bool) != Some(true) {
+                    return Err("critical sound must set critical to true".to_string());
+                }
+                if sound
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .is_none_or(str::is_empty)
+                {
+                    return Err("critical sound name must be a non-empty string".to_string());
+                }
+                if let Some(volume) = sound.get("volume") {
+                    if volume
+                        .as_f64()
+                        .is_none_or(|value| !(0.0..=1.0).contains(&value))
+                    {
+                        return Err("critical sound volume must be between 0 and 1".to_string());
+                    }
+                }
+            }
+            _ => return Err("sound must be a string or critical sound object".to_string()),
+        }
+    }
     let Some(value) = notification.get("interruption_level") else {
-        return Ok(());
+        return validate_notification_tail(notification);
     };
     let Some(level) = value.as_str() else {
         return Err("interruption_level must be a string".to_string());
@@ -962,6 +1076,74 @@ fn validate_notification(notification: &Value) -> Result<(), String> {
         return Err(
             "interruption_level must be passive, active, time-sensitive, or critical".to_string(),
         );
+    }
+    validate_notification_tail(notification)
+}
+
+fn validate_notification_tail(notification: &Value) -> Result<(), String> {
+    if let Some(score) = notification.get("relevance_score") {
+        if score
+            .as_f64()
+            .is_none_or(|value| !(0.0..=1.0).contains(&value))
+        {
+            return Err("relevance_score must be between 0 and 1".to_string());
+        }
+    }
+    if notification
+        .get("image")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.is_empty())
+        && !notification_has_alert(notification)
+    {
+        return Err(
+            "image requires an alert title, subtitle, body, or localization key".to_string(),
+        );
+    }
+    if let Some(data) = notification.get("data") {
+        let Some(data) = data.as_object() else {
+            return Err("data must be a JSON object".to_string());
+        };
+        if data.contains_key("aps") {
+            return Err("data.aps is reserved by APNs".to_string());
+        }
+    }
+    if let Some(apns) = notification.get("apns") {
+        let Some(apns) = apns.as_object() else {
+            return Err("apns must be a JSON object".to_string());
+        };
+        if let Some(collapse_id) = apns.get("collapse_id") {
+            let Some(collapse_id) = collapse_id.as_str() else {
+                return Err("apns.collapse_id must be a string".to_string());
+            };
+            if collapse_id.is_empty() {
+                return Err("apns.collapse_id must not be empty".to_string());
+            }
+            if collapse_id.len() > 64 {
+                return Err("apns.collapse_id must not exceed 64 bytes".to_string());
+            }
+        }
+        if let Some(expiration) = apns.get("expiration") {
+            if expiration.as_u64().is_none() {
+                return Err("apns.expiration must be a non-negative integer".to_string());
+            }
+        }
+        if let Some(priority) = apns.get("priority") {
+            let priority = priority.as_u64();
+            if !matches!(priority, Some(1 | 5 | 10)) {
+                return Err("apns.priority must be 1, 5, or 10".to_string());
+            }
+            if notification_is_background(notification) && priority != Some(5) {
+                return Err("background notifications require apns.priority 5".to_string());
+            }
+        }
+    }
+    let payload = serde_json::to_vec(notification)
+        .map_err(|error| format!("invalid notification: {error}"))?;
+    let apns_body = apns::apns_body_from_payload(&payload);
+    if apns_body.len() > APNS_PAYLOAD_LIMIT_BYTES {
+        return Err(format!(
+            "APNs payload exceeds {APNS_PAYLOAD_LIMIT_BYTES} bytes"
+        ));
     }
     Ok(())
 }
@@ -1287,6 +1469,85 @@ mod tests {
         assert_eq!(
             validate_notification(&json!({ "interruption_level": 1 })).unwrap_err(),
             "interruption_level must be a string"
+        );
+    }
+
+    #[test]
+    fn notification_accepts_complete_standard_apns_surface() {
+        let notification = json!({
+            "title_loc_key": "TITLE",
+            "title_loc_args": ["Codex"],
+            "subtitle_loc_key": "PROJECT",
+            "subtitle_loc_args": ["Lux"],
+            "body_loc_key": "BODY",
+            "body_loc_args": ["Deploy"],
+            "launch_image": "LaunchQuestion",
+            "sound": {"critical": true, "name": "alarm.caf", "volume": 0.5},
+            "badge": 1,
+            "target_content_id": "question-window",
+            "relevance_score": 0.9,
+            "filter_criteria": "work",
+            "apns": {
+                "collapse_id": "agent-question",
+                "expiration": 1_900_000_000,
+                "priority": 10
+            },
+            "data": {"question": {"id": 7}, "urgent": true}
+        });
+        assert!(validate_notification(&notification).is_ok());
+    }
+
+    #[test]
+    fn notification_rejects_invalid_apns_fields_before_enqueue() {
+        let cases = [
+            (json!({"badge": -1}), "badge must be a non-negative integer"),
+            (
+                json!({"sound": {"critical": true, "name": "default", "volume": 1.1}}),
+                "critical sound volume must be between 0 and 1",
+            ),
+            (
+                json!({"relevance_score": 2}),
+                "relevance_score must be between 0 and 1",
+            ),
+            (
+                json!({"content_available": true, "apns": {"priority": 10}}),
+                "background notifications require apns.priority 5",
+            ),
+            (
+                json!({"apns": {"collapse_id": ""}}),
+                "apns.collapse_id must not be empty",
+            ),
+            (json!({"data": {"aps": {}}}), "data.aps is reserved by APNs"),
+            (
+                json!({"image": "https://example.com/image.png"}),
+                "image requires an alert title, subtitle, body, or localization key",
+            ),
+        ];
+        for (notification, expected) in cases {
+            assert_eq!(
+                validate_notification(&notification).unwrap_err(),
+                expected,
+                "notification: {notification}"
+            );
+        }
+        assert_eq!(
+            validate_notification(&json!({
+                "apns": {"collapse_id": "x".repeat(65)}
+            }))
+            .unwrap_err(),
+            "apns.collapse_id must not exceed 64 bytes"
+        );
+    }
+
+    #[test]
+    fn notification_rejects_payloads_larger_than_apns_limit() {
+        let notification = json!({
+            "title": "Too large",
+            "data": {"blob": "x".repeat(APNS_PAYLOAD_LIMIT_BYTES)}
+        });
+        assert_eq!(
+            validate_notification(&notification).unwrap_err(),
+            format!("APNs payload exceeds {APNS_PAYLOAD_LIMIT_BYTES} bytes")
         );
     }
 

--- a/src/push/webpush.rs
+++ b/src/push/webpush.rs
@@ -327,7 +327,7 @@ impl WebPushSink {
     /// Sign a VAPID JWT (RFC 8292) scoped to the push service origin.
     fn vapid_jwt(&self, endpoint: &str) -> Result<String, DeliveryError> {
         let endpoint = validate_endpoint(endpoint, private_endpoints_allowed())
-            .map_err(DeliveryError::Terminal)?;
+            .map_err(DeliveryError::InvalidTarget)?;
         let aud = endpoint.origin().ascii_serialization();
         let claims = VapidClaims {
             aud,
@@ -335,22 +335,23 @@ impl WebPushSink {
             sub: self.subject.clone(),
         };
         let key = EncodingKey::from_ec_pem(self.private_pem.as_bytes())
-            .map_err(|e| DeliveryError::Terminal(format!("invalid VAPID key: {e}")))?;
+            .map_err(|e| DeliveryError::Permanent(format!("invalid VAPID key: {e}")))?;
         encode(&Header::new(Algorithm::ES256), &claims, &key)
-            .map_err(|e| DeliveryError::Terminal(format!("VAPID JWT sign failed: {e}")))
+            .map_err(|e| DeliveryError::Permanent(format!("VAPID JWT sign failed: {e}")))
     }
 }
 
 impl Sink for WebPushSink {
     async fn deliver(&self, target: &DeliveryTarget, payload: &[u8]) -> Result<(), DeliveryError> {
         // The web "token" is the serialized browser PushSubscription.
-        let sub: Subscription = serde_json::from_str(&target.token)
-            .map_err(|e| DeliveryError::Terminal(format!("invalid web push subscription: {e}")))?;
+        let sub: Subscription = serde_json::from_str(&target.token).map_err(|e| {
+            DeliveryError::InvalidTarget(format!("invalid web push subscription: {e}"))
+        })?;
         validate_endpoint(&sub.endpoint, private_endpoints_allowed())
-            .map_err(DeliveryError::Terminal)?;
-        let p256dh = b64url_decode(&sub.keys.p256dh).map_err(DeliveryError::Terminal)?;
-        let auth = b64url_decode(&sub.keys.auth).map_err(DeliveryError::Terminal)?;
-        let body = seal(payload, &p256dh, &auth).map_err(DeliveryError::Terminal)?;
+            .map_err(DeliveryError::InvalidTarget)?;
+        let p256dh = b64url_decode(&sub.keys.p256dh).map_err(DeliveryError::InvalidTarget)?;
+        let auth = b64url_decode(&sub.keys.auth).map_err(DeliveryError::InvalidTarget)?;
+        let body = seal(payload, &p256dh, &auth).map_err(DeliveryError::InvalidTarget)?;
         let jwt = self.vapid_jwt(&sub.endpoint)?;
 
         let resp = self
@@ -376,10 +377,10 @@ impl Sink for WebPushSink {
 fn classify_web_push(status: u16) -> Result<(), DeliveryError> {
     match status {
         200..=202 => Ok(()),
-        404 | 410 => Err(DeliveryError::Terminal(format!(
+        404 | 410 => Err(DeliveryError::InvalidTarget(format!(
             "subscription gone ({status})"
         ))),
-        400 | 401 | 403 => Err(DeliveryError::Terminal(format!("rejected ({status})"))),
+        400 | 401 | 403 => Err(DeliveryError::Permanent(format!("rejected ({status})"))),
         429 => Err(DeliveryError::Retryable("throttled".to_string())),
         500..=599 => Err(DeliveryError::Retryable(format!(
             "push service error ({status})"
@@ -481,5 +482,19 @@ mod tests {
         )
         .is_ok());
         assert!(validate_endpoint("http://127.0.0.1:9000/mock", true).is_ok());
+    }
+
+    #[test]
+    fn response_classification_only_prunes_gone_subscriptions() {
+        assert!(classify_web_push(201).is_ok());
+        assert!(classify_web_push(410).unwrap_err().invalidates_target());
+
+        let bad_request = classify_web_push(400).unwrap_err();
+        assert!(bad_request.is_permanent());
+        assert!(!bad_request.invalidates_target());
+
+        let unavailable = classify_web_push(503).unwrap_err();
+        assert!(!unavailable.is_permanent());
+        assert!(!unavailable.invalidates_target());
     }
 }

--- a/src/push/worker.rs
+++ b/src/push/worker.rs
@@ -12,7 +12,7 @@ use crate::auth::{durable_table_delete_where, durable_table_update_where, unix_s
 use crate::store::Store;
 use crate::tables::{CmpOp, SharedSchemaCache, WhereClause};
 
-use super::apns::{ApnsSink, DeliveryError, DeliveryTarget, Sink};
+use super::apns::{apns_request_id, ApnsSink, DeliveryError, DeliveryTarget, Sink};
 use super::webpush::WebPushSink;
 use super::{
     get_apns_credentials, get_vapid_credentials, metrics, select_rows, DEVICES_TABLE, OUTBOX_TABLE,
@@ -55,7 +55,11 @@ pub(crate) enum Action {
 pub(crate) fn decide(attempts: i64, result: Result<(), DeliveryError>, now_secs: u64) -> Action {
     match result {
         Ok(()) => Action::Delivered,
-        Err(e) if e.is_terminal() => Action::DisableDevice {
+        Err(e) if e.invalidates_target() => Action::DisableDevice {
+            error: e.message().to_string(),
+        },
+        Err(e) if e.is_permanent() => Action::Dead {
+            attempts: attempts + 1,
             error: e.message().to_string(),
         },
         Err(e) => {
@@ -169,6 +173,7 @@ async fn process_pending(
                 let target = DeliveryTarget {
                     token: token.clone(),
                     topic: topic.clone(),
+                    request_id: apns_request_id(&id),
                 };
                 sink.deliver(&target, payload.as_bytes()).await
             }
@@ -177,6 +182,7 @@ async fn process_pending(
                 let target = DeliveryTarget {
                     token: token.clone(),
                     topic: String::new(),
+                    request_id: String::new(),
                 };
                 sink.deliver(&target, payload.as_bytes()).await
             }
@@ -362,12 +368,27 @@ mod tests {
     }
 
     #[test]
-    fn terminal_disables_device() {
-        let action = decide(0, Err(DeliveryError::Terminal("unregistered".into())), 1000);
+    fn invalid_target_disables_device() {
+        let action = decide(
+            0,
+            Err(DeliveryError::InvalidTarget("unregistered".into())),
+            1000,
+        );
         assert_eq!(
             action,
             Action::DisableDevice {
                 error: "unregistered".into()
+            }
+        );
+    }
+
+    #[test]
+    fn permanent_delivery_error_dead_letters_without_disabling_device() {
+        assert_eq!(
+            decide(0, Err(DeliveryError::Permanent("bad payload".into())), 1000),
+            Action::Dead {
+                attempts: 1,
+                error: "bad payload".into(),
             }
         );
     }

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -176,6 +176,11 @@ struct Captured {
     path: String,
     authorization: String,
     apns_topic: String,
+    apns_push_type: String,
+    apns_priority: String,
+    apns_expiration: String,
+    apns_collapse_id: String,
+    apns_id: String,
     content_encoding: String,
     body: String,
 }
@@ -187,10 +192,20 @@ struct MockApns {
 
 impl MockApns {
     fn start(status: u16) -> Self {
+        let reason = if status == 200 {
+            "{}"
+        } else {
+            "{\"reason\":\"Unregistered\"}"
+        };
+        Self::start_with_reason(status, reason)
+    }
+
+    fn start_with_reason(status: u16, reason: &str) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let requests = Arc::new(Mutex::new(Vec::new()));
         let reqs = requests.clone();
+        let reason = reason.to_string();
         std::thread::spawn(move || {
             for conn in listener.incoming() {
                 let Ok(mut stream) = conn else { continue };
@@ -219,6 +234,11 @@ impl MockApns {
                         match k.trim().to_ascii_lowercase().as_str() {
                             "authorization" => cap.authorization = v.trim().to_string(),
                             "apns-topic" => cap.apns_topic = v.trim().to_string(),
+                            "apns-push-type" => cap.apns_push_type = v.trim().to_string(),
+                            "apns-priority" => cap.apns_priority = v.trim().to_string(),
+                            "apns-expiration" => cap.apns_expiration = v.trim().to_string(),
+                            "apns-collapse-id" => cap.apns_collapse_id = v.trim().to_string(),
+                            "apns-id" => cap.apns_id = v.trim().to_string(),
                             "content-encoding" => cap.content_encoding = v.trim().to_string(),
                             _ => {}
                         }
@@ -240,11 +260,6 @@ impl MockApns {
                 }
                 cap.body = String::from_utf8_lossy(&body).to_string();
                 reqs.lock().unwrap().push(cap);
-                let reason = if status == 200 {
-                    "{}"
-                } else {
-                    "{\"reason\":\"Unregistered\"}"
-                };
                 let response = format!(
                     "HTTP/1.1 {status} X\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{reason}",
                     reason.len()
@@ -595,7 +610,15 @@ fn push_end_to_end_delivers_to_apns_mock() {
             "notification": {
                 "title": "Hi",
                 "body": "There",
-                "interruption_level": "time-sensitive"
+                "interruption_level": "time-sensitive",
+                "target_content_id": "question-window",
+                "relevance_score": 0.8,
+                "filter_criteria": "work",
+                "apns": {
+                    "priority": 5,
+                    "expiration": 1_900_000_000,
+                    "collapse_id": "question-user"
+                }
             }
         })
         .to_string(),
@@ -614,10 +637,25 @@ fn push_end_to_end_delivers_to_apns_mock() {
         got.authorization
     );
     assert_eq!(got.apns_topic, "com.example.app");
+    assert_eq!(got.apns_push_type, "alert");
+    assert_eq!(got.apns_priority, "5");
+    assert_eq!(got.apns_expiration, "1900000000");
+    assert_eq!(got.apns_collapse_id, "question-user");
+    assert_eq!(got.apns_id.len(), 36);
+    assert_eq!(
+        got.apns_id
+            .chars()
+            .filter(|character| *character == '-')
+            .count(),
+        4
+    );
     let body: Value = serde_json::from_str(&got.body).unwrap();
     assert_eq!(body["aps"]["alert"]["title"], "Hi");
     assert_eq!(body["aps"]["alert"]["body"], "There");
     assert_eq!(body["aps"]["interruption-level"], "time-sensitive");
+    assert_eq!(body["aps"]["target-content-id"], "question-window");
+    assert_eq!(body["aps"]["relevance-score"], 0.8);
+    assert_eq!(body["aps"]["filter-criteria"], "work");
 
     // Delivered: the outbox drains and the counter increments.
     let deadline = Instant::now() + Duration::from_secs(3);
@@ -699,6 +737,77 @@ fn push_unregistered_token_disables_device() {
         }
         std::thread::sleep(Duration::from_millis(50));
     }
+    drop(server);
+}
+
+#[test]
+fn push_bad_request_dead_letters_without_disabling_device() {
+    let mock = MockApns::start_with_reason(400, r#"{"reason":"BadCollapseId"}"#);
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start(dir.path(), resp_port, http_port, false);
+
+    set_creds(http_port, &mock.url());
+    let (token, uid) = anon_login(http_port);
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/devices",
+        &json!({"token":"healthy-token","platform":"ios","app_id":"default"}).to_string(),
+        Some(&token),
+    );
+    assert_eq!(s, 200, "register: {b}");
+
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({"subject_id": uid, "notification": {"title":"Hi"}}).to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 200, "send: {b}");
+    assert!(
+        mock.wait_for_request(Duration::from_secs(5)).is_some(),
+        "mock should receive the attempt"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let dead = loop {
+        let (s, body) = http(
+            http_port,
+            "GET",
+            "/v1/push/admin/outbox",
+            "",
+            Some("rootsecret"),
+        );
+        assert_eq!(s, 200, "dead letters: {body}");
+        if body["dead_letters"]
+            .as_array()
+            .is_some_and(|rows| !rows.is_empty())
+        {
+            break body;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "delivery was not dead-lettered: {body}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    assert!(
+        dead["dead_letters"][0]["last_error"]
+            .as_str()
+            .is_some_and(|error| error.contains("BadCollapseId") && error.contains("apns-id")),
+        "dead letter should retain APNs diagnostics: {dead}"
+    );
+
+    let (s, devices) = http(http_port, "GET", "/v1/push/devices", "", Some(&token));
+    assert_eq!(s, 200, "devices: {devices}");
+    assert_eq!(
+        devices["devices"].as_array().map(Vec::len),
+        Some(1),
+        "request errors must not disable a healthy device: {devices}"
+    );
     drop(server);
 }
 

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -590,7 +590,15 @@ fn push_end_to_end_delivers_to_apns_mock() {
         http_port,
         "POST",
         "/v1/push/send",
-        &json!({"subject_id": uid, "notification": {"title":"Hi","body":"There"}}).to_string(),
+        &json!({
+            "subject_id": uid,
+            "notification": {
+                "title": "Hi",
+                "body": "There",
+                "interruption_level": "time-sensitive"
+            }
+        })
+        .to_string(),
         Some("rootsecret"),
     );
     assert_eq!(s, 200, "send: {b}");
@@ -609,6 +617,7 @@ fn push_end_to_end_delivers_to_apns_mock() {
     let body: Value = serde_json::from_str(&got.body).unwrap();
     assert_eq!(body["aps"]["alert"]["title"], "Hi");
     assert_eq!(body["aps"]["alert"]["body"], "There");
+    assert_eq!(body["aps"]["interruption-level"], "time-sensitive");
 
     // Delivered: the outbox drains and the counter increments.
     let deadline = Instant::now() + Duration::from_secs(3);
@@ -616,6 +625,33 @@ fn push_end_to_end_delivers_to_apns_mock() {
         std::thread::sleep(Duration::from_millis(50));
     }
     assert!(info_field(resp_port, "push_delivered_total") >= 1);
+    drop(server);
+}
+
+#[test]
+fn push_send_rejects_invalid_interruption_level() {
+    let dir = tempfile::tempdir().unwrap();
+    let resp_port = free_port();
+    let http_port = free_port();
+    let server = start(dir.path(), resp_port, http_port, false);
+
+    let (s, b) = http(
+        http_port,
+        "POST",
+        "/v1/push/send",
+        &json!({
+            "subject_id": "user-1",
+            "notification": {"title": "Hi", "interruption_level": "urgent"}
+        })
+        .to_string(),
+        Some("rootsecret"),
+    );
+    assert_eq!(s, 400, "invalid interruption level: {b}");
+    assert!(
+        b.to_string()
+            .contains("interruption_level must be passive, active, time-sensitive, or critical"),
+        "error response: {b}"
+    );
     drop(server);
 }
 


### PR DESCRIPTION
## Summary

- complete the standard APNs notification surface: localized title/subtitle/body, launch image, critical sounds, target content ID, relevance score, Focus filter criteria, nested custom JSON, interruption levels, and rich-media delivery through a notification service extension
- add APNs transport controls for collapse ID, expiration, and priority while deriving safe alert/background push types and stable request IDs
- validate field types, ranges, background priority, reserved payload keys, collapse-ID length, and the final 4 KB APNs payload before enqueue
- distinguish bad devices from bad payloads or credentials so request/configuration errors dead-letter without disabling healthy device tokens; apply the same safety split to Web Push
- expose the full typed API from Node and browser SDK entry points and document the iOS requirements

This intentionally covers normal alert and background notifications. Live Activities, VoIP, MDM, location, Push-to-Talk, widgets/controls, file-provider, and broadcast pushes remain separate APIs because they use different tokens, topics, push types, payload contracts, and lifecycles.

## Validation

- `cargo test --all-targets` (all passing, including 628 library unit tests and 16 push integration tests)
- `cargo test --test push -- --test-threads=1`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bun test` (65 passing)
- `bun run build`