### PR TITLE
Add durable Cloud operation UX to the CLI

### DIFF
--- a/cli/src/cloud.rs
+++ b/cli/src/cloud.rs
@@ -1,0 +1,650 @@
+use reqwest::{Method, StatusCode};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
+
+const CLOUD_API_PREFIX: &str = "/cloud/v1";
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Clone)]
+pub(crate) struct CloudClient {
+    http: reqwest::Client,
+    base_url: String,
+    token: String,
+}
+
+impl CloudClient {
+    pub(crate) fn new(http: reqwest::Client, api_url: &str, token: &str) -> Self {
+        Self {
+            http,
+            base_url: format!("{}{}", api_url.trim_end_matches('/'), CLOUD_API_PREFIX),
+            token: token.to_string(),
+        }
+    }
+
+    pub(crate) async fn workspaces(&self) -> Result<Vec<Workspace>, CloudError> {
+        self.request(Method::GET, "/workspaces", None, None).await
+    }
+
+    pub(crate) async fn projects(&self, workspace_id: &str) -> Result<Vec<Project>, CloudError> {
+        let mut url = reqwest::Url::parse(&format!("{}/projects", self.base_url))
+            .map_err(|error| CloudError::client(format!("invalid cloud API URL: {error}")))?;
+        url.query_pairs_mut()
+            .append_pair("workspace_id", workspace_id);
+        self.request_url(Method::GET, url, None, None).await
+    }
+
+    pub(crate) async fn resolve_project(&self, selector: &str) -> Result<Project, CloudError> {
+        let workspaces = self.workspaces().await?;
+        if workspaces.is_empty() {
+            return Err(CloudError::client("no workspace found for this token"));
+        }
+        let mut projects = Vec::new();
+        for workspace in workspaces {
+            projects.extend(self.projects(&workspace.id).await?);
+        }
+        select_project(projects, selector)
+    }
+
+    pub(crate) async fn create_project(
+        &self,
+        workspace_id: &str,
+        name: &str,
+        memory_mb: u32,
+        idempotency_key: &str,
+    ) -> Result<Accepted<Project>, CloudError> {
+        self.request(
+            Method::POST,
+            "/projects",
+            Some(serde_json::json!({
+                "workspace_id": workspace_id,
+                "name": name,
+                "memory_mb": memory_mb,
+            })),
+            Some(idempotency_key),
+        )
+        .await
+    }
+
+    pub(crate) async fn project_action(
+        &self,
+        project_id: &str,
+        action: &str,
+        payload: serde_json::Value,
+        idempotency_key: &str,
+    ) -> Result<Accepted<Project>, CloudError> {
+        self.request(
+            Method::POST,
+            &format!("/projects/{project_id}/actions/{action}"),
+            Some(payload),
+            Some(idempotency_key),
+        )
+        .await
+    }
+
+    pub(crate) async fn delete_project(
+        &self,
+        project_id: &str,
+        idempotency_key: &str,
+    ) -> Result<Accepted<Project>, CloudError> {
+        self.request(
+            Method::DELETE,
+            &format!("/projects/{project_id}"),
+            None,
+            Some(idempotency_key),
+        )
+        .await
+    }
+
+    pub(crate) async fn snapshots(&self, project_id: &str) -> Result<Vec<Snapshot>, CloudError> {
+        self.request(
+            Method::GET,
+            &format!("/projects/{project_id}/snapshots"),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn create_snapshot(
+        &self,
+        project_id: &str,
+        idempotency_key: &str,
+    ) -> Result<Accepted<Snapshot>, CloudError> {
+        self.request(
+            Method::POST,
+            &format!("/projects/{project_id}/snapshots"),
+            None,
+            Some(idempotency_key),
+        )
+        .await
+    }
+
+    pub(crate) async fn restore_snapshot(
+        &self,
+        project_id: &str,
+        snapshot_id: &str,
+        idempotency_key: &str,
+    ) -> Result<Accepted<Snapshot>, CloudError> {
+        self.request(
+            Method::POST,
+            &format!("/projects/{project_id}/snapshots/{snapshot_id}/restore"),
+            None,
+            Some(idempotency_key),
+        )
+        .await
+    }
+
+    pub(crate) async fn operations(&self, project_id: &str) -> Result<Vec<Operation>, CloudError> {
+        self.request(
+            Method::GET,
+            &format!("/projects/{project_id}/operations"),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn operation(&self, operation_id: &str) -> Result<Operation, CloudError> {
+        self.request(
+            Method::GET,
+            &format!("/operations/{operation_id}"),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn wait_for_operation<F>(
+        &self,
+        operation_id: &str,
+        timeout: Duration,
+        mut on_change: F,
+    ) -> Result<Operation, WaitError>
+    where
+        F: FnMut(&Operation),
+    {
+        let started = Instant::now();
+        let mut last_state: Option<(String, String, u8, Option<String>)> = None;
+        loop {
+            let operation = self.operation(operation_id).await.map_err(WaitError::Api)?;
+            let state = (
+                operation.status.clone(),
+                operation.phase.clone(),
+                operation.progress,
+                operation.message.clone(),
+            );
+            if last_state.as_ref() != Some(&state) {
+                on_change(&operation);
+                last_state = Some(state);
+            }
+            if operation.is_terminal() {
+                return Ok(operation);
+            }
+            if started.elapsed() >= timeout {
+                return Err(WaitError::Timeout {
+                    operation_id: operation_id.to_string(),
+                    timeout,
+                });
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    async fn request<T: DeserializeOwned>(
+        &self,
+        method: Method,
+        path: &str,
+        payload: Option<serde_json::Value>,
+        idempotency_key: Option<&str>,
+    ) -> Result<T, CloudError> {
+        let url = reqwest::Url::parse(&format!("{}{}", self.base_url, path))
+            .map_err(|error| CloudError::client(format!("invalid cloud API URL: {error}")))?;
+        self.request_url(method, url, payload, idempotency_key)
+            .await
+    }
+
+    async fn request_url<T: DeserializeOwned>(
+        &self,
+        method: Method,
+        url: reqwest::Url,
+        payload: Option<serde_json::Value>,
+        idempotency_key: Option<&str>,
+    ) -> Result<T, CloudError> {
+        let mut request = self
+            .http
+            .request(method, url)
+            .bearer_auth(&self.token)
+            .header("Accept", "application/json");
+        if let Some(payload) = payload {
+            request = request.json(&payload);
+        }
+        if let Some(key) = idempotency_key {
+            request = request.header("Idempotency-Key", key);
+        }
+        let response = request.send().await.map_err(|error| CloudError {
+            code: "cloud_unavailable".to_string(),
+            message: format!("Cloud request failed: {error}"),
+            request_id: None,
+            status: None,
+        })?;
+        let status = response.status();
+        let bytes = response.bytes().await.map_err(|error| CloudError {
+            code: "invalid_response".to_string(),
+            message: format!("Cloud response could not be read: {error}"),
+            request_id: None,
+            status: Some(status.as_u16()),
+        })?;
+        if status.is_success() {
+            let envelope: DataEnvelope<T> =
+                serde_json::from_slice(&bytes).map_err(|error| CloudError {
+                    code: "invalid_response".to_string(),
+                    message: format!(
+                        "Cloud returned invalid JSON (HTTP {}): {error}",
+                        status.as_u16()
+                    ),
+                    request_id: None,
+                    status: Some(status.as_u16()),
+                })?;
+            return Ok(envelope.data);
+        }
+        let parsed: Result<ErrorEnvelope, _> = serde_json::from_slice(&bytes);
+        match parsed {
+            Ok(envelope) => Err(CloudError {
+                code: envelope.error.code,
+                message: envelope.error.message,
+                request_id: Some(envelope.error.request_id),
+                status: Some(status.as_u16()),
+            }),
+            Err(_) => Err(CloudError {
+                code: "cloud_error".to_string(),
+                message: format!("Cloud request failed (HTTP {}).", status.as_u16()),
+                request_id: None,
+                status: Some(status.as_u16()),
+            }),
+        }
+    }
+}
+
+fn select_project(projects: Vec<Project>, selector: &str) -> Result<Project, CloudError> {
+    if let Some(project) = projects.iter().find(|project| project.id == selector) {
+        return Ok(project.clone());
+    }
+    let mut matches = projects
+        .into_iter()
+        .filter(|project| project.name == selector || project.slug == selector);
+    let Some(project) = matches.next() else {
+        return Err(CloudError {
+            code: "project_not_found".to_string(),
+            message: format!("Project '{selector}' was not found."),
+            request_id: None,
+            status: Some(StatusCode::NOT_FOUND.as_u16()),
+        });
+    };
+    if matches.next().is_some() {
+        return Err(CloudError::client(format!(
+            "Project name '{selector}' is ambiguous across workspaces; use its ID."
+        )));
+    }
+    Ok(project)
+}
+
+#[derive(Debug)]
+pub(crate) struct CloudError {
+    pub(crate) code: String,
+    pub(crate) message: String,
+    pub(crate) request_id: Option<String>,
+    pub(crate) status: Option<u16>,
+}
+
+impl CloudError {
+    fn client(message: impl Into<String>) -> Self {
+        Self {
+            code: "client_error".to_string(),
+            message: message.into(),
+            request_id: None,
+            status: None,
+        }
+    }
+}
+
+impl std::fmt::Display for CloudError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)?;
+        if let Some(status) = self.status {
+            write!(formatter, " (HTTP {status})")?;
+        }
+        if let Some(request_id) = &self.request_id {
+            write!(formatter, " (request {request_id})")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum WaitError {
+    Api(CloudError),
+    Timeout {
+        operation_id: String,
+        timeout: Duration,
+    },
+}
+
+impl std::fmt::Display for WaitError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Api(error) => error.fmt(formatter),
+            Self::Timeout {
+                operation_id,
+                timeout,
+            } => write!(
+                formatter,
+                "operation {operation_id} did not finish within {} seconds",
+                timeout.as_secs()
+            ),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct DataEnvelope<T> {
+    data: T,
+}
+
+#[derive(Deserialize)]
+struct ErrorEnvelope {
+    error: ErrorBody,
+}
+
+#[derive(Deserialize)]
+struct ErrorBody {
+    code: String,
+    message: String,
+    request_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct Workspace {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) slug: String,
+    pub(crate) role: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct Project {
+    pub(crate) id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) name: String,
+    pub(crate) slug: String,
+    pub(crate) status: String,
+    pub(crate) desired_state: String,
+    pub(crate) lifecycle_phase: String,
+    pub(crate) generation: u64,
+    pub(crate) observed_generation: u64,
+    pub(crate) version: u64,
+    pub(crate) region: String,
+    pub(crate) memory_mb: u32,
+    pub(crate) auth_enabled: bool,
+    pub(crate) deletion_protection: bool,
+    pub(crate) safe_error_code: Option<String>,
+    pub(crate) safe_error_message: Option<String>,
+    pub(crate) public_endpoints: PublicEndpoints,
+    pub(crate) conditions: Vec<ProjectCondition>,
+    pub(crate) created_at: String,
+    pub(crate) started_at: Option<String>,
+    pub(crate) deleted_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct PublicEndpoints {
+    pub(crate) http: Option<String>,
+    pub(crate) resp: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct ProjectCondition {
+    #[serde(rename = "type")]
+    pub(crate) kind: String,
+    pub(crate) status: bool,
+    pub(crate) reason: String,
+    pub(crate) message: Option<String>,
+    pub(crate) observed_generation: u64,
+    pub(crate) transitioned_at: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct Operation {
+    pub(crate) id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) project_id: Option<String>,
+    pub(crate) kind: String,
+    pub(crate) status: String,
+    pub(crate) phase: String,
+    pub(crate) progress: u8,
+    pub(crate) message: Option<String>,
+    pub(crate) attempt: u32,
+    pub(crate) max_attempts: u32,
+    pub(crate) retryable: bool,
+    pub(crate) error_code: Option<String>,
+    pub(crate) error_message: Option<String>,
+    pub(crate) requested_by: Option<String>,
+    pub(crate) parent_operation_id: Option<String>,
+    pub(crate) created_at: String,
+    pub(crate) started_at: Option<String>,
+    pub(crate) updated_at: String,
+    pub(crate) completed_at: Option<String>,
+}
+
+impl Operation {
+    pub(crate) fn is_terminal(&self) -> bool {
+        matches!(self.status.as_str(), "succeeded" | "failed" | "canceled")
+    }
+
+    pub(crate) fn succeeded(&self) -> bool {
+        self.status == "succeeded"
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct Snapshot {
+    pub(crate) id: String,
+    pub(crate) project_id: String,
+    pub(crate) status: String,
+    pub(crate) file_size_bytes: Option<u64>,
+    pub(crate) error_code: Option<String>,
+    pub(crate) error_message: Option<String>,
+    pub(crate) created_at: String,
+    pub(crate) completed_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct Accepted<T> {
+    pub(crate) resource: T,
+    pub(crate) operation: Operation,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+
+    async fn server(status: &str, body: &'static str) -> (String, oneshot::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = oneshot::channel();
+        let status = status.to_string();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 4096];
+            loop {
+                let read = stream.read(&mut buffer).await.unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                let header_end = request
+                    .windows(4)
+                    .position(|window| window == b"\r\n\r\n")
+                    .map(|position| position + 4);
+                let Some(header_end) = header_end else {
+                    continue;
+                };
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or(0);
+                if request.len() >= header_end + content_length {
+                    break;
+                }
+            }
+            request_tx
+                .send(String::from_utf8_lossy(&request).into_owned())
+                .unwrap();
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+        (format!("http://{address}"), request_rx)
+    }
+
+    #[test]
+    fn terminal_operation_states_are_explicit() {
+        let operation = |status: &str| Operation {
+            id: "op".to_string(),
+            workspace_id: "workspace".to_string(),
+            project_id: Some("project".to_string()),
+            kind: "project.restart".to_string(),
+            status: status.to_string(),
+            phase: status.to_string(),
+            progress: 100,
+            message: None,
+            attempt: 1,
+            max_attempts: 3,
+            retryable: false,
+            error_code: None,
+            error_message: None,
+            requested_by: None,
+            parent_operation_id: None,
+            created_at: "now".to_string(),
+            started_at: None,
+            updated_at: "now".to_string(),
+            completed_at: None,
+        };
+        assert!(!operation("queued").is_terminal());
+        assert!(!operation("running").is_terminal());
+        assert!(operation("succeeded").is_terminal());
+        assert!(operation("failed").is_terminal());
+        assert!(operation("canceled").is_terminal());
+    }
+
+    fn project(id: &str, workspace_id: &str, name: &str) -> Project {
+        Project {
+            id: id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            name: name.to_string(),
+            slug: name.to_lowercase(),
+            status: "running".to_string(),
+            desired_state: "running".to_string(),
+            lifecycle_phase: "ready".to_string(),
+            generation: 1,
+            observed_generation: 1,
+            version: 1,
+            region: "nyc1".to_string(),
+            memory_mb: 512,
+            auth_enabled: true,
+            deletion_protection: false,
+            safe_error_code: None,
+            safe_error_message: None,
+            public_endpoints: PublicEndpoints {
+                http: None,
+                resp: None,
+            },
+            conditions: Vec::new(),
+            created_at: "now".to_string(),
+            started_at: None,
+            deleted_at: None,
+        }
+    }
+
+    #[test]
+    fn project_selection_spans_workspaces_and_rejects_ambiguous_names() {
+        let projects = vec![
+            project("project-a", "workspace-a", "shared"),
+            project("project-b", "workspace-b", "shared"),
+            project("project-c", "workspace-b", "unique"),
+        ];
+
+        assert_eq!(
+            select_project(projects.clone(), "project-b")
+                .unwrap()
+                .workspace_id,
+            "workspace-b"
+        );
+        assert_eq!(
+            select_project(projects.clone(), "unique").unwrap().id,
+            "project-c"
+        );
+        assert!(select_project(projects, "shared")
+            .unwrap_err()
+            .message
+            .contains("ambiguous"));
+    }
+
+    #[tokio::test]
+    async fn mutations_use_v1_path_auth_and_idempotency_headers() {
+        let body = r#"{"data":{"accepted":true}}"#;
+        let (base_url, request) = server("202 Accepted", body).await;
+        let client = CloudClient::new(reqwest::Client::new(), &base_url, "secret-token");
+
+        let accepted: serde_json::Value = client
+            .request(
+                Method::POST,
+                "/projects",
+                Some(serde_json::json!({
+                    "workspace_id": "workspace",
+                    "name": "My Project",
+                    "memory_mb": 512,
+                })),
+                Some("stable-key"),
+            )
+            .await
+            .unwrap();
+        let request = request.await.unwrap().to_ascii_lowercase();
+
+        assert_eq!(accepted["accepted"], true);
+        assert!(request.starts_with("post /cloud/v1/projects http/1.1\r\n"));
+        assert!(request.contains("\r\nauthorization: bearer secret-token\r\n"));
+        assert!(request.contains("\r\nidempotency-key: stable-key\r\n"));
+        assert!(request.contains(r#""workspace_id":"workspace""#));
+        assert!(request.contains(r#""memory_mb":512"#));
+    }
+
+    #[tokio::test]
+    async fn nested_cloud_errors_preserve_status_and_request_id() {
+        let body = r#"{"error":{"code":"PROJECT_OPERATION_CONFLICT","message":"Another lifecycle operation is active.","request_id":"request-123"}}"#;
+        let (base_url, _request) = server("409 Conflict", body).await;
+        let client = CloudClient::new(reqwest::Client::new(), &base_url, "secret-token");
+
+        let error = client
+            .delete_project("project", "stable-key")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code, "PROJECT_OPERATION_CONFLICT");
+        assert_eq!(error.status, Some(409));
+        assert_eq!(error.request_id.as_deref(), Some("request-123"));
+        assert!(error.to_string().contains("HTTP 409"));
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -14,6 +14,8 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+mod cloud;
+
 const DEFAULT_API_URL: &str = "https://api.luxdb.dev";
 
 #[derive(Parser)]
@@ -24,6 +26,25 @@ struct Cli {
 
     #[arg(long, global = true, env = "LUX_API_URL")]
     api_url: Option<String>,
+
+    #[arg(long, global = true, help = "Emit machine-readable JSON")]
+    json: bool,
+
+    #[arg(
+        long,
+        global = true,
+        help = "Return after Cloud accepts an asynchronous mutation"
+    )]
+    no_wait: bool,
+
+    #[arg(
+        long,
+        global = true,
+        default_value = "900",
+        value_name = "SECONDS",
+        help = "Maximum time to wait for a Cloud operation"
+    )]
+    wait_timeout: u64,
 }
 
 #[derive(Subcommand)]
@@ -134,6 +155,11 @@ enum Commands {
         #[arg(long, help = "Acknowledge data will be permanently deleted")]
         accept_consequences: bool,
     },
+    /// Inspect durable Lux Cloud operations.
+    Operations {
+        #[command(subcommand)]
+        action: OperationsAction,
+    },
     Connect {
         #[arg(help = "Project name, ID, or connection URL (lux://...)")]
         project: Option<String>,
@@ -222,6 +248,22 @@ enum Commands {
         out: Option<String>,
         #[arg(long, help = "Print to stdout instead of writing a file")]
         stdout: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum OperationsAction {
+    /// List recent operations for a project.
+    List {
+        #[arg(help = "Project name or ID")]
+        project: String,
+    },
+    /// Get an operation, optionally following it until completion.
+    Get {
+        #[arg(help = "Operation ID")]
+        operation: String,
+        #[arg(long, help = "Follow until the operation reaches a terminal state")]
+        wait: bool,
     },
 }
 
@@ -2124,6 +2166,97 @@ fn get_client(api_url_override: &Option<String>) -> (reqwest::Client, String, St
     (client, api_url, config.token)
 }
 
+fn get_cloud_client(api_url_override: &Option<String>) -> cloud::CloudClient {
+    let (client, api_url, token) = get_client(api_url_override);
+    cloud::CloudClient::new(client, &api_url, &token)
+}
+
+fn cloud_error<T>(error: impl std::fmt::Display) -> T {
+    eprintln!("{} {error}", "Cloud error:".red());
+    std::process::exit(1);
+}
+
+fn cloud_idempotency_key(kind: &str) -> String {
+    format!("cli-{kind}-{}", random_hex(16))
+}
+
+fn print_cloud_operation(operation: &cloud::Operation) {
+    let message = operation
+        .message
+        .as_deref()
+        .filter(|message| !message.is_empty())
+        .map(|message| format!(" — {message}"))
+        .unwrap_or_default();
+    println!(
+        "  {:>3}%  {:<10} {}{}",
+        operation.progress, operation.status, operation.phase, message
+    );
+}
+
+async fn finish_cloud_mutation<T: Serialize>(
+    client: &cloud::CloudClient,
+    accepted: cloud::Accepted<T>,
+    no_wait: bool,
+    json: bool,
+    wait_timeout: u64,
+) {
+    if no_wait {
+        if json {
+            println!("{}", serde_json::to_string_pretty(&accepted).unwrap());
+        } else {
+            println!(
+                "{} Operation accepted: {}",
+                "Accepted.".green(),
+                accepted.operation.id
+            );
+            println!(
+                "Use {} to follow progress.",
+                format!("lux operations get {} --wait", accepted.operation.id).cyan()
+            );
+        }
+        return;
+    }
+
+    if !json {
+        println!("{} {}", "Operation:".bold(), accepted.operation.id);
+    }
+    let operation = client
+        .wait_for_operation(
+            &accepted.operation.id,
+            std::time::Duration::from_secs(wait_timeout),
+            |operation| {
+                if !json {
+                    print_cloud_operation(operation);
+                }
+            },
+        )
+        .await
+        .unwrap_or_else(cloud_error);
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "resource": accepted.resource,
+                "operation": operation,
+            }))
+            .unwrap()
+        );
+    } else if operation.succeeded() {
+        println!("{}", "Done.".green());
+    }
+
+    if !operation.succeeded() {
+        let message = operation
+            .error_message
+            .as_deref()
+            .or(operation.message.as_deref())
+            .unwrap_or("Cloud operation did not succeed.");
+        eprintln!("{} {message}", "Operation failed:".red());
+        std::process::exit(1);
+    }
+}
+
 /// A `lux_` token is scoped to one workspace. Resolve it so workspace-scoped
 /// endpoints (project list/create) can name it. Exits on failure.
 async fn resolve_workspace_id(client: &reqwest::Client, api_url: &str, token: &str) -> String {
@@ -2865,6 +2998,9 @@ fn format_bytes(bytes: u64) -> String {
 pub async fn run() {
     let cli = Cli::parse();
     let api_url_override = cli.api_url.clone();
+    let json = cli.json;
+    let no_wait = cli.no_wait;
+    let wait_timeout = cli.wait_timeout;
 
     match cli.command {
         Commands::Init => {
@@ -3261,26 +3397,24 @@ pub async fn run() {
         }
 
         Commands::Projects => {
-            let (client, api_url, token) = get_client(&api_url_override);
-            let workspace_id = resolve_workspace_id(&client, &api_url, &token).await;
-
-            let res = client
-                .get(format!("{api_url}/projects?workspace_id={workspace_id}"))
-                .header("Authorization", format!("Bearer {token}"))
-                .send()
+            let client = get_cloud_client(&api_url_override);
+            let workspace = client
+                .workspaces()
                 .await
-                .unwrap_or_else(|e| {
-                    eprintln!("{} {e}", "Failed:".red());
-                    std::process::exit(1);
-                });
+                .unwrap_or_else(cloud_error)
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| cloud_error("No workspace found for this token."));
+            let projects = client
+                .projects(&workspace.id)
+                .await
+                .unwrap_or_else(cloud_error);
 
-            let body: ApiResponse<Vec<Instance>> = res.json().await.unwrap_or_else(|e| {
-                eprintln!("{} {e}", "Failed to parse response:".red());
-                std::process::exit(1);
-            });
-            let instances = unwrap_api(body);
-
-            if instances.is_empty() {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&projects).unwrap());
+                return;
+            }
+            if projects.is_empty() {
                 println!("{}", "No projects found.".dimmed());
                 return;
             }
@@ -3293,16 +3427,16 @@ pub async fn run() {
                 "MEMORY".dimmed()
             );
 
-            for inst in &instances {
-                let status = match inst.status.as_str() {
-                    "running" => inst.status.green().to_string(),
-                    "error" => inst.status.red().to_string(),
-                    _ => inst.status.yellow().to_string(),
+            for project in &projects {
+                let status = match project.status.as_str() {
+                    "running" => project.status.green().to_string(),
+                    "error" => project.status.red().to_string(),
+                    _ => project.status.yellow().to_string(),
                 };
 
                 println!(
                     "  {:<16}  {:<10}  {:<6}  {}MB",
-                    inst.name, status, inst.region, inst.memory_mb,
+                    project.name, status, project.region, project.memory_mb,
                 );
             }
         }
@@ -3542,127 +3676,63 @@ pub async fn run() {
             memory,
             accept_charges,
         } => {
-            let (client, api_url, token) = get_client(&api_url_override);
-
-            let sizes_res = client
-                .get(format!("{api_url}/billing/sizes"))
-                .header("Authorization", format!("Bearer {token}"))
-                .send()
-                .await
-                .unwrap_or_else(|e| {
-                    eprintln!("{} {e}", "Failed:".red());
-                    std::process::exit(1);
-                });
-
-            let sizes_body: ApiResponse<Vec<serde_json::Value>> = sizes_res.json().await.unwrap();
-            let sizes = sizes_body.data.unwrap_or_default();
-
-            let size = sizes
-                .iter()
-                .find(|s| s.get("memory_mb").and_then(|v| v.as_u64()) == Some(memory as u64))
-                .unwrap_or_else(|| {
-                    let available: Vec<String> = sizes
-                        .iter()
-                        .filter_map(|s| {
-                            let mb = s.get("memory_mb")?.as_u64()?;
-                            let label = s.get("label")?.as_str()?;
-                            Some(format!("{mb}MB ({label})"))
-                        })
-                        .collect();
-                    eprintln!(
-                        "{} No size with {}MB. Available: {}",
-                        "Error:".red(),
-                        memory,
-                        available.join(", ")
-                    );
-                    std::process::exit(1);
-                });
-
-            let price_id = size.get("price_id").and_then(|v| v.as_str()).unwrap_or("");
-            let price_cents = size
-                .get("price_cents")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0);
+            if memory != 512 {
+                cloud_error::<()>("Only the Standard 512 MB project size is currently available.");
+            }
 
             if !accept_charges {
                 eprintln!(
-                    "{} This will create a {}MB instance at ${}/mo.",
+                    "{} This creates a {}MB Standard project under your workspace's current billing plan.",
                     "Billing:".yellow(),
                     memory,
-                    price_cents / 100
                 );
                 eprintln!("Run with {} to confirm.", "--accept-charges".bold());
                 std::process::exit(1);
             }
 
-            println!("{} Creating project '{}'...", "...".dimmed(), name);
-
-            let workspace_id = resolve_workspace_id(&client, &api_url, &token).await;
-            let res = client
-                .post(format!("{api_url}/projects"))
-                .header("Authorization", format!("Bearer {token}"))
-                .json(&serde_json::json!({
-                    "name": name,
-                    "price_id": price_id,
-                    "workspace_id": workspace_id,
-                }))
-                .send()
+            if !json {
+                println!("{} Creating project '{}'...", "...".dimmed(), name);
+            }
+            let client = get_cloud_client(&api_url_override);
+            let workspace = client
+                .workspaces()
                 .await
-                .unwrap_or_else(|e| {
-                    eprintln!("{} {e}", "Failed:".red());
-                    std::process::exit(1);
-                });
-
-            let body: ApiResponse<Instance> = res.json().await.unwrap_or_else(|e| {
-                eprintln!("{} {e}", "Failed to parse:".red());
-                std::process::exit(1);
-            });
-
-            if let Some(error) = body.error {
-                eprintln!("{} {error}", "Error:".red());
-                std::process::exit(1);
-            }
-
-            if let Some(inst) = body.data {
-                println!("{} Project '{}' created", "Done.".green(), inst.name);
-                println!("{} {}", "ID:".bold(), inst.id);
-                println!("{} {}MB", "Memory:".bold(), inst.memory_mb);
-                println!("{} {}", "Region:".bold(), inst.region);
-                println!(
-                    "\n{} Run {} to check when it's ready",
-                    "Tip:".bold(),
-                    format!("lux status {}", inst.name).cyan()
-                );
-            }
+                .unwrap_or_else(cloud_error)
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| cloud_error("No workspace found for this token."));
+            let accepted = client
+                .create_project(
+                    &workspace.id,
+                    &name,
+                    memory,
+                    &cloud_idempotency_key("project-create"),
+                )
+                .await
+                .unwrap_or_else(cloud_error);
+            finish_cloud_mutation(&client, accepted, no_wait, json, wait_timeout).await;
         }
 
         Commands::Restart { project } => {
-            let (client, api_url, token) = get_client(&api_url_override);
             let project = require_project_arg(project.as_deref());
-            let inst = find_project(&client, &api_url, &token, &project).await;
-
-            println!("{} Restarting '{}'...", "...".dimmed(), inst.name);
-
-            let res = client
-                .post(format!("{api_url}/projects/{}/restart", inst.id))
-                .header("Authorization", format!("Bearer {token}"))
-                .send()
+            let client = get_cloud_client(&api_url_override);
+            let target = client
+                .resolve_project(&project)
                 .await
-                .unwrap_or_else(|e| {
-                    eprintln!("{} {e}", "Failed:".red());
-                    std::process::exit(1);
-                });
-
-            if res.status().is_success() {
-                println!("{} Project '{}' is restarting.", "Done.".green(), inst.name);
-            } else {
-                let body: serde_json::Value = res.json().await.unwrap_or_default();
-                let msg = body
-                    .get("error")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("Unknown error");
-                eprintln!("{} {msg}", "Error:".red());
+                .unwrap_or_else(cloud_error);
+            if !json {
+                println!("{} Restarting '{}'...", "...".dimmed(), target.name);
             }
+            let accepted = client
+                .project_action(
+                    &target.id,
+                    "restart",
+                    serde_json::json!({}),
+                    &cloud_idempotency_key("project-restart"),
+                )
+                .await
+                .unwrap_or_else(cloud_error);
+            finish_cloud_mutation(&client, accepted, no_wait, json, wait_timeout).await;
         }
 
         Commands::Snapshot {
@@ -3670,124 +3740,67 @@ pub async fn run() {
             list,
             restore,
         } => {
-            let (client, api_url, token) = get_client(&api_url_override);
             let project = require_project_arg(project.as_deref());
-            let inst = find_project(&client, &api_url, &token, &project).await;
+            let client = get_cloud_client(&api_url_override);
+            let target = client
+                .resolve_project(&project)
+                .await
+                .unwrap_or_else(cloud_error);
 
             if let Some(snapshot_id) = restore {
-                println!(
-                    "{} Restoring '{}' from {}...",
-                    "...".dimmed(),
-                    inst.name,
-                    snapshot_id
-                );
-                let res = client
-                    .post(format!(
-                        "{api_url}/snapshots/{}/{}/restore",
-                        inst.id, snapshot_id
-                    ))
-                    .header("Authorization", format!("Bearer {token}"))
-                    .send()
-                    .await
-                    .unwrap_or_else(|e| {
-                        eprintln!("{} {e}", "Failed:".red());
-                        std::process::exit(1);
-                    });
-                if res.status().is_success() {
-                    println!("{} Restore started for '{}'.", "Done.".green(), inst.name);
-                } else {
-                    let body: serde_json::Value = res.json().await.unwrap_or_default();
-                    let msg = body
-                        .get("error")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("Unknown error");
-                    eprintln!("{} {msg}", "Error:".red());
+                if !json {
+                    println!(
+                        "{} Restoring '{}' from {}...",
+                        "...".dimmed(),
+                        target.name,
+                        snapshot_id
+                    );
                 }
-            } else if list {
-                let res = client
-                    .get(format!("{api_url}/snapshots/{}", inst.id))
-                    .header("Authorization", format!("Bearer {token}"))
-                    .send()
+                let accepted = client
+                    .restore_snapshot(
+                        &target.id,
+                        &snapshot_id,
+                        &cloud_idempotency_key("snapshot-restore"),
+                    )
                     .await
-                    .unwrap_or_else(|e| {
-                        eprintln!("{} {e}", "Failed:".red());
-                        std::process::exit(1);
-                    });
-                let body: serde_json::Value = res.json().await.unwrap_or_default();
-                let rows = body
-                    .get("data")
-                    .and_then(|d| d.as_array())
-                    .cloned()
-                    .unwrap_or_default();
-                if rows.is_empty() {
-                    println!("No snapshots for '{}'.", inst.name);
+                    .unwrap_or_else(cloud_error);
+                finish_cloud_mutation(&client, accepted, no_wait, json, wait_timeout).await;
+            } else if list {
+                let snapshots = client
+                    .snapshots(&target.id)
+                    .await
+                    .unwrap_or_else(cloud_error);
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&snapshots).unwrap());
+                } else if snapshots.is_empty() {
+                    println!("No snapshots for '{}'.", target.name);
                 } else {
                     println!("{:<10} {:<10} {:<26} ID", "STATUS", "SIZE", "CREATED");
-                    for r in rows {
-                        let status = r.get("status").and_then(|v| v.as_str()).unwrap_or("?");
-                        let size = r
-                            .get("file_size_bytes")
-                            .and_then(|v| v.as_u64())
+                    for snapshot in snapshots {
+                        let size = snapshot
+                            .file_size_bytes
                             .map(format_bytes)
                             .unwrap_or_else(|| "-".to_string());
-                        let created = r.get("created_at").and_then(|v| v.as_str()).unwrap_or("");
-                        let id = r.get("id").and_then(|v| v.as_str()).unwrap_or("");
-                        let err = r
-                            .get("error_message")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("");
-                        let err_suffix = if err.is_empty() {
-                            String::new()
-                        } else {
-                            format!("  {}", err.red())
-                        };
-                        println!("{status:<10} {size:<10} {created:<26} {id}{err_suffix}");
+                        let error = snapshot
+                            .error_message
+                            .as_deref()
+                            .map(|error| format!("  {}", error.red()))
+                            .unwrap_or_default();
+                        println!(
+                            "{:<10} {:<10} {:<26} {}{}",
+                            snapshot.status, size, snapshot.created_at, snapshot.id, error
+                        );
                     }
                 }
             } else {
-                println!("{} Snapshotting '{}'...", "...".dimmed(), inst.name);
-
-                let res = client
-                    .post(format!("{api_url}/snapshots/{}", inst.id))
-                    .header("Authorization", format!("Bearer {token}"))
-                    .send()
-                    .await
-                    .unwrap_or_else(|e| {
-                        eprintln!("{} {e}", "Failed:".red());
-                        std::process::exit(1);
-                    });
-
-                if res.status().is_success() {
-                    let body: serde_json::Value = res.json().await.unwrap_or_default();
-                    let id = body
-                        .get("data")
-                        .and_then(|d| d.get("id"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
-                    let suffix = if id.is_empty() {
-                        String::new()
-                    } else {
-                        format!(" ({id})")
-                    };
-                    println!(
-                        "{} Snapshot started for '{}'.{}",
-                        "Done.".green(),
-                        inst.name,
-                        suffix
-                    );
-                    println!(
-                        "{} {}",
-                        "Tip:".bold(),
-                        format!("lux snapshot {} --list", inst.name).cyan()
-                    );
-                } else {
-                    let body: serde_json::Value = res.json().await.unwrap_or_default();
-                    let msg = body
-                        .get("error")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("Unknown error");
-                    eprintln!("{} {msg}", "Error:".red());
+                if !json {
+                    println!("{} Snapshotting '{}'...", "...".dimmed(), target.name);
                 }
+                let accepted = client
+                    .create_snapshot(&target.id, &cloud_idempotency_key("snapshot-create"))
+                    .await
+                    .unwrap_or_else(cloud_error);
+                finish_cloud_mutation(&client, accepted, no_wait, json, wait_timeout).await;
             }
         }
 
@@ -3795,40 +3808,96 @@ pub async fn run() {
             project,
             accept_consequences,
         } => {
-            let (client, api_url, token) = get_client(&api_url_override);
-            let inst = find_project(&client, &api_url, &token, &project).await;
+            let client = get_cloud_client(&api_url_override);
+            let target = client
+                .resolve_project(&project)
+                .await
+                .unwrap_or_else(cloud_error);
 
             if !accept_consequences {
                 eprintln!(
                     "{} This will permanently delete '{}' and all its data.",
                     "Warning:".red(),
-                    inst.name
+                    target.name
                 );
                 eprintln!("Run with {} to confirm.", "--accept-consequences".bold());
                 std::process::exit(1);
             }
 
-            println!("{} Destroying '{}'...", "...".dimmed(), inst.name);
-
-            let res = client
-                .delete(format!("{api_url}/projects/{}", inst.id))
-                .header("Authorization", format!("Bearer {token}"))
-                .send()
+            if !json {
+                println!("{} Destroying '{}'...", "...".dimmed(), target.name);
+            }
+            let accepted = client
+                .delete_project(&target.id, &cloud_idempotency_key("project-delete"))
                 .await
-                .unwrap_or_else(|e| {
-                    eprintln!("{} {e}", "Failed:".red());
-                    std::process::exit(1);
-                });
+                .unwrap_or_else(cloud_error);
+            finish_cloud_mutation(&client, accepted, no_wait, json, wait_timeout).await;
+        }
 
-            if res.status().is_success() {
-                println!("{} Project '{}' destroyed.", "Done.".green(), inst.name);
-            } else {
-                let body: serde_json::Value = res.json().await.unwrap_or_default();
-                let msg = body
-                    .get("error")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("Unknown error");
-                eprintln!("{} {msg}", "Error:".red());
+        Commands::Operations { action } => {
+            let client = get_cloud_client(&api_url_override);
+            match action {
+                OperationsAction::List { project } => {
+                    let target = client
+                        .resolve_project(&project)
+                        .await
+                        .unwrap_or_else(cloud_error);
+                    let operations = client
+                        .operations(&target.id)
+                        .await
+                        .unwrap_or_else(cloud_error);
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&operations).unwrap());
+                    } else if operations.is_empty() {
+                        println!("No operations for '{}'.", target.name);
+                    } else {
+                        println!(
+                            "{:<12} {:<9} {:>4}  {:<24} ID",
+                            "KIND", "STATUS", "%", "UPDATED"
+                        );
+                        for operation in operations {
+                            println!(
+                                "{:<12} {:<9} {:>3}%  {:<24} {}",
+                                operation.kind,
+                                operation.status,
+                                operation.progress,
+                                operation.updated_at,
+                                operation.id
+                            );
+                        }
+                    }
+                }
+                OperationsAction::Get { operation, wait } => {
+                    let operation = if wait {
+                        client
+                            .wait_for_operation(
+                                &operation,
+                                std::time::Duration::from_secs(wait_timeout),
+                                |current| {
+                                    if !json {
+                                        print_cloud_operation(current);
+                                    }
+                                },
+                            )
+                            .await
+                            .unwrap_or_else(cloud_error)
+                    } else {
+                        client
+                            .operation(&operation)
+                            .await
+                            .unwrap_or_else(cloud_error)
+                    };
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&operation).unwrap());
+                    } else if !wait {
+                        print_cloud_operation(&operation);
+                        println!("{} {}", "ID:".bold(), operation.id);
+                        println!("{} {}", "Kind:".bold(), operation.kind);
+                    }
+                    if operation.is_terminal() && !operation.succeeded() {
+                        std::process::exit(1);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Updates the Lux CLI to use the durable Lux Cloud API introduced by [lux-db/cloud#42](https://github.com/lux-db/cloud/pull/42).

- centralizes Cloud requests in a typed `CloudClient`
- moves supported project commands to `/cloud/v1`
- sends idempotency keys for mutations
- adds operation list/get/wait commands and polling to terminal operation states
- adds global `--json`, `--no-wait`, and `--wait-timeout` behavior
- resolves project names across every accessible workspace and rejects ambiguous matches
- surfaces structured Cloud errors with HTTP status and request ID
- keeps omitted project arguments local and positional project arguments Cloud-targeted

## Dependency and merge order

Merge and deploy `lux-db/cloud#42` first. Merge this PR after the `/cloud/v1` endpoints are available.

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo test` — 55 passed
- raw TCP contract tests for `/cloud/v1`, authorization, idempotency headers, nested errors, and cross-workspace project resolution
- staged secret scan
