### PR TITLE
fix(auth): bind native OAuth codes with PKCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,12 @@ GET  /auth/v1/authorize?provider=google&redirect_to=http://localhost:5173/callba
 POST /auth/v1/signin/apple
 ```
 
+OAuth authorization-code clients can send an RFC 7636
+`code_challenge` with `code_challenge_method=S256`, then include the matching
+`code_verifier` in the token exchange. Lux binds and verifies the pair before
+consuming the one-time code. PKCE is required for custom-scheme callback URLs;
+browser HTTP(S) flows remain backward compatible.
+
 Lux supports Google, GitHub, and Apple OAuth. Configure a local or remote
 self-hosted engine with the CLI; managed Cloud projects use the **Auth** page in
 the Lux dashboard.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1173,7 +1173,9 @@ fn authorization_code_grant(
         Err(response) => return response,
     };
     let now = Instant::now();
-    let token = match consume_flow_token(store, cache, "oauth_code", code, now) {
+    let token = match consume_flow_token(store, cache, "oauth_code", code, now, |flow| {
+        verify_oauth_pkce(flow, parsed)
+    }) {
         Ok(token) => token,
         Err(response) => return response,
     };
@@ -1261,7 +1263,7 @@ fn verify_otp(
         _ => return error(400, "Bad Request", "unsupported verification type"),
     };
     let now = Instant::now();
-    let flow = match consume_flow_token(store, cache, expected_kind, token, now) {
+    let flow = match consume_flow_token(store, cache, expected_kind, token, now, |_| Ok(())) {
         Ok(flow) => flow,
         Err(response) => return response,
     };
@@ -2205,6 +2207,27 @@ fn oauth_authorize(
             return AuthHttpResponse::json(status, status_text, body);
         }
     };
+    let flow = get_param(params, "flow").unwrap_or("code");
+    if !matches!(flow, "code" | "implicit") {
+        let (status, status_text, body) = error(400, "Bad Request", "unsupported oauth flow");
+        return AuthHttpResponse::json(status, status_text, body);
+    }
+    let code_challenge = match oauth_pkce_challenge(params) {
+        Ok(challenge) => challenge,
+        Err(response) => {
+            let (status, status_text, body) = response;
+            return AuthHttpResponse::json(status, status_text, body);
+        }
+    };
+    let is_custom_scheme = !redirect_to.starts_with('/') && url_origin(&redirect_to).is_none();
+    if flow == "code" && is_custom_scheme && code_challenge.is_none() {
+        let (status, status_text, body) = error(
+            400,
+            "Bad Request",
+            "custom-scheme oauth code flows require PKCE",
+        );
+        return AuthHttpResponse::json(status, status_text, body);
+    }
     let config = match oauth_provider_config(store, cache, &provider, Instant::now()) {
         Ok(Some(config)) if config.enabled => config,
         Ok(Some(_)) => {
@@ -2231,7 +2254,8 @@ fn oauth_authorize(
     let payload = json!({
         "provider": provider,
         "redirect_to": redirect_to,
-        "flow": get_param(params, "flow").unwrap_or("code"),
+        "flow": flow,
+        "code_challenge": code_challenge,
         "oidc_nonce": oidc_nonce,
         "created_at": unix_seconds(),
     });
@@ -2391,7 +2415,12 @@ async fn oauth_callback(
                     user_id: &subject.user_id,
                     email: &subject.email,
                     redirect_to: &redirect_to,
-                    metadata: json!({}),
+                    metadata: json!({
+                        "code_challenge": state_value
+                            .get("code_challenge")
+                            .cloned()
+                            .unwrap_or(Value::Null),
+                    }),
                 },
                 now,
             ) {
@@ -4507,13 +4536,17 @@ fn validate_auth_email_settings(
     }
 }
 
-fn consume_flow_token(
+fn consume_flow_token<F>(
     store: &Store,
     cache: &SharedSchemaCache,
     kind: &str,
     token: &str,
     now: Instant,
-) -> Result<HashMap<String, String>, (u16, &'static str, String)> {
+    validate: F,
+) -> Result<HashMap<String, String>, (u16, &'static str, String)>
+where
+    F: FnOnce(&HashMap<String, String>) -> Result<(), (u16, &'static str, String)>,
+{
     let _guard = FLOW_TOKEN_CONSUME_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
@@ -4555,6 +4588,7 @@ fn consume_flow_token(
     if expires_at <= now_sec {
         return Err(error(400, "Bad Request", "invalid or expired token"));
     }
+    validate(&existing)?;
     let consumed_at = now_sec.to_string();
     let expires_at_s = expires_at.to_string();
     let rows = tables::table_update_where_returning_ttl(
@@ -5580,6 +5614,56 @@ fn hash_secret(secret: &str) -> String {
         let _ = write!(out, "{byte:02x}");
     }
     out
+}
+
+fn oauth_pkce_challenge(
+    params: &[(String, String)],
+) -> Result<Option<String>, (u16, &'static str, String)> {
+    let Some(challenge) = get_param(params, "code_challenge") else {
+        return Ok(None);
+    };
+    if challenge.len() != 43
+        || !challenge
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(error(400, "Bad Request", "invalid PKCE code_challenge"));
+    }
+    if get_param(params, "code_challenge_method") != Some("S256") {
+        return Err(error(
+            400,
+            "Bad Request",
+            "PKCE code_challenge_method must be S256",
+        ));
+    }
+    Ok(Some(challenge.to_string()))
+}
+
+fn verify_oauth_pkce(
+    flow: &HashMap<String, String>,
+    request: &Value,
+) -> Result<(), (u16, &'static str, String)> {
+    let metadata = flow
+        .get("metadata")
+        .and_then(|value| serde_json::from_str::<Value>(value).ok())
+        .unwrap_or_else(|| json!({}));
+    let Some(challenge) = metadata.get("code_challenge").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    let verifier = required_string(request, "code_verifier")?;
+    if !(43..=128).contains(&verifier.len())
+        || !verifier
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~'))
+    {
+        return Err(error(400, "Bad Request", "invalid PKCE code_verifier"));
+    }
+    let digest = Sha256::digest(verifier.as_bytes());
+    let calculated = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
+    if !constant_time_eq(calculated.as_bytes(), challenge.as_bytes()) {
+        return Err(error(400, "Bad Request", "PKCE verification failed"));
+    }
+    Ok(())
 }
 
 fn random_token(bytes: usize) -> String {

--- a/src/auth/tests.rs
+++ b/src/auth/tests.rs
@@ -1786,6 +1786,88 @@ fn authorization_code_flow_is_one_time_use() {
 }
 
 #[test]
+fn authorization_code_pkce_is_bound_and_failed_attempt_does_not_consume() {
+    let config = Arc::new(crate::ServerConfig {
+        auth: AuthConfig {
+            enabled: true,
+            ..AuthConfig::default()
+        },
+        ..crate::ServerConfig::default()
+    });
+    let store = Store::new_with_config(config);
+    let cache = Arc::new(RwLock::new(SchemaCache::new()));
+    bootstrap(&store, &cache, &store.config().auth).unwrap();
+    bootstrap_runtime(&store, &cache, &store.config().auth).unwrap();
+
+    let (_, _, signup_body) = route_http(
+        "POST",
+        "/auth/v1/signup",
+        r#"{"email":"pkce@example.com","password":"password123"}"#,
+        &[],
+        &[],
+        &store,
+        &cache,
+    );
+    let signup: Value = serde_json::from_str(&signup_body).unwrap();
+    let user_id = signup["user"]["id"].as_str().unwrap();
+    let settings = auth_settings(&store, &cache, Instant::now()).unwrap();
+    // RFC 7636 Appendix B's verifier/challenge pair.
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+    let code = create_flow_token(
+        &store,
+        &cache,
+        FlowTokenInsert {
+            settings: &settings,
+            kind: "oauth_code",
+            user_id,
+            email: "pkce@example.com",
+            redirect_to: "vigil://auth/callback",
+            metadata: json!({"code_challenge": challenge}),
+        },
+        Instant::now(),
+    )
+    .unwrap();
+
+    for body in [
+        format!(r#"{{"grant_type":"authorization_code","code":"{code}"}}"#),
+        format!(
+            r#"{{"grant_type":"authorization_code","code":"{code}","code_verifier":"{}"}}"#,
+            "x".repeat(43)
+        ),
+    ] {
+        let (status, _, _) = route_http("POST", "/auth/v1/token", &body, &[], &[], &store, &cache);
+        assert_eq!(status, 400);
+    }
+
+    let (status, _, body) = route_http(
+        "POST",
+        "/auth/v1/token",
+        &format!(
+            r#"{{"grant_type":"authorization_code","code":"{code}","code_verifier":"{verifier}"}}"#
+        ),
+        &[],
+        &[],
+        &store,
+        &cache,
+    );
+    assert_eq!(status, 200, "correct verifier should redeem code: {body}");
+
+    let (status, _, _) = route_http(
+        "POST",
+        "/auth/v1/token",
+        &format!(
+            r#"{{"grant_type":"authorization_code","code":"{code}","code_verifier":"{verifier}"}}"#
+        ),
+        &[],
+        &[],
+        &store,
+        &cache,
+    );
+    assert_eq!(status, 400, "successful redemption remains one-time");
+}
+
+#[test]
 fn flow_token_consume_has_single_winner_under_concurrency() {
     let config = Arc::new(crate::ServerConfig {
         auth: AuthConfig {
@@ -1828,7 +1910,11 @@ fn flow_token_consume_has_single_winner_under_concurrency() {
         let token = token.clone();
         handles.push(std::thread::spawn(move || {
             barrier.wait();
-            if consume_flow_token(&store, &cache, "recovery", &token, Instant::now()).is_ok() {
+            if consume_flow_token(&store, &cache, "recovery", &token, Instant::now(), |_| {
+                Ok(())
+            })
+            .is_ok()
+            {
                 successes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             }
         }));
@@ -1924,6 +2010,60 @@ async fn oauth_provider_config_and_authorize_redirect_are_core_owned() {
         location.contains("scope=openid%20email%20profile"),
         "{location}"
     );
+
+    let (status, _, body) = route_http(
+        "PATCH",
+        "/auth/v1/admin/settings",
+        r#"{"redirect_allow_list":["vigil://auth/callback"]}"#,
+        &[],
+        &[("apikey".to_string(), "lux_sec_test".to_string())],
+        &store,
+        &cache,
+    );
+    assert_eq!(status, 200, "allow custom redirect: {body}");
+
+    let response = route_http_response(
+        "GET",
+        "/auth/v1/authorize",
+        "",
+        &[
+            ("provider".to_string(), "google".to_string()),
+            (
+                "redirect_to".to_string(),
+                "vigil://auth/callback".to_string(),
+            ),
+            ("flow".to_string(), "code".to_string()),
+        ],
+        &[("host".to_string(), "localhost:17777".to_string())],
+        &store,
+        &cache,
+    )
+    .await;
+    assert_eq!(response.status, 400, "custom schemes must require PKCE");
+
+    let response = route_http_response(
+        "GET",
+        "/auth/v1/authorize",
+        "",
+        &[
+            ("provider".to_string(), "google".to_string()),
+            (
+                "redirect_to".to_string(),
+                "vigil://auth/callback".to_string(),
+            ),
+            ("flow".to_string(), "code".to_string()),
+            (
+                "code_challenge".to_string(),
+                "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM".to_string(),
+            ),
+            ("code_challenge_method".to_string(), "S256".to_string()),
+        ],
+        &[("host".to_string(), "localhost:17777".to_string())],
+        &store,
+        &cache,
+    )
+    .await;
+    assert_eq!(response.status, 302, "valid S256 PKCE should authorize");
 }
 
 #[test]

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -1592,7 +1592,11 @@ mod tests {
 
     #[test]
     fn plaintext_push_secret_writes_are_rejected() {
-        let store = Store::new();
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::new_with_config(Arc::new(ServerConfig {
+            data_dir: dir.path().to_string_lossy().into_owned(),
+            ..ServerConfig::default()
+        }));
         let error = update_apns_credentials(
             &store,
             &cache(),


### PR DESCRIPTION
## What changed
- accept and persist RFC 7636 S256 challenges across OAuth authorization and callback
- require PKCE for custom-scheme authorization-code redirects while preserving existing HTTP(S) browser flows
- verify the code verifier before atomically consuming the one-time authorization code
- reject malformed flows and cover missing, incorrect, successful, and single-use verifier behavior
- isolate the push secret rejection test from checkout-local encrypted state

## Security properties
- failed verifier attempts do not burn the authorization code
- comparison is constant-time
- only S256 is accepted
- verifier validation occurs inside the flow-token consume lock

## Validation
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets --quiet`
- HTTP responsiveness regression test repeated 5x against the current release binary